### PR TITLE
Update GitHub Authorization and Integration instructions

### DIFF
--- a/getting-started/proc-add-custom-app-file-openshift.adoc
+++ b/getting-started/proc-add-custom-app-file-openshift.adoc
@@ -39,9 +39,6 @@ The list of Helm Releases appears on the page.
 --
 . Click *Upgrade*.
 
-. Alternatively, go to the YAML view for the helm values and set the value of `upstream.backstage.command` to `[]`.
-. Click *Upgrade*.
-
 
 
 

--- a/getting-started/proc-add-source-control-rhdh-catalog.adoc
+++ b/getting-started/proc-add-source-control-rhdh-catalog.adoc
@@ -3,19 +3,137 @@
 
 To populate the Catalog in {product}, you need to add software templates, and to add the templates, you must enable a source control such as GitHub, GitLab, or BitBucket.
 
-== Setting GitHub integration and authentication
-
-The GitHub integration and authentication is required to enable the GitHub plugins in {product}.
-
 .Prerequisites
 
 * You have a GitHub account.
-* You have an account in Red Hat OpenShift
+* You have an account on a Red Hat OpenShift cluster.
+* You have completed the *Installing Red Hat Developer Hub using Helm Chart* section, especially steps 7 and 8, or the GitHub login will fail.
+
+== Configuring GitHub authentication
+
+This configuration is required to enable GitHub OAuth login in {product}.
 
 .Procedure
 
-. In OpenShift, click *ConfigMap*.
-. Modify your `app-config-rhdh` file to include the GitHub configuration as follows:
+. Visit the main page of the GitHub Organization that you want to create the OAuth application under.
+. Click on *Settings* -> *<> Developer Settings* -> *OAuth Apps* -> *Register an application*
+. Application name should be `Developer Hub`
+. `Homepage URL` should be as follows:
+`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
+. `Authorization callback URL` should be as follows:
+`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+
+. `Enable Device Flow` should be un-checked.
+. Click `Register application` to create your OAuth application.
+. Once the application has been created, you will need to click on `Generate a new client secret` and
+make sure to copy the client secret as it will not be shown again!
+. In OpenShift, click *ConfigMaps*.
+
+. Create a key/value secret named `github-secrets` using the following environment variables as keys and the values that you created for your GitHub OAuth application.
++
+--
+.. In Red Hat OpenShift, go to the *Secrets* tab and click *Create*.
+.. Select *Key/value secret*.
+.. Enter *Secret name* as `github-secrets`.
+.. Add environment variables as *Key* and *Value* and click *Create*.
+--
++
+--
+[cols="1,1"]
+|===
+|Key |Value 
+
+|GITHUB_APP_CLIENT_ID
+|Client ID from OAuth application
+
+|GITHUB_APP_CLIENT_SECRET
+|Client Secret from OAuth application
+
+|===
+--
+. Modify your `app-config-rhdh` ConfigMap to include the GitHub authorization configuration as follows:
++
+--
+[source]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: app-config-rhdh
+data:
+  app-config-rhdh.yaml: |
+    app:
+      title: Red Hat Developer Hub
+    auth:
+      # see https://backstage.io/docs/auth/ to learn about auth providers
+      environment: development
+      providers:
+        github:
+          development:
+            clientId: ${GITHUB_APP_CLIENT_ID}
+            clientSecret: ${GITHUB_APP_CLIENT_SECRET}
+----
+--
+
+. Click *Save*.
+. Navigate to the *Helm* tab and select *Upgrade*.
+. Under *Root Schema → Backstage Chart Schema → Backstage Parameters → Backstage container environment variables from existing Secrets*, input `github-secrets` as the value.
+. Click *Upgrade*.
+
+== Configuring GitHub integration
+
+This configuration is required to enable the GitHub plugins in {product}.
+
+.Procedure
+
+. Visit the main page of the GitHub Organization that you want to create the OAuth application under.
+. Click on *Settings* -> *<> Developer Settings* -> *GitHub Apps* -> *New GitHub App*
+. Application name should be `Developer Hub`
+. `Homepage URL` should be as follows:
+`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
+. `Authorization callback URL` should be as follows:
+`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+. Deselect *Webhook URL* -> *Active*
+. Under the *Where can this GitHub App be installed?* section, ensure that *Only on this account* is selected.
+. Once the application has been created, you will need to click on `Generate a new client secret` and
+make sure to copy the client secret as it will not be shown again!
+. Scroll to the bottom of the page and click *Generate a private key* and download the file that is generated.
+. In OpenShift, click *ConfigMaps*.
+
+. Create (or edit) a key/value secret named `github-secrets` using the following environment variables as keys and the values that you created for your GitHub OAuth application.
++
+--
+.. In Red Hat OpenShift, go to the *Secrets* tab and click *Create*.
+.. Select *Key/value secret*.
+.. Enter *Secret name* as `github-secrets`.
+.. Add environment variables as *Key* and *Value* and click *Create*.
+--
++
+--
+[cols="1,1"]
+|===
+|Key |Value 
+
+|GITHUB_APP_APP_ID
+|App ID from GitHub application
+
+|GITHUB_APP_CLIENT_ID
+|Client ID from GitHub application
+
+|GITHUB_APP_CLIENT_SECRET
+|Client Secret from GitHub application
+
+|GITHUB_APP_WEBHOOK_URL
+|Enter "none"
+
+|GITHUB_APP_WEBHOOK_SECRET
+|Enter "none"
+
+|GITHUB_APP_PRIVATE_KEY
+|Upload the private key that was downloaded
+|===
+--
+. Modify your `app-config-rhdh` ConfigMap to include the GitHub integration configuration as follows:
 +
 --
 [source]
