### PR TITLE
chore: latest helm and operator releases are 1.1.2

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -12,7 +12,7 @@
 :product-very-short: RHDH
 :product-version: 1.2
 :product-bundle-version: 1.1.2
-:product-chart-version: 1.12
+:product-chart-version: 1.1.2
 :rhdeveloper-name: Red Hat Developer
 :rhel: Red Hat Enterprise Linux
 

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -11,8 +11,8 @@
 :product-short: Developer Hub
 :product-very-short: RHDH
 :product-version: 1.2
-:product-bundle-version: 1.1.1
-:product-chart-version: 1.1.1
+:product-bundle-version: 1.1.2
+:product-chart-version: 1.12
 :rhdeveloper-name: Red Hat Developer
 :rhel: Red Hat Enterprise Linux
 


### PR DESCRIPTION
Note that this is a manual update for now but once we branch for 1.2, I expect to set 1.2.0 in both the 1.2.x and main branches. ref: https://issues.redhat.com/browse/RHIDP-931