### PR TITLE
RHIDP-2681: Remove unsupported auth providers

### DIFF
--- a/assemblies/assembly-enabling-authentication.adoc
+++ b/assemblies/assembly-enabling-authentication.adoc
@@ -11,24 +11,25 @@ Authentication providers are typically used in the following ways:
 
 The {product} supports the following authentication providers:
 
-Auth0:: `auth0`
-Atlassian:: `atlassian`
-Microsoft Azure:: `microsoft`
-Microsoft Azure Easy Auth:: `azure-easyauth`
-Bitbucket:: `bitbucket`
-Bitbucket Server:: `bitbucketServer`
-Cloudflare Access:: `cfaccess`
+//Auth0:: `auth0`
+//Atlassian:: `atlassian`
+Microsoft Azure::
+`microsoft`
+//Microsoft Azure Easy Auth:: `azure-easyauth`
+//Bitbucket:: `bitbucket`
+//Bitbucket Server:: `bitbucketServer`
+//Cloudflare Access:: `cfaccess`
 GitHub:: `github`
-GitLab:: `gitlab`
-Google:: `google`
-Google IAP:: `gcp-iap`
-OIDC:: `oidc`
-Okta:: `okta`
-OAuth 2 Custom Proxy:: `oauth2Proxy`
-OneLogin:: `onelogin`
-SAML:: `saml`
+//GitLab:: `gitlab`
+//Google:: `google`
+//Google IAP:: `gcp-iap`
+Keycloak:: `oidc`
+//Okta:: `okta`
+//OAuth 2 Custom Proxy:: `oauth2Proxy`
+//OneLogin:: `onelogin`
+//SAML:: `saml`
 
-For each provider that you want to use, follow the dedicated procedure to:
+For each provider that you want to use, follow the dedicated procedure to complete the following tasks:
 
 . Set up the shared secret that the authentication provider and {product} require to communicate.
 . Configure {product} to use the authentication provider.


### PR DESCRIPTION
**Versions:**
1.2+

**Jira:** 
https://issues.redhat.com/browse/RHIDP-2681

**Preview:** 
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-343/admin-rhdh/#enabling-authentication

**Reviews:**
- [ ] SME: @kim-tsao 
- [ ] QE: N/A
- [ ] Doc: N/A