### PR TITLE
Add fix for deploy action failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ on:
   # will prevent the job from running until it's approved manually by human intervention.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: 
+    branches:
     - main
     - rhdh-1.**
     - 1.**.x
@@ -67,7 +67,7 @@ jobs:
         run: |
           # update
           sudo apt-get update -y || true
-          # install 
+          # install
           sudo apt-get -y -q install asciidoctor && asciidoctor --version
           echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
@@ -81,7 +81,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         # if: github.ref == 'refs/heads/main'
         with:
-          github_token: ${{ secrets.RHDH_BOT_TOKEN }}
+          deploy_key: ${{ secrets.RHDH_BOT_TOKEN }}
           publish_branch: gh-pages
           keep_files: true
           publish_dir: ./titles-generated
@@ -89,11 +89,11 @@ jobs:
       - name: PR comment with doc preview
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.RHDH_BOT_TOKEN }}
+          deploy_key: ${{ secrets.RHDH_BOT_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'PR Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${{ github.event.number }}/' 
+              body: 'PR Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${{ github.event.number }}/'
             });

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,7 +78,7 @@ jobs:
 
       # repo must be public for this to work
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         # if: github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.RHDH_BOT_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
       - name: PR comment with doc preview
         uses: actions/github-script@v7
         with:
-          deploy_key: ${{ secrets.RHDH_BOT_TOKEN }}
+          github_token: ${{ secrets.RHDH_BOT_TOKEN }}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
One of my manual cherrypicked PRs has a check failing for deploying the preview: https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/actions/runs/8648296395/job/23711771598?pr=161

![image](https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/assets/40172997/f6c2364e-425d-4d49-b9c3-510844ced1da)

It seems to be happening occassionally for other PRs also, so I tried to look into a fix for it. Based on https://github.com/peaceiris/actions-gh-pages/issues/339 I am proposing that updating the variable here from `github_token` to `deploy_key` may fix the issue, but I am not an expert on GH actions, so will need someone to sanity check 🙂 