### PR TITLE
CM example indentation fix.

### DIFF
--- a/installation/proc-install-rhdh-operator.adoc
+++ b/installation/proc-install-rhdh-operator.adoc
@@ -65,10 +65,10 @@ data:
     backend:
       auth:
         keys:
-        - secret: “${BACKEND_SECRET}”
-       baseUrl: https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
-       cors:
-         origin: https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
+          - secret: “${BACKEND_SECRET}”
+      baseUrl: https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
+      cors:
+        origin: https://backstage-<CUSTOM_RESOURCE_NAME>-<NAMESPACE_NAME>.<OPENSHIFT_INGRESS_DOMAIN>
 ----
 
 .Example


### PR DESCRIPTION
Fixed CM indentation for `backend.baseUrl` and  `backend.cors.origin`