### PR TITLE
RHIDP-1785: Remove unnecessary link and fix IDs

### DIFF
--- a/modules/rhdh-plugins-reference/assembly-rhdh-installing-dynamic-plugins.adoc
+++ b/modules/rhdh-plugins-reference/assembly-rhdh-installing-dynamic-plugins.adoc
@@ -1,17 +1,16 @@
 [id="rhdh-installing-dynamic-plugins"]
-
 = Dynamic plugin installation
 
 The dynamic plugin support is based on the backend plugin manager package, which is a service that scans a configured root directory (`dynamicPlugins.rootDirectory` in the app config) for dynamic plugin packages and loads them dynamically.
 
-You can use the dynamic plugins that come preinstalled with {product} or install external dynamic plugins from a public NPM registry. 
+You can use the dynamic plugins that come preinstalled with {product} or install external dynamic plugins from a public NPM registry.
 
 //viewing installed plugins
 include::proc-viewing-installed-plugins.adoc[leveloffset=+1]
 //preinstalled plugins
 include::con-preinstalled-dynamic-plugins.adoc[leveloffset=+1]
-include::ref-rhdh-plugins.adoc[leveloffset=+2]
-//helm installed plugins 
+include::rhdh-supported-plugins.adoc[leveloffset=+2]
+//helm installed plugins
 include::con-install-dynamic-plugin-helm.adoc[leveloffset=+1]
 include::proc-obtaining-integrity-checksum.adoc[leveloffset=+2]
 include::ref-example-dynamic-plugin-helm-installations.adoc[leveloffset=+2]

--- a/modules/rhdh-plugins-reference/rhdh-supported-plugins.adoc
+++ b/modules/rhdh-plugins-reference/rhdh-supported-plugins.adoc
@@ -10,7 +10,7 @@ For more information on Red Hat Technology Preview features, see https://access.
 Additional detail on how Red Hat provides support for bundled community dynamic plugins is available on the https://access.redhat.com/policy/developerhub-support-policy[Red Hat Developer Support Policy] page.
 ====
 
-There are 56 plugins available in {product}. See the xref:rhdh-supported-plugins[Dynamic plugins support matrix] for details. 
+There are 56 plugins available in {product}. See the following table for more information:
 
 [dynamic-plugins-matrix]
 .Dynamic plugins support matrix
@@ -96,7 +96,7 @@ a|
 
 |Disabled
 
-|Azure Devops |Frontend |@backstage/plugin-azure-devops | |0.3.12 |Community Support 
+|Azure Devops |Frontend |@backstage/plugin-azure-devops | |0.3.12 |Community Support
 |./dynamic-plugins/dist/backstage-plugin-azure-devops |
 |Disabled
 
@@ -398,7 +398,3 @@ enables you to visualize the PipelineRun resources available on the
 Kubernetes cluster. |3.5.12 |Production
 |./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton | |Disabled
 |===
-
-
-
-

--- a/titles/rhdh-plugins-reference/master.adoc
+++ b/titles/rhdh-plugins-reference/master.adoc
@@ -10,7 +10,7 @@ include::attributes.adoc[]
 
 include::snip-concious-language.adoc[leveloffset=+1]
 
-include::modules/rhdh-plugins-reference/ref-rhdh-plugins.adoc[leveloffset=+1]
+include::modules/rhdh-plugins-reference/rhdh-supported-plugins.adoc[leveloffset=+1]
 include::modules/rhdh-plugins-reference/con-rhdh-installing-dynamic-plugins.adoc[leveloffset=+1]
 
 == Plugins reference


### PR DESCRIPTION
Issue:
https://issues.redhat.com/browse/RHIDP-1785

Description:
Removing unnecessary link to table.
Also taking this opportunity to clean up the filename/ID for this module so that they match. This makes it much easier to find where the content needs to be updated if a link to the content is provided in a Jira issue.

Preview link:
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-179/admin-rhdh/#rhdh-supported-plugins

/cherrypick 1.1.x
/cherrypick rhdh-1.0