### PR TITLE
RHIDP-2579: Update techdocs plugin to enabled by default

### DIFF
--- a/modules/dynamic-plugins/rhdh-supported-plugins.adoc
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.adoc
@@ -369,7 +369,7 @@ that lets you display a Tech Radar for your organization |0.6.13 |Community Supp
 |Techdocs |Frontend |@backstage/plugin-techdocs |The Backstage plugin
 that renders technical documentation for your components |1.10.0
 |Production |./dynamic-plugins/dist/backstage-plugin-techdocs |
-|Disabled
+|Enabled
 
 |Techdocs |Backend |@backstage/plugin-techdocs-backend |The Backstage
 backend plugin that renders technical documentation for your components
@@ -391,7 +391,7 @@ backend plugin that renders technical documentation for your components
 
 `AWS_SECRET_ACCESS_KEY`
 
-|Disabled
+|Enabled
 
 |Tekton |Frontend |@janus-idp/backstage-plugin-tekton |The Tekton plugin
 enables you to visualize the PipelineRun resources available on the


### PR DESCRIPTION
**Versions:**
1.1+

**Jira link:**
- [RHIDP-2579](https://issues.redhat.com/browse/RHIDP-2579)

**Preview link:**
- https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-282/plugin-rhdh/#rhdh-supported-plugins

**Reviews:**
- [x] SME: @Zaperex 
- QE: Not required - there is nothing to test here, SME sign off should be enough
- [x] Peer review: @linfraze 