### PR TITLE
RHIDP-3001 - Fix downstream tooling bug

### DIFF
--- a/modules/installation/proc-add-custom-app-config-file-ocp-operator.adoc
+++ b/modules/installation/proc-add-custom-app-config-file-ocp-operator.adoc
@@ -36,13 +36,15 @@ data:
       auth:
         keys:
           - secret: "${BACKEND_SECRET}" # <2>
-      baseUrl: <{product-very-short}_URL> # <1>
+      baseUrl: <{product-very-short}_URL> # <3>
       cors:
-        origin: <{product-very-short}_URL> # <1>
+        origin: <{product-very-short}_URL> # <4>
 ----
 +
 <1> Set the external URL of your {product} instance.
 <2> Use an environment variable exposing an {ocp-short} secret to define the mandatory {product-short} backend authentication key.
+<3> Set the external URL of your {product} instance.
+<4> Set the external URL of your {product} instance.
 
 . Click *Create*.
 . Select the *Secrets* view.


### PR DESCRIPTION
**Version(s):**

1.2

**Issue:**

https://issues.redhat.com/browse/RHIDP-3001

Downstream tooling does not allow reusing the same callout:

![Screenshot_2024-07-01_2](https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/assets/243761/1d9a5931-befe-4bfc-afba-472828b67fa2)


**Link to docs preview:**
<!--- Add direct link(s) to the exact page(s) that contain the updated content from the preview build. --->

**Reviews:**
- [ ] SME: @ mention assignee
- [ ] QE: @ mention assignee
- [ ] Docs review: @ mention assignee
<!--- SME approval is required to merge a PR unless the changes are made by a subject matter expert. --->
<!--- QE approval is required to merge a PR unless there are no technical changes to the content. --->
<!--- Docs team approval is required for ALL PRs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, request reviews from all required stakeholders via Slack GitHub, or Jira. --->
