### PR TITLE
chore: [1.1.x] wrong paths to plugins in supported...

### DIFF
--- a/modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc
+++ b/modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc
@@ -111,15 +111,15 @@ requests, etc. which is used by the Azure DevOps frontend plugin. |0.5.5
 
 |Disabled
 
-|Azure Devops |Backend |@backstage/plugin-scaffolder-backend-module-azure |The azure module for @backstage/plugin-scaffolder-backend |0.1.5 |Community Support |dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic | |Enabled
+|Azure Devops |Backend |@backstage/plugin-scaffolder-backend-module-azure |The azure module for @backstage/plugin-scaffolder-backend |0.1.5 |Community Support |./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-azure-dynamic | |Enabled
 
-|Bitbucket |Backend |@backstage/plugin-catalog-backend-module-bitbucket-cloud |A Backstage catalog backend module that helps integrate towards Bitbucket Cloud. |0.1.28 |Community Support |dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud |`BITBUCKET_WORKSPACE` |Disabled
+|Bitbucket |Backend |@backstage/plugin-catalog-backend-module-bitbucket-cloud |A Backstage catalog backend module that helps integrate towards Bitbucket Cloud. |0.1.28 |Community Support |./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic |`BITBUCKET_WORKSPACE` |Disabled
 
-|Bitbucket |Backend |@backstage/plugin-catalog-backend-module-bitbucket-server |A Backstage catalog backend module that helps integrate towards Bitbucket Server. |0.1.26 |Community Support |dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server |`BITBUCKET_HOST` |Disabled
+|Bitbucket |Backend |@backstage/plugin-catalog-backend-module-bitbucket-server |A Backstage catalog backend module that helps integrate towards Bitbucket Server. |0.1.26 |Community Support |./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic |`BITBUCKET_HOST` |Disabled
 
-|Bitbucket |Backend |@backstage/plugin-scaffolder-backend-module-bitbucket-cloud |The Bitbucket Cloud module for @backstage/plugin-scaffolder-backend |0.1.3 |Community Support |dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud | |Enabled
+|Bitbucket |Backend |@backstage/plugin-scaffolder-backend-module-bitbucket-cloud |The Bitbucket Cloud module for @backstage/plugin-scaffolder-backend |0.1.3 |Community Support |./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic | |Enabled
 
-|Bitbucket |Backend |@backstage/plugin-scaffolder-backend-module-bitbucket-server |The Bitbucket Server module for @backstage/plugin-scaffolder-backend. |0.1.3 |Community Support |dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server | |Enabled
+|Bitbucket |Backend |@backstage/plugin-scaffolder-backend-module-bitbucket-server |The Bitbucket Server module for @backstage/plugin-scaffolder-backend. |0.1.3 |Community Support |./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic | |Enabled
 
 |Datadog |Frontend |@roadiehq/backstage-plugin-datadog |Embed Datadog
 graphs and dashboards into Backstage. |2.2.6 |Community Support
@@ -131,7 +131,7 @@ that integrates towards Dynatrace. |9.0.0 |Community Support
 
 |Dynamic Plugins |Frontend |@janus-idp/backstage-plugin-dynamic-plugins-info |Dynamic Plugins Info plugin for Backstage. |1.0.2 |Production |@janus-idp/backstage-plugin-dynamic-plugins-info | |Enabled
 
-|Gerrit |Backend |@backstage/plugin-scaffolder-backend-module-gerrit |The gerrit module for @backstage/plugin-scaffolder-backend. |0.1.5 |Community Support |dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic | |Enabled
+|Gerrit |Backend |@backstage/plugin-scaffolder-backend-module-gerrit |The gerrit module for @backstage/plugin-scaffolder-backend. |0.1.5 |Community Support |./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gerrit-dynamic | |Enabled
 
 |Github |Backend |@backstage/plugin-catalog-backend-module-github |A
 Backstage catalog backend module that helps integrate towards Github
@@ -156,7 +156,7 @@ that integrates towards GitHub Actions |0.6.11 |Community Support
 that integrates towards GitHub Issues |0.2.19 |Community Support
 |./dynamic-plugins/dist/backstage-plugin-github-issues | |Disabled
 
-|Github |Backend |@backstage/plugin-scaffolder-backend-module-github |The github module for @backstage/plugin-scaffolder-backend. |0.2.3 |Community Support |dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic | |Enabled
+|Github |Backend |@backstage/plugin-scaffolder-backend-module-github |The github module for @backstage/plugin-scaffolder-backend. |0.2.3 |Community Support |./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic | |Enabled
 
 |Github |Frontend |@roadiehq/backstage-plugin-github-insights |Backstage
 plugin to provide Readmes, Top Contributors and other widgets. |2.3.27
@@ -304,7 +304,7 @@ a|
 
 |Pagerduty |Frontend |@pagerduty/backstage-plugin |A Backstage plugin
 that integrates towards PagerDuty |0.9.3 |Community Support
-|./dynamic-plugins/wrappers/pagerduty-backstage-plugin | |Disabled
+|././dynamic-plugins/dist/pagerduty-backstage-plugin | |Disabled
 
 |Quay |Frontend |@janus-idp/backstage-plugin-quay |The Quay plugin
 displays the information about your container images within the Quay


### PR DESCRIPTION
### What does this PR do?

chore: wrong paths to plugins in supported plugins table

Signed-off-by: Nick Boldt <nboldt@redhat.com>

Update modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc

Co-authored-by: David Festal <dfestal@redhat.com>

Update modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc

Co-authored-by: David Festal <dfestal@redhat.com>

Update modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc

Co-authored-by: David Festal <dfestal@redhat.com>

Update modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc

Co-authored-by: David Festal <dfestal@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.