### PR TITLE
RHIDP-2895: Separate K8s module from OCP assembly for Helm CLI install

### DIFF
--- a/artifacts/snip-install-helm-cli-k8s.adoc
+++ b/artifacts/snip-install-helm-cli-k8s.adoc
@@ -1,0 +1,56 @@
+[id="snip-install-helm-cli-k8s_{context}"]
+= Installing {product} on Kubernetes with Helm CLI
+
+You can use the Helm CLI to install {product} on the following platforms:
+
+* {eks-brand-name} ({eks-short})
+* {aks-brand-name} ({aks-short})
+
+.Prerequisites
+* You have installed the link:https://kubernetes.io/docs/reference/kubectl/[`kubectl` CLI].
+* You have installed the link:https://helm.sh/docs/intro/install[Helm CLI].
+* You started a `kubectl` session, with `developer` or `admin` permissions, on a Kubernetes cluster.
+
+.Procedure
+. Add the OpenShift Helm Charts repository.
++
+----
+helm repo add openshift-helm-charts https://charts.openshift.io/
+----
+
+. Create and activate the _<rhdh>_ Kubernetes namespace:
++
+[subs="quotes+"]
+----
+NAMESPACE=_<rhdh>_
+kubectl create namespace ${NAMESPACE}
+kubectl config set-context --current --namespace=${NAMESPACE}
+----
+
+. Install the {product} Helm chart by running the following command:
++
+[subs="attributes+"]
+----
+helm upgrade redhat-developer-hub -i https://github.com/openshift-helm-charts/charts/releases/download/redhat-redhat-developer-hub-{product-chart-version}/redhat-developer-hub-{product-chart-version}.tgz
+----
+
+. Configure your {product-short} Helm chart instance with the {product-short} database password and router base URL values from your {ocp-short} cluster:
++
+[subs="attributes+"]
+----
+PASSWORD=$(kubectl get secret redhat-developer-hub-postgresql -o jsonpath="{.data.password}" | base64 -d)
+CLUSTER_ROUTER_BASE=$(kubectl get route console -n openshift-console -o=jsonpath='{.spec.host}' | sed 's/^[^.]*\.//')
+helm upgrade redhat-developer-hub -i "https://github.com/openshift-helm-charts/charts/releases/download/redhat-redhat-developer-hub-{product-chart-version}/redhat-developer-hub-{product-chart-version}.tgz" \
+    --set global.clusterRouterBase="$CLUSTER_ROUTER_BASE" \
+    --set global.postgresql.auth.password="$PASSWORD"
+----
+
+. Display the running {product-short} instance URL, by running the following command:
++
+----
+echo "https://redhat-developer-hub-$NAMESPACE.$CLUSTER_ROUTER_BASE"
+----
+
+.Verification
+* Open the running {product-short} instance URL in your browser to use {product-short}.
+

--- a/assemblies/assembly-install-rhdh-ocp.adoc
+++ b/assemblies/assembly-install-rhdh-ocp.adoc
@@ -1,5 +1,4 @@
 [id='assembly-install-rhdh-ocp']
-
 = Deploying {product} on {ocp-short}
 
 You can install {product} on {ocp-short} using one of the following methods:
@@ -9,13 +8,18 @@ You can install {product} on {ocp-short} using one of the following methods:
 
 // Helm chart method
 include::modules/installation/proc-install-rhdh-ocp-helm.adoc[leveloffset=+1]
+
 include::modules/installation/proc-installing-rhdh-on-openshift-with-helm-cli.adoc[leveloffset=+2]
-include::modules/installation/proc-installing-rhdh-on-kubernetes-with-helm-cli.adoc[leveloffset=+2]
+
 include::modules/getting-started/proc-add-custom-app-file-openshift-helm.adoc[leveloffset=+2]
+
 include::modules/installation/proc-install-rhdh-airgapped-environment-ocp-helm.adoc[leveloffset=+2]
 
 // Operator method
 include::modules/installation/proc-install-rhdh-ocp-operator.adoc[leveloffset=+1]
+
 include::modules/installation/proc-add-custom-app-config-file-ocp-operator.adoc[leveloffset=+2]
+
 include::modules/installation/proc-config-dynamic-plugins-rhdh-operator.adoc[leveloffset=+2]
+
 include::modules/installation/proc-install-rhdh-airgapped-environment-ocp-operator.adoc[leveloffset=+2]

--- a/assemblies/assembly-rhdh-integration-aks.adoc
+++ b/assemblies/assembly-rhdh-integration-aks.adoc
@@ -1,5 +1,4 @@
 [id='assembly-rhdh-integration-aks_{context}']
-
 = {product} integration with {aks-brand-name} ({aks-short})
 
 You can integrate {product-short} with {aks-brand-name} ({aks-short}), which provides a significant advancement in development, offering a streamlined environment for building, deploying, and managing your applications.
@@ -12,6 +11,8 @@ This integration requires the deployment of {product-short} on {aks-short} using
 include::modules/admin/proc-rhdh-deploy-aks.adoc[leveloffset=+1]
 
 include::modules/admin/proc-rhdh-deploy-aks-using-helm.adoc[leveloffset=+2]
+
+include::../artifacts/snip-install-helm-cli-k8s.adoc[leveloffset=+3]
 
 include::modules/admin/proc-rhdh-deploy-aks-using-operator.adoc[leveloffset=+2]
 

