### PR TITLE
RHIDP-2143: Fix GitHub typo

### DIFF
--- a/getting-started/assembly-auth-provider-github.adoc
+++ b/getting-started/assembly-auth-provider-github.adoc
@@ -2,7 +2,7 @@
 
 = GitHub authentication provider
 
-{product} uses a built-in Github authentication provider to authenticate users in GitHub or GitHub Enterprise.
+{product} uses a built-in GitHub authentication provider to authenticate users in GitHub or GitHub Enterprise.
 
 include::con-github-app-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fix typo / inconsistency with GitHub name