### PR TITLE
RHIDP-3086 - Added script to run ccutil with podman

### DIFF
--- a/build/scripts/build-ccutil.sh
+++ b/build/scripts/build-ccutil.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023-2024 Red Hat, Inc.
+# Copyright (c) 2025 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build/scripts/build-ccutil.sh
+++ b/build/scripts/build-ccutil.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright (c) 2023-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Utility script build html previews with referenced images
+# Requires: asciidoctor - see https://docs.asciidoctor.org/asciidoctor/latest/install/linux-packaging/
+# input: titles/
+# output: titles-generated/ and titles-generated/$BRANCH/
+
+# grep regex for title folders to exclude from processing below
+EXCLUDED_TITLES="rhdh-plugins-reference"
+BRANCH="main"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '-b') BRANCH="$2"; shift 1;;
+  esac
+  shift 1
+done
+
+rm -fr titles-generated/;
+mkdir -p titles-generated/"${BRANCH}";
+echo "<html><head><title>Red Hat Developer Hub Documentation Preview - ${BRANCH}</title></head><body><ul>" > titles-generated/"${BRANCH}"/index.html;
+# exclude the rhdh-plugins-reference as it's embedded in the admin guide
+# shellcheck disable=SC2044,SC2013
+set -e
+for t in $(find titles -name master.adoc | sort -uV | grep -E -v "${EXCLUDED_TITLES}"); do
+    d=${t%/*};
+    dest=${d/titles/titles-generated\/${BRANCH}};
+    rm -rf "$d/build" || true
+    CMD="podman run --interactive --rm --tty \
+          --volume "$(pwd)":/docs:Z \
+          --workdir "/docs/$d" \
+          quay.io/ivanhorvath/ccutil:amazing ccutil compile --format html-single --lang en-US";
+    echo -e -n "\nBuilding $t into $dest ...\n  ";
+    echo "${CMD}" | sed -r -e "s/\  +/ \\\\\n    /g"
+    $CMD
+    rm -rfv "$dest" || true
+    mv -f "$d/build/tmp/en-US/html-single/" "$dest"
+    # shellcheck disable=SC2013
+    for im in $(grep images/ "$d/index.html" | grep -E -v 'mask-image|background|fa-icons|jupumbra' | sed -r -e "s#.+(images/[^\"]+)\".+#\1#"); do
+        # echo "  Copy $im ...";
+        IMDIR="$d/${im%/*}/"
+        mkdir -p "${IMDIR}"; rsync -q "$im" "${IMDIR}";
+    done
+    # shellcheck disable=SC2044
+    for f in $(find "$d/" -type f); do echo "    $f"; done
+    echo "<li><a href=${d/titles-generated\/${BRANCH}/.}>${d/titles-generated\/${BRANCH}\//}</a></li>" >> titles-generated/"${BRANCH}"/index.html;
+done
+echo "</ul></body></html>" >> titles-generated/"${BRANCH}"/index.html
+
+# shellcheck disable=SC2143
+if [[ $BRANCH == "pr-"* ]]; then
+  # fetch the existing https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/index.html to add prs and branches
+  curl -sSL https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pulls.html -o titles-generated/pulls.html
+  if [[ -z $(grep "./${BRANCH}/index.html" titles-generated/pulls.html) ]]; then
+      echo "Building root index for $BRANCH in titles-generated/pulls.html ...";
+      echo "<li><a href=./${BRANCH}/index.html>${BRANCH}</a></li>" >> titles-generated/pulls.html
+  fi
+else
+  # fetch the existing https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/index.html to add prs and branches
+  curl -sSL https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/index.html -o titles-generated/index.html
+  if [[ -z $(grep "./${BRANCH}/index.html" titles-generated/index.html) ]]; then
+      echo "Building root index for $BRANCH in titles-generated/index.html ...";
+      echo "<li><a href=./${BRANCH}/index.html>${BRANCH}</a></li>" >> titles-generated/index.html
+  fi
+fi

--- a/build/scripts/build-ccutil.sh
+++ b/build/scripts/build-ccutil.sh
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Utility script build html previews with referenced images
-# Requires: asciidoctor - see https://docs.asciidoctor.org/asciidoctor/latest/install/linux-packaging/
+# Requires: Podman - see https://podman.io
 # input: titles/
 # output: titles-generated/ and titles-generated/$BRANCH/
 


### PR DESCRIPTION
Currently, when there is a broken ID in an xref statement, it will not break any build until we do the final build on Pantheon.

Example:

```
Running: ccutil deploy --target stage --lang en-US --doctype book --uuid 84f825c6-b193-470e-8731-62c8d4f39004
Transforming the AsciiDoc content to DocBook XML...
{{[31m[1mUnknown ID or title "proc-install-rhdh-ocp-operator_assembly-install-rhdh-ocp", used as an internal cross reference[0m}}
{{[31m[1mUnknown ID or title "proc-install-operator_admin-rhdh", used as an internal cross reference[0m}}
{{[31m[1mUnknown ID or title "proc-install-rhdh-ocp-helm_assembly-install-rhdh-ocp", used as an internal cross reference[0m}}
{{[31m[1mUnknown ID or title "proc-install-rhdh-ocp-operator_assembly-install-rhdh-ocp", used as an internal cross reference[0m}}
{{[31m[1mUnknown ID or title "proc-install-rhdh-ocp-helm_assembly-install-rhdh-ocp", used as an internal cross reference[0m}}
{{[31m[1mUnknown ID or title "proc-install-rhdh-ocp-helm_assembly-install-rhdh-ocp", used as an internal cross reference[0m}}
{{[31m[1m/var/lib/jenkins/workspace/doc-red_hat_developer_hub-1.2-administration_guide_for_red_hat_developer_hub-en-US (stage)/titles/admin-rhdh/build/en-US/master.xml fails to validate[0m}}
Build step 'Execute shell' marked build as failure
```

I borrowed the existing build script, and replaced asciidoctor by ccutil.

This is not perfect, this only enables to build locally with the ccutil container, but does not enable it (yet) in GitHub pipeline.

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->

**Issue:** https://issues.redhat.com/browse/RHIDP-3086

**Link to docs preview:**
<!--- Add direct link(s) to the exact page(s) that contain the updated content from the preview build. --->

**Reviews:**
- [ ] SME: @ mention assignee
- [ ] QE: @ mention assignee
- [ ] Docs review: @ mention assignee
<!--- SME approval is required to merge a PR unless the changes are made by a subject matter expert. --->
<!--- QE approval is required to merge a PR unless there are no technical changes to the content. --->
<!--- Docs team approval is required for ALL PRs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, request reviews from all required stakeholders via Slack GitHub, or Jira. --->