--- a/assemblies/assembly-rhdh-integration-aws.adoc
+++ b/assemblies/assembly-rhdh-integration-aws.adoc
@@ -1,5 +1,4 @@
 [id='assembly-rhdh-integration-aws_{context}']
-
 = {product} integration with {aws-brand-name} ({aws-short})
 
 You can integrate your {product} application with {aws-brand-name} ({aws-short}), which can help you streamline your workflows within the {aws-short} ecosystem. Integrating the {product-short} resources with {aws-short} provides access to a comprehensive suite of tools, services, and solutions.
@@ -10,6 +9,9 @@ The integration with {aws-short} requires the deployment of {product-short} in {
 * The {product} Operator
 
 include::modules/admin/proc-rhdh-deploy-eks-using-helm.adoc[leveloffset=+1]
+
+include::modules/installation/proc-installing-rhdh-on-kubernetes-with-helm-cli.adoc[leveloffset=+2]
+
 include::modules/admin/proc-rhdh-deploy-eks-using-operator.adoc[leveloffset=+1]
 
 include::modules/admin/proc-rhdh-monitoring-logging-aws.adoc[leveloffset=+1]

--- a/modules/admin/proc-install-operator.adoc
+++ b/modules/admin/proc-install-operator.adoc
@@ -56,5 +56,5 @@ The `fast` channel includes all of the updates available for a particular versio
 
 [role="_additional-resources"]
 .Additional resources
-* xref:proc-install-rhdh-ocp-operator_admin-rhdh[Deploying {product} on {ocp-short} using the Operator]
+* xref:proc-install-rhdh-ocp-operator_{context}[Deploying {product} on {ocp-short} using the Operator]
 * link:https://docs.openshift.com/container-platform/{ocp-version}/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console]

--- a/modules/release-notes/con-relnotes-notable-features.adoc
+++ b/modules/release-notes/con-relnotes-notable-features.adoc
@@ -5,25 +5,25 @@ This section highlights new features in {product} {product-version}.
 
 == {product} Operator is now generally available (GA)
 
-You can use the {product} Operator to install {product-short} on your {ocp-short}cluster. For more information, see the link:{LinkAdminGuide}#proc-install-rhdh-ocp-operator_admin-rhdh[Installing {product} using the Operator] section in the _Administration guide_.
+You can use the {product} Operator to install {product-short} on your {ocp-short}cluster. For more information, see the link:{LinkAdminGuide}#proc-install-rhdh-ocp-operator_{context}[Installing {product} using the Operator] section in the _Administration guide_.
 
 == Backstage version update
 
 {product} is now based on the upstream Backstage project v{product-backstage-version}.
 
 
-== Ability to manage role-based access controls (RBAC) using the web interface  
+== Ability to manage role-based access controls (RBAC) using the web interface
 
 As an administrator, you can now use {product-short} to assign specific roles and permissions to individual users or groups. Using the {product-short} web interface, you can perform the following actions:
 
-* Creating a role 
+* Creating a role
 * Editing a role and related permissions
 * Deleting a role
 
 For more information, see the link:{LinkAdminGuide}#con-rbac-overview_admin-rhdh[Role-Based Access Control in {product}] section in the _Administration guide_.
 
 
-==  Migration of the {product} to the new backend system  
+==  Migration of the {product} to the new backend system
 
 {product} {product-version} is now migrated to the Backstage new backend system. With this migration, you might notice the following functionality-related changes in the {product-short} application:
 
@@ -40,17 +40,17 @@ The new backend system's Scaffolder plugin utilizes an identity service that int
 
 == Support for Elastic Kubernetes Services (EKS)
 
-You can now install and use the {product} on an EKS cluster. 
+You can now install and use the {product} on an EKS cluster.
 
 For more information, see the link:{LinkAdminGuide}#con-rhdh-integration-aws_admin-rhdh[{product} integration with Amazon Web Services] section in the _Administration guide_.
 
 == Support for Azure Kubernetes Services (AKS)
 
-You can now install and use the {product} on an AKS cluster. 
+You can now install and use the {product} on an AKS cluster.
 
 For more information, see the link:{LinkAdminGuide}#con-rhdh-integration-aks_admin-rhdh[{product} integration with Azure Kubernetes Services] section in the _Administration guide_.
 
-== Support for viewing installed plugins using the web interface 
+== Support for viewing installed plugins using the web interface
 
 As an administrator, you can now use the {product-short} web interface to view a table of plugins that are installed. This feature uses the `dynamic-plugins-info` frontend component, which generates a table of plugins that are currently installed in the {product}. You can apply client-side sorting, filtering, and pagination to the plugins table.
 


### PR DESCRIPTION
Removes Helm CLI installation proc for K8s from the OCP assembly and makes it a sub-section under both the EKS and AKS Helm chart installation procs. 

Fixes the following: 
https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/287
https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/318 
[RHIDP-2614](https://issues.redhat.com/browse/RHIDP-2614)

**Version:**
1.2+

**Jira:**
https://issues.redhat.com/browse/RHIDP-2895 

**Preview:**
EKS 8.1 sub-section - https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-325/admin-rhdh/#proc-installing-rhdh-on-kubernetes-with-helm-cli_assembly-rhdh-observability
AKS 9.1.1 sub-section - https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-325/admin-rhdh/#snip-install-helm-cli-k8s_assembly-rhdh-observability