### PR TITLE
RHIDP-1025: Migrate Janus IDP customization provider repo to redhat-developers org (1.1.x)

### DIFF
--- a/getting-started/proc-customize-rhdh-homepage.adoc
+++ b/getting-started/proc-customize-rhdh-homepage.adoc
@@ -32,10 +32,10 @@ proxy:
 It is not necessary that the same service provides the Home page and Tech Radar data.
 ====
 
-You can use the https://github.com/janus-idp/backstage-customization-provider[`backstage-customization-provider`] as an example service, which provides data for both Home page and Tech Radar. The `backstage-customization-provider` service provides the same data as default {product-short} data. You can fork the `backstage-customization-provider` service repository from GitHub and modify it with your own data, if required.
+You can use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both Home page and Tech Radar. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
 --
 
-This section describes how you can deploy the `backstage-customization-provider` service onto the cluster where the {product-short} Helm Chart is deployed.
+This section describes how you can deploy the `red-hat-developer-hub-customization-provider` service onto the cluster where the {product-short} Helm Chart is deployed.
 
 .Prerequisites
 
@@ -47,7 +47,7 @@ This section describes how you can deploy the `backstage-customization-provider`
 . Add the URL of your Git repository to the *Git Repo URL* field.
 +
 --
-To use the `backstage-customization-provider` service, you can add the URL of https://github.com/janus-idp/backstage-customization-provider[backstage-customization-provider] repository.
+To use the `red-hat-developer-hub-customization-provider` service, you can add the URL of https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[red-hat-developer-hub-customization-provider] repository.
 --
 
 . In the *General* section, rename the value in the *Name* field to *rhdh-customization-provider* and click *Create*.


### PR DESCRIPTION
### Description
Update references and links to the backstage-customization-provider repository in the janus-idp org to point to the red-hat-developer-hub-customization-provider repository in the redhat-developers org
Cherry Picked to 1.1.x

### JIRA issue
Fixes [RHIDP-1025](https://issues.redhat.com/browse/RHIDP-1025)

### Related PR
https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/147