### PR TITLE
chore: Added HTMLtest configuration to test links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 titles/*/build
 index.html
 titles-generated/
+.cache/
 .vscode/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -9,6 +9,5 @@ ExternalTimeout: 30
 OutputDir: .cache/htmltest
 IgnoreDirectoryMissingTrailingSlash: true
 IgnoreSSLVerify: true
-IgnoreURLs: # Not published, false positives, websites refusing crawlers
-#  - https://docs.github.com
-#  - https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language
+IgnoreURLs: # List URLS that are not published, false positives, websites refusing crawlers
+  - https://docs.github.com/

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,14 @@
+---
+# .htmltest.yml
+# Defines htmltest configuration
+# See: https://github.com/wjdp/htmltest
+#
+DirectoryPath: titles-generated/main
+CheckDoctype: false
+ExternalTimeout: 30
+OutputDir: .cache/htmltest
+IgnoreDirectoryMissingTrailingSlash: true
+IgnoreSSLVerify: true
+IgnoreURLs: # Not published, false positives, websites refusing crawlers
+#  - https://docs.github.com
+#  - https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language


### PR DESCRIPTION
This update adds a configuration file for htmltest to test links in user working copies.

See: https://github.com/wjdp/htmltest

To test:

1. Install htmltest from https://github.com/wjdp/htmltest
2. Run `htmltest`

Sample output (with current broken links):

```
htmltest 
htmltest started at 05:07:44 on titles-generated/main
========================================================================
admin-rhdh/index.html
  Get "https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>": dial tcp: lookup backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>: no such host --- admin-rhdh/index.html --> https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
  Get "https://<rhdh_url>/api/auth/oidc/handler/frame": dial tcp: lookup <rhdh_url>: no such host --- admin-rhdh/index.html --> https://<rhdh_url>/api/auth/oidc/handler/frame
  Get "https://<rhdh_url>": dial tcp: lookup <rhdh_url>: no such host --- admin-rhdh/index.html --> https://<rhdh_url>
  bad reference: "parse \"http://SERVER:PORT/api/permission/policies\": invalid port \":PORT\" after host" --- admin-rhdh/index.html --> <nil>
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies/user/default/johndoe": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies/user/default/johndoe
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "https://localhost:8443/auth": dial tcp [::1]:8443: connect: connection refused --- admin-rhdh/index.html --> https://localhost:8443/auth
getting-started-rhdh/index.html
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame
  Get "http://<SERVICE_NAME>:8080": dial tcp: lookup <SERVICE_NAME>: no such host --- getting-started-rhdh/index.html --> http://<SERVICE_NAME>:8080
  Get "http://rhdh-customization-provider:8080": dial tcp: lookup rhdh-customization-provider: no such host --- getting-started-rhdh/index.html --> http://rhdh-customization-provider:8080
  Get "http://<SERVICE_NAME>/tech-radar": dial tcp: lookup <SERVICE_NAME>: no such host --- getting-started-rhdh/index.html --> http://<SERVICE_NAME>/tech-radar
  Get "http://rhdh-customization-provider/tech-radar": dial tcp: lookup rhdh-customization-provider: no such host --- getting-started-rhdh/index.html --> http://rhdh-customization-provider/tech-radar
  Get "https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>
  Get "https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame
  Get "https://ghe.<company>.com": dial tcp: lookup ghe.<company>.com: no such host --- getting-started-rhdh/index.html --> https://ghe.<company>.com
  Get "https://your-intermediate-service.com/handler": dial tcp: lookup your-intermediate-service.com: no such host --- getting-started-rhdh/index.html --> https://your-intermediate-service.com/handler
========================================================================
✘✘✘ failed in 23.945148367s
22 errors in 4 documents

```