@@ -39,46 +157,10 @@ data:
               webhookSecret: ${GITHUB_APP_WEBHOOK_SECRET}
               privateKey: |
                 ${GITHUB_APP_PRIVATE_KEY}
-    auth:
-      # see https://backstage.io/docs/auth/ to learn about auth providers
-      environment: development
-      providers:
-        github:
-          development:
-            clientId: ${GITHUB_APP_CLIENT_ID}
-            clientSecret: ${GITHUB_APP_CLIENT_SECRET}
 ----
+
 --
-
-. Click *Save*.
-. Create a key or value Secret file named `rhdh-secrets` using the environment variables as keys from the previous code snippet by following the steps below:
-+
---
-.. In Red Hat OpenShift, go to the *Secrets* tab and click *Create*.
-.. Enter *Secret name* as `rhdh-secrets`.
-.. Add environment variables as *Key* and *Value* and click *Create*.
---
-
-. To log in using your GitHub application, ensure that the *Callback URL* in your GitHub application is configured as follows:
-+
---
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
-
-In the previous example of Callback URL, `OPENSHIFT_ROUTE_HOST` is the API URL added into the *Root Schema -> global -> clusterRouteBase* field.
-
-The following is an example of the Callback URL:
-
-image::rhdh/example-callback-url.png[]
-
-[NOTE]
-====
-To access the GitHub security insights widget on the Overview page in {product-short}, ensure that your GitHub application has Read-only Dependabot Alerts permissions.
-====
---
-
-. Navigate to the *Helm* tab and select *Upgrade*.
-. Under *Root Schema → Backstage Chart Schema → Backstage Parameters → Backstage container environment variables from Secrets*, add `rhdh-secrets` as value.
-. Click *Upgrade*.
+. Click on *Toplogy* -> *developer hub* -> *Actions* (dropdown) -> *Restart rollout*
 
 == Enabling GitHub discovery in {product}
 

--- a/getting-started/proc-add-source-control-rhdh-catalog.adoc
+++ b/getting-started/proc-add-source-control-rhdh-catalog.adoc
@@ -18,7 +18,7 @@ The configuration of GitHub authentication is required to enable the GitHub OAut
 . In the Red Hat OpenShift cluster, navigate to the main page of the GitHub organization where you want to create the OAuth application. 
 . Click *Settings* -> *<> Developer Settings* -> *OAuth Apps* -> *Register an application*
 . Enter the application name as `Developer Hub`.
-. Add the following as the *Homepage URL*:
+. Add the following URL as the *Homepage URL*:
 +
 --
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
@@ -41,7 +41,7 @@ The configuration of GitHub authentication is required to enable the GitHub OAut
 .. Select *Key/value secret*.
 .. Enter *Secret name* as `github-secrets`.
 .. Add environment variables as *Key* and *Value* and click *Create*.
-
++
 .Environment variables
 [cols="1,1"]
 |===
@@ -81,7 +81,7 @@ data:
 
 . Click *Save*.
 . Navigate to the *Helm* tab and select *Upgrade*.
-. Under *Root Schema → Backstage Chart Schema → Backstage Parameters → Backstage container environment variables from existing Secrets*, input `github-secrets` as the value.
+. Under *Root Schema → Backstage Chart Schema → Backstage Parameters → Backstage container environment variables from existing Secrets*, enter `github-secrets` as the value.
 . Click *Upgrade*.
 
 == Configuring GitHub integration
