### PR TITLE
chore: fix CSS for code blocks overflow in admonitions

### DIFF
--- a/.asciidoctor/docs.css
+++ b/.asciidoctor/docs.css
@@ -1553,21 +1553,23 @@ section {
   display:inline-block;
   text-decoration:none
 }
-.admonitionblock #description,
-.admonitionblock p {
+.admonitionblock{
+  margin-bottom:var(--rh-space-lg,1rem)
   font-size:var(--rh-font-size-body-text-md,1rem)
 }
-.admonitionblock {
-  width:-moz-fit-content;
-  width:fit-content;
-  margin-bottom:var(--rh-space-lg,1rem)
+.admonitionblock table {
+  margin:0;
+  border:none;
+  width:fit-content
+}
+.admonitionblock td {
+  margin:0;
+  border:none;
+  display:block
 }
 .admonitionblock .title {
-  color:#002952;
-  font-weight: 700
-}
-.admonitionblock table, .admonitionblock td {
   margin:0;
-  border:none
+  color:#002952;
+  font-weight:700
 }
 


### PR DESCRIPTION
CSS: fix code blocks overflow in admonitions

Example: 

![Screenshot_%T_%Y%M%D_%H%m%S-11](https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/assets/243761/51a7e561-8205-4220-a41a-9baa679213aa)
