### PR TITLE
fix: Fixed broken links

### DIFF
--- a/admin/con-rbac-rest-api.adoc
+++ b/admin/con-rbac-rest-api.adoc
@@ -30,7 +30,7 @@ The RBAC REST API supports the following HTTP methods for API requests:
 
 *Base URL*
 
-The base URL for RBAC REST API requests is `http://SERVER:PORT/api/permission/policies`, such as `http://localhost:7007/api/permission/policies`.
+The base URL for RBAC REST API requests is `pass:c[http://SERVER:PORT/api/permission/policies]`, such as `pass:c[http://localhost:7007/api/permission/policies]`.
 
 *Endpoints*
 
@@ -38,7 +38,7 @@ RBAC REST API endpoints, such as `/api/permission/policies/[kind]/[namespace]/[n
 
 Example request URL for `/api/permission/policies/[kind]/[namespace]/[name]` endpoint is:
 
-`http://localhost:7007/api/permission/policies/user/default/johndoe`
+`pass:c[http://localhost:7007/api/permission/policies/user/default/johndoe]`
 
 [NOTE]
 ====
@@ -50,7 +50,7 @@ If at least one permission is assigned to `user:default/johndoe`, then the examp
 HTTP `POST` requests in the RBAC REST API may require a JSON request body with data to accompany the request.
 
 Example `POST` request URL and JSON request body data for
-`http://localhost:7007/api/permission/policies`:
+`pass:c[http://localhost:7007/api/permission/policies]`:
 
 [source,json]
 ----

--- a/admin/proc-rbac-send-request-rbac-rest-api.adoc
+++ b/admin/proc-rbac-send-request-rbac-rest-api.adoc
@@ -18,7 +18,7 @@ The RBAC REST API enables you to interact with the permission policies and roles
 * Authorization: Enter the generated token from the web console.
 * HTTP method: Set to `POST`.
 * URL: Enter the RBAC REST API base URL and endpoint such as
-`http://localhost:7007/api/permission/policies`.
+`pass:c[http://localhost:7007/api/permission/policies]`.
 
 
 *For curl utility*:
@@ -32,7 +32,7 @@ The RBAC REST API enables you to interact with the permission policies and roles
 +
 `$token` is the requested token from the web console in a browser.
 
-* URL: Enter the following RBAC REST API base URL endpoint, such as `http://localhost:7007/api/permission/policies`
+* URL: Enter the following RBAC REST API base URL endpoint, such as `pass:c[http://localhost:7007/api/permission/policies]`
 * `-d`: Add a request JSON body
 
 *Example request*:

--- a/admin/proc-rhdh-monitoring-logging-aws.adoc
+++ b/admin/proc-rhdh-monitoring-logging-aws.adoc
@@ -86,7 +86,7 @@ To verify if the scraping works:
 $ kubectl --namespace=prometheus port-forward deploy/prometheus-server 9090
 ----
 
-. Open your web browser and navigate to `http://localhost:9090` to access the Prometheus console.
+. Open your web browser and navigate to `pass:c[http://localhost:9090]` to access the Prometheus console.
 . Monitor relevant metrics, such as `process_cpu_user_seconds_total`.
 
 == Logging with Amazon CloudWatch logs

--- a/admin/proc-using-aws-cognito-auth-provider.adoc
+++ b/admin/proc-using-aws-cognito-auth-provider.adoc
@@ -21,9 +21,9 @@ Ensure that you have noted the AWS region where the user pool is located and the
 --
 When setting up the hosted UI using the Amazon Cognito console, ensure to make the following adjustments:
 
-. In the *Allowed callback URL(s)* section, include the URL `https://<rhdh_url>/api/auth/oidc/handler/frame`. Ensure to replace `<rhdh_url>` with your {product-short} application's URL, such as, `my.rhdh.example.com`.
+. In the *Allowed callback URL(s)* section, include the URL `pass:c[https://<rhdh_url>/api/auth/oidc/handler/frame]`. Ensure to replace `<rhdh_url>` with your {product-short} application's URL, such as, `my.rhdh.example.com`.
 
-. Similarly, in the *Allowed sign-out URL(s)* section, add `https://<rhdh_url>`. Replace `<rhdh_url>` with your {product-short} application's URL, such as `my.rhdh.example.com`.
+. Similarly, in the *Allowed sign-out URL(s)* section, add `pass:c[https://<rhdh_url>]`. Replace `<rhdh_url>` with your {product-short} application's URL, such as `my.rhdh.example.com`.
 
 . Under *OAuth 2.0 grant types*, select *Authorization code grant* to return an authorization code.
 