@@ -93,7 +93,7 @@ The configuration of GitHub is required to enable the GitHub plugins in {product
 . In the Red Hat OpenShift cluster, navigate to the main page of the GitHub organization where you want to create the OAuth application.
 . Click *Settings* -> *<> Developer Settings* -> *GitHub Apps* -> *New GitHub App*.
 . Enter the application name as `Developer Hub`.
-. Add the following as the *Homepage URL*:
+. Add the following URL as the *Homepage URL*:
 +
 --
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
@@ -105,8 +105,9 @@ The configuration of GitHub is required to enable the GitHub plugins in {product
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
 --
 
-. Unselect *Webhook URL* -> *Active*.
+. Deselect *Webhook URL* -> *Active*.
 . Under the *Where can this GitHub App be installed?* section, ensure that *Only on this account* is selected.
+. Click *Register application*.
 . After creating the application, click *Generate a new client secret* and copy the generated client secret.
 . Click *Generate a private key* at the bottom of the page and download the generated file.
 . In OpenShift, click *ConfigMaps*.

--- a/getting-started/proc-add-source-control-rhdh-catalog.adoc
+++ b/getting-started/proc-add-source-control-rhdh-catalog.adoc
@@ -6,39 +6,43 @@ To populate the Catalog in {product}, you need to add software templates, and to
 .Prerequisites
 
 * You have a GitHub account.
-* You have an account on a Red Hat OpenShift cluster.
-* You have completed the *Installing Red Hat Developer Hub using Helm Chart* section, especially steps 7 and 8, or the GitHub login will fail.
+* You have an account on the Red Hat OpenShift cluster.
+* You have installed the {product-short}, otherwise the GitHub login fails. For more information about installation, see xref:proc-install-rhdh-helm_rhdh-getting-started[].
 
 == Configuring GitHub authentication
 
-This configuration is required to enable GitHub OAuth login in {product}.
+The configuration of GitHub authentication is required to enable the GitHub OAuth login in {product-short}.
 
 .Procedure
 
-. Visit the main page of the GitHub Organization that you want to create the OAuth application under.
-. Click on *Settings* -> *<> Developer Settings* -> *OAuth Apps* -> *Register an application*
-. Application name should be `Developer Hub`
-. `Homepage URL` should be as follows:
+. In the Red Hat OpenShift cluster, navigate to the main page of the GitHub organization where you want to create the OAuth application. 
+. Click *Settings* -> *<> Developer Settings* -> *OAuth Apps* -> *Register an application*
+. Enter the application name as `Developer Hub`.
+. Add the following as the *Homepage URL*:
++
+--
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
-. `Authorization callback URL` should be as follows:
+--
+
+. Add the following URL as *Authorization callback URL*:
++
+--
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+--
 
-. `Enable Device Flow` should be un-checked.
-. Click `Register application` to create your OAuth application.
-. Once the application has been created, you will need to click on `Generate a new client secret` and
-make sure to copy the client secret as it will not be shown again!
+. Uncheck the *Enable Device Flow* checkbox.
+. Click *Register application* to create your OAuth application.
+. After creating the application, click *Generate a new client secret* and copy the generated client secret.
 . In OpenShift, click *ConfigMaps*.
-
-. Create a key/value secret named `github-secrets` using the following environment variables as keys and the values that you created for your GitHub OAuth application.
+. Generate a key/value secret named 'github-secrets' using the provided environment variables as keys, and input the values you generated for your GitHub OAuth application:
 +
 --
 .. In Red Hat OpenShift, go to the *Secrets* tab and click *Create*.
 .. Select *Key/value secret*.
 .. Enter *Secret name* as `github-secrets`.
 .. Add environment variables as *Key* and *Value* and click *Create*.
---
-+
---
+
+.Environment variables
 [cols="1,1"]
 |===
 |Key |Value 
@@ -48,10 +52,10 @@ make sure to copy the client secret as it will not be shown again!
 
 |GITHUB_APP_CLIENT_SECRET
 |Client Secret from OAuth application
-
 |===
 --
-. Modify your `app-config-rhdh` ConfigMap to include the GitHub authorization configuration as follows:
+
+. Modify your `app-config-rhdh` ConfigMap to include the GitHub authentication configuration as follows:
 +
 --
 [source]
@@ -82,34 +86,39 @@ data:
 
 == Configuring GitHub integration
 
-This configuration is required to enable the GitHub plugins in {product}.
+The configuration of GitHub is required to enable the GitHub plugins in {product-short}.
 
 .Procedure
 
-. Visit the main page of the GitHub Organization that you want to create the OAuth application under.
-. Click on *Settings* -> *<> Developer Settings* -> *GitHub Apps* -> *New GitHub App*
-. Application name should be `Developer Hub`
-. `Homepage URL` should be as follows:
+. In the Red Hat OpenShift cluster, navigate to the main page of the GitHub organization where you want to create the OAuth application.
+. Click *Settings* -> *<> Developer Settings* -> *GitHub Apps* -> *New GitHub App*.
+. Enter the application name as `Developer Hub`.
+. Add the following as the *Homepage URL*:
++
+--
 `https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
-. `Authorization callback URL` should be as follows:
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
-. Deselect *Webhook URL* -> *Active*
-. Under the *Where can this GitHub App be installed?* section, ensure that *Only on this account* is selected.
-. Once the application has been created, you will need to click on `Generate a new client secret` and
-make sure to copy the client secret as it will not be shown again!
-. Scroll to the bottom of the page and click *Generate a private key* and download the file that is generated.
-. In OpenShift, click *ConfigMaps*.
+--
 
-. Create (or edit) a key/value secret named `github-secrets` using the following environment variables as keys and the values that you created for your GitHub OAuth application.
+. Add the following URL as *Authorization callback URL*:
++
+--
+`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+--
+
+. Unselect *Webhook URL* -> *Active*.
+. Under the *Where can this GitHub App be installed?* section, ensure that *Only on this account* is selected.
+. After creating the application, click *Generate a new client secret* and copy the generated client secret.
+. Click *Generate a private key* at the bottom of the page and download the generated file.
+. In OpenShift, click *ConfigMaps*.
+. Generate a key/value secret named 'github-secrets' using the provided environment variables as keys, and input the values you generated for your GitHub OAuth application:
 +
 --
 .. In Red Hat OpenShift, go to the *Secrets* tab and click *Create*.
 .. Select *Key/value secret*.
 .. Enter *Secret name* as `github-secrets`.
 .. Add environment variables as *Key* and *Value* and click *Create*.
---
-+
---
+
+.Environment variables
 [cols="1,1"]
 |===
 |Key |Value 
@@ -133,6 +142,7 @@ make sure to copy the client secret as it will not be shown again!
 |Upload the private key that was downloaded
 |===
 --
+
 . Modify your `app-config-rhdh` ConfigMap to include the GitHub integration configuration as follows:
 +
 --
@@ -158,9 +168,9 @@ data:
               privateKey: |
                 ${GITHUB_APP_PRIVATE_KEY}
 ----
-
 --
-. Click on *Toplogy* -> *developer hub* -> *Actions* (dropdown) -> *Restart rollout*
+
+. Click *Toplogy* -> *developer hub* -> *Actions* (drop-down) -> *Restart rollout*.
 
 == Enabling GitHub discovery in {product}
 

--- a/installation/proc-install-rhdh-helm.adoc
+++ b/installation/proc-install-rhdh-helm.adoc
@@ -22,7 +22,7 @@ The {product} Helm chart is available in the Helm catalog in Red Hat OpenShift D
 . Create a project in the OpenShift, if not present.
 +
 For more information about creating a project in OpenShift, see link: https://docs.openshift.com/container-platform/3.11/dev_guide/projects.html#create-a-project[Red Hat OpenShift documentation]. 
-. Switch to *Developer* mode on your Red Hat OpenShift web console.
+. Switch to *Developer* perspective on your Red Hat OpenShift web console.
 . Click *+Add*.
 . From the *Developer Catalog* panel, click *Helm Chart*.
 . Search for _Developer Hub_ in the search bar and select the *{product}* card.

--- a/modules/installation/proc-install-rhdh-helm.adoc
+++ b/modules/installation/proc-install-rhdh-helm.adoc
@@ -21,10 +21,19 @@ The {product} Helm chart is available in the Helm catalog in Red Hat OpenShift D
 
 . Switch to *Developer* mode on your Red Hat OpenShift web console.
 . Click *+Add*.
+. Click **create a Project**
+. Choose a name for your project and click **Create**
 . From the *Developer Catalog* panel, click *Helm Chart*.
 . Search for _Developer Hub_ in the search bar and select the *{product}* card.
 . Click *Create*.
-. Copy the OpenShift router host from *Root Schema* -> *global* -> *clusterRouterBase*, and adjust the other values if needed.
+. Note the OpenShift router host from *Root Schema* -> *global* -> *clusterRouterBase*, which will be needed in the next section, and adjust the other values if needed.
++
+
+[NOTE]
+====
+If you did not configure a custom domain for your cluster, you will need to replace the *clusterRouterBase* with the base domain for your cluster, something like `apps.<clusterName>.com`.
+====
++
 . Click *Create* and wait for the database and {product} to start.
 . Click the *Open URL* option to start using the {product} platform.
 +


### PR DESCRIPTION
Update instructions to be more specific and clear about how to configure the GitHub Authorization and GitHub Integration settings including where to go and how to create the OAuth App and GitHub App that are required for configuration.