--- a/artifacts/rhdh-plugins-reference/keycloak/keycloak-plugin-readme.adoc
+++ b/artifacts/rhdh-plugins-reference/keycloak/keycloak-plugin-readme.adoc
@@ -89,7 +89,7 @@ The following table describes the parameters that you can configure to enable th
 | Name | Description | Default Value | Required
 
 | `baseUrl`
-| Location of the Keycloak server, such as `https://localhost:8443/auth`. Note that the newer versions of Keycloak omit the `/auth` context path.
+| Location of the Keycloak server, such as `pass:c[https://localhost:8443/auth]`. Note that the newer versions of Keycloak omit the `/auth` context path.
 | ""
 | Yes
 

--- a/getting-started/proc-add-source-control-rhdh-catalog.adoc
+++ b/getting-started/proc-add-source-control-rhdh-catalog.adoc
@@ -21,13 +21,13 @@ The configuration of GitHub authentication is required to enable the GitHub OAut
 . Add the following URL as the *Homepage URL*:
 +
 --
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
+`pass:c[https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/]`
 --
 
 . Add the following URL as *Authorization callback URL*:
 +
 --
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+`pass:c[https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame]`
 --
 
 . Uncheck the *Enable Device Flow* checkbox.
@@ -96,13 +96,13 @@ The configuration of GitHub is required to enable the GitHub plugins in {product
 . Add the following URL as the *Homepage URL*:
 +
 --
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/`
+`pass:c[https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/]`
 --
 
 . Add the following URL as *Authorization callback URL*:
 +
 --
-`https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame`
+`pass:c[https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame]`
 --
 
 . Deselect *Webhook URL* -> *Active*.

--- a/getting-started/proc-configuring-github-app.adoc
+++ b/getting-started/proc-configuring-github-app.adoc
@@ -8,8 +8,8 @@ The GitHub authentication provider uses the following configuration keys:
 
 * `clientId`: the client ID that you generated on GitHub. For example: b59241722e3c3b4816e2
 * `clientSecret`: the client secret tied to the generated client ID.
-* `enterpriseInstanceUrl` (optional): the base URL for a GitHub Enterprise instance. For example: https://ghe.<company>.com. The `enterpriseInstanceUrl` is only needed for GitHub Enterprise.
-* `callbackUrl` (optional): the callback URL that GitHub uses when initiating an OAuth flow. For example: https://your-intermediate-service.com/handler. The `callbackUrl` is only needed if {product-short} is not the immediate receiver, such as in cases when you use one OAuth app for many {product-short} instances.
+* `enterpriseInstanceUrl` (optional): the base URL for a GitHub Enterprise instance. For example: `pass:c[https://ghe.<company>.com]`. The `enterpriseInstanceUrl` is only needed for GitHub Enterprise.
+* `callbackUrl` (optional): the callback URL that GitHub uses when initiating an OAuth flow. For example: pass:c[https://your-intermediate-service.com/handler]. The `callbackUrl` is only needed if {product-short} is not the immediate receiver, such as in cases when you use one OAuth app for many {product-short} instances.
 
 To configure the GitHub App, add the provider configuration to your `app-config.yaml` file under the root auth configuration. For example:
 

--- a/getting-started/proc-customize-rhdh-homepage.adoc
+++ b/getting-started/proc-customize-rhdh-homepage.adoc
@@ -121,7 +121,7 @@ proxy:
 Ensure that the API request call returns the response in JSON format.
 --
 
-. Define the `HOMEPAGE_DATA_URL` as http://<SERVICE_NAME>:8080. For example, `http://rhdh-customization-provider:8080`.
+. Define the `HOMEPAGE_DATA_URL` as `pass:c[http://<SERVICE_NAME>:8080]. For example, `pass:c[http://rhdh-customization-provider:8080]`.
 +
 --
 You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or directly replacing it in your custom ConfigMap.

--- a/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -61,7 +61,7 @@ proxy:
 Ensure that the API request call returns the response in JSON format.
 --
 
-. Define the `TECHRADAR_DATA_URL`` as `http://<SERVICE_NAME>/tech-radar`, for example `http://rhdh-customization-provider/tech-radar`. 
+. Define the `TECHRADAR_DATA_URL`` as `pass:c[http://<SERVICE_NAME>/tech-radar]`, for example `pass:c[http://rhdh-customization-provider/tech-radar]`.
 +
 --
 [NOTE]

--- a/getting-started/proc-registering-github-app.adoc
+++ b/getting-started/proc-registering-github-app.adoc
@@ -9,7 +9,7 @@ To add GitHub authentication, complete the steps in link:https://docs.github.com
 Use the following examples to enter the information about your production environment into the required fields on the *Register new GitHub App* page:
 
 * Application name: {product}
-* Homepage URL:  `https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>`
-* Authorization callback URL: `https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame`
+* Homepage URL:  `pass:c[https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>]`
+* Authorization callback URL: `pass:c[https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame]`
 
 NOTE: The Homepage URL points to the {product-short} front end, while the authorization callback URL points to the authentication provider backend.

--- a/installation/proc-install-rhdh-operator.adoc
+++ b/installation/proc-install-rhdh-operator.adoc
@@ -101,7 +101,7 @@ You are responsible for protecting your {product} installation from external and
 For more information about roles and responsibilities in Developer Hub, see the xref:con-rbac-overview_{context}[Role-Based Access Control (RBAC) in {product}] section in the Administration Guide for {product}.
 --
 
-You need to know the external URL of your {product} instance and set it in the `app.baseUrl`, `backend.baseUrl` and `backend.cors.origin` fields of the application configuration. By default, this will be named as follows: `https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>;`. You can use the `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'` command to display your ingress domain. If you are using a different host or sub-domain, which is customizable in the `Custom Resource spec.application.route field`, you must adjust the application configuration accordingly.
+You need to know the external URL of your {product} instance and set it in the `app.baseUrl`, `backend.baseUrl` and `backend.cors.origin` fields of the application configuration. By default, this will be named as follows: `pass:c[https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>;]`. You can use the `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'` command to display your ingress domain. If you are using a different host or sub-domain, which is customizable in the `Custom Resource spec.application.route field`, you must adjust the application configuration accordingly.
 
 .Prerequisites
 * You have created an account in Red Hat OpenShift.


### PR DESCRIPTION
Fixed these broken links, mostly by deactivating the links:

```
htmltest 
htmltest started at 05:07:44 on titles-generated/main
========================================================================
admin-rhdh/index.html
  Get "https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>": dial tcp: lookup backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>: no such host --- admin-rhdh/index.html --> https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
  Get "https://<rhdh_url>/api/auth/oidc/handler/frame": dial tcp: lookup <rhdh_url>: no such host --- admin-rhdh/index.html --> https://<rhdh_url>/api/auth/oidc/handler/frame
  Get "https://<rhdh_url>": dial tcp: lookup <rhdh_url>: no such host --- admin-rhdh/index.html --> https://<rhdh_url>
  bad reference: "parse \"http://SERVER:PORT/api/permission/policies\": invalid port \":PORT\" after host" --- admin-rhdh/index.html --> <nil>
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies/user/default/johndoe": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies/user/default/johndoe
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "http://localhost:7007/api/permission/policies": dial tcp [::1]:7007: connect: connection refused --- admin-rhdh/index.html --> http://localhost:7007/api/permission/policies
  Get "https://localhost:8443/auth": dial tcp [::1]:8443: connect: connection refused --- admin-rhdh/index.html --> https://localhost:8443/auth
getting-started-rhdh/index.html
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/
  Get "https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<OPENSHIFT_ROUTE_HOST>/api/auth/github/handler/frame
  Get "http://<SERVICE_NAME>:8080": dial tcp: lookup <SERVICE_NAME>: no such host --- getting-started-rhdh/index.html --> http://<SERVICE_NAME>:8080
  Get "http://rhdh-customization-provider:8080": dial tcp: lookup rhdh-customization-provider: no such host --- getting-started-rhdh/index.html --> http://rhdh-customization-provider:8080
  Get "http://<SERVICE_NAME>/tech-radar": dial tcp: lookup <SERVICE_NAME>: no such host --- getting-started-rhdh/index.html --> http://<SERVICE_NAME>/tech-radar
  Get "http://rhdh-customization-provider/tech-radar": dial tcp: lookup rhdh-customization-provider: no such host --- getting-started-rhdh/index.html --> http://rhdh-customization-provider/tech-radar
  Get "https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>
  Get "https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame": dial tcp: lookup developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>: no such host --- getting-started-rhdh/index.html --> https://developer-hub-<NAMESPACE_NAME>.<KUBERNETES_ROUTE_HOST>/api/auth/github/handler/frame
  Get "https://ghe.<company>.com": dial tcp: lookup ghe.<company>.com: no such host --- getting-started-rhdh/index.html --> https://ghe.<company>.com
  Get "https://your-intermediate-service.com/handler": dial tcp: lookup your-intermediate-service.com: no such host --- getting-started-rhdh/index.html --> https://your-intermediate-service.com/handler
========================================================================
✘✘✘ failed in 23.945148367s
22 errors in 4 documents
```