### PR TITLE
RHIDP-2810: Document Learning Path configuration

### DIFF
--- a/modules/getting-started/proc-customize-rhdh-homepage.adoc
+++ b/modules/getting-started/proc-customize-rhdh-homepage.adoc
@@ -87,10 +87,7 @@ where `HOMEPAGE_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>:8080]`, fo
 The `red-hat-developer-hub-customization-provider` service contains the 8080 port by default. If you are using a custom port, you can specify it with the 'PORT' environmental variable in the `app-config-rhdh.yaml` file.
 ====
 +
-[NOTE]
-====
-You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or by directly replacing it in your custom ConfigMap.
-====
+. Replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or by directly replacing it in your custom ConfigMap.
 +
 . Delete the {product-short} pod to ensure that the new configurations are loaded correctly.
 
@@ -136,7 +133,7 @@ You can also view the *Service Resources* in the Topology view.
   }
 ]
 ----
-
++
 [NOTE]
 ====
 If the request call fails or is not configured, the {product-short} instance falls back to the default local data.

--- a/modules/getting-started/proc-customize-rhdh-homepage.adoc
+++ b/modules/getting-started/proc-customize-rhdh-homepage.adoc
@@ -1,9 +1,22 @@
 [id='proc-customize-rhdh-homepage_{context}']
 = Customizing the Home page in {product}
 
-To access the Home page in {product}, the base URL must include the `/developer-hub` proxy. You can configure the Home page by passing the data into the `app-config.yaml` file as a proxy. You can provide data to the Home page by using the following sources:
+To access the Home page in {product}, the base URL must include the `/developer-hub` proxy. You can configure the Home page by passing the data into the `app-config.yaml` file as a proxy. You can provide data to the Home page from the following sources:
 
-* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
+* JSON files hosted on GitHub or GitLab.
+* A dedicated service that provides the Home page data in JSON format using an API.
+
+== Using hosted JSON files to provide data to the Learning Paths
+
+.Prerequisites
+
+You have installed {product} by using either the Operator or Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+
+.Procedure
+
+To access the data from the JSON files, complete the following step:
+
+* Add the following code to the `app-config.yaml` file:
 +
 [source,yaml]
 ----
@@ -22,10 +35,13 @@ proxy:
 	<HEADER_KEY>: <HEADER_VALUE> # optional and can be passed as needed i.e Authorization can be passed for private GitHub repo and PRIVATE-TOKEN can be passed for private GitLab repo
 ----
 
-* A separate service that provides the Home page data in JSON format using an API. When using a separate service, you can do the following:
-** Use the same service to provide the data to all configurable {product-short} pages or use a different service for each page.
-** Use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both the Home and Tech Radar pages. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
-** Deploy the `red-hat-developer-hub-customization-provider` service and the {product-short} Helm chart on the same cluster.
+== Using a dedicated service to provide data to the Learning Paths
+
+When using a dedicated service, you can do the following:
+
+* Use the same service to provide the data to all configurable {product-short} pages or use a different service for each page.
+* Use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both the Home and Tech Radar pages. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
+* Deploy the `red-hat-developer-hub-customization-provider` service and the {product-short} Helm chart on the same cluster.
 
 .Prerequisites
 
@@ -39,20 +55,16 @@ To use a separate service to provide the Home page data, complete the following 
 . Enter the URL of your Git repository into the *Git Repo URL* field.
 +
 --
-To use the `red-hat-developer-hub-customization-provider` service, add the URL for the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[red-hat-developer-hub-customization-provider] repository.
+To use the `red-hat-developer-hub-customization-provider` service, add the URL for the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[red-hat-developer-hub-customization-provider] repository or your fork of the repository containing your customizations.
 --
 
-[NOTE]
-====
-The `rhdh-customization-provider` service contains the 8080 port.
-====
-
-. On the *General* tab, rename the value in the *Name* field to *rhdh-customization-provider* and click *Create*.
+. On the *General* tab, enter *red-hat-developer-hub-customization-provider* in the *Name* field and click *Create*.
 . On the *Advanced Options* tab, copy the value from the *Target Port*.
 +
---
+[NOTE]
+====
 The *Target Port* automatically generates a Kubernetes or {ocp-short} service to communicate with.
---
+====
 +
 . Add the following code to the `app-config-rhdh.yaml` file:
 +
@@ -72,7 +84,12 @@ where `HOMEPAGE_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>:8080]`, fo
 +
 [NOTE]
 ====
-You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or directly replacing it in your custom ConfigMap.
+The `red-hat-developer-hub-customization-provider` service contains the 8080 port by default. If you are using a custom port, you can specify it with the 'PORT' environmental variable in the `app-config-rhdh.yaml` file.
+====
++
+[NOTE]
+====
+You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or by directly replacing it in your custom ConfigMap.
 ====
 +
 . Delete the {product-short} pod to ensure that the new configurations are loaded correctly.

--- a/modules/getting-started/proc-customize-rhdh-homepage.adoc
+++ b/modules/getting-started/proc-customize-rhdh-homepage.adoc
@@ -1,11 +1,10 @@
 [id='proc-customize-rhdh-homepage_{context}']
 = Customizing the Home page in {product}
 
-In {product}, the Home page data is configurable, which can be passed into the `app-config.yaml` file as a proxy. You can provide the Home page data using the following ways:
+To access the Home page in {product}, the base URL must include the `/developer-hub` proxy. You can configure the Home page by passing the data into the `app-config.yaml` file as a proxy. You can provide data to the Home page by using the following sources:
 
-* Using JSON files that are hosted or GitHub or GitLab. To access the data from the JSON files, you can add the following code in the `app-config.yaml` file:
+* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
 +
---
 [source,yaml]
 ----
 proxy:
@@ -22,48 +21,72 @@ proxy:
       headers:
 	<HEADER_KEY>: <HEADER_VALUE> # optional and can be passed as needed i.e Authorization can be passed for private GitHub repo and PRIVATE-TOKEN can be passed for private GitLab repo
 ----
---
 
-* Using a separate service that provides the Home page data in JSON format using an API.
-+
---
-[NOTE]
-====
-It is not necessary that the same service provides the Home page and Tech Radar data.
-====
-
-You can use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both Home page and Tech Radar. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
---
-
-This section describes how you can deploy the `red-hat-developer-hub-customization-provider` service onto the cluster where the {product-short} Helm Chart is deployed.
+* A separate service that provides the Home page data in JSON format using an API. When using a separate service, you can do the following:
+** Use the same service to provide the data to all configurable {product-short} pages or use a different service for each page.
+** Use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both the Home and Tech Radar pages. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
+** Deploy the `red-hat-developer-hub-customization-provider` service and the {product-short} Helm chart on the same cluster.
 
 .Prerequisites
 
-* You have installed the {product} using Helm Chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+* You have installed the {product} using the Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
 
 .Procedure
 
-. In Red Hat OpenShift, select *+Add* and click *Import from Git* option.
-. Add the URL of your Git repository to the *Git Repo URL* field.
+To use a separate service to provide the Home page data, complete the following steps:
+
+. From the *Developer* perspective in the {ocp-brand-name} web console, click *+Add* > *Import from Git*.
+. Enter the URL of your Git repository into the *Git Repo URL* field.
 +
 --
-To use the `red-hat-developer-hub-customization-provider` service, you can add the URL of https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[red-hat-developer-hub-customization-provider] repository.
+To use the `red-hat-developer-hub-customization-provider` service, add the URL for the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[red-hat-developer-hub-customization-provider] repository.
 --
 
-. In the *General* section, rename the value in the *Name* field to *rhdh-customization-provider* and click *Create*.
-. Go to the *Advanced Options* and copy the value from the *Target Port*.
-+
---
-The *Target Port* is used to automatically generate a Kubernetes or OpenShift service to communicate with.
---
+[NOTE]
+====
+The `rhdh-customization-provider` service contains the 8080 port.
+====
 
-. To view the service, navigate to the *OpenShift Administrator* view and go to the *Networking -> Service* section.
+. On the *General* tab, rename the value in the *Name* field to *rhdh-customization-provider* and click *Create*.
+. On the *Advanced Options* tab, copy the value from the *Target Port*.
 +
 --
+The *Target Port* automatically generates a Kubernetes or {ocp-short} service to communicate with.
+--
++
+. Add the following code to the `app-config-rhdh.yaml` file:
++
+[source,yaml]
+----
+proxy:
+  endpoints:
+    # Other Proxies
+    # customize developer hub instance
+    '/developer-hub':
+      target: ${HOMEPAGE_DATA_URL}
+      changeOrigin: true
+      # Change to "false" in case of using self-hosted cluster with a self-signed certificate
+      secure: true
+----
+where `HOMEPAGE_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>:8080]`, for example, `pass:c[http://rhdh-customization-provider:8080]`.
++
+[NOTE]
+====
+You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or directly replacing it in your custom ConfigMap.
+====
++
+. Delete the {product-short} pod to ensure that the new configurations are loaded correctly.
+
+.Verification
+* To view the service, navigate to the *Administrator* perspective in the {ocp-short} web console and click *Networking* > *Service*.
++
+[NOTE]
+====
 You can also view the *Service Resources* in the Topology view.
+====
 
-If you follow this procedure with examples, then `rhdh-customization-provider` service is called and contains the 8080 port. The provided API URL for the Home page must return the data in JSON format as shown in the following example:
-
+* Ensure that the provided API URL for the Home page returns the data in JSON format as shown in the following example:
++
 [source,json]
 ----
 [
@@ -97,40 +120,12 @@ If you follow this procedure with examples, then `rhdh-customization-provider` s
 ]
 ----
 
+[NOTE]
+====
 If the request call fails or is not configured, the {product-short} instance falls back to the default local data.
+====
 
-To access the Home page in {product}, the base URL must include the `/developer-hub` proxy.
---
-
-. Add the following code to the `app-config-rhdh.yaml` file:
-+
---
-[source,yaml]
-----
-proxy:
-  endpoints:
-    # Other Proxies
-    # customize developer hub instance
-    '/developer-hub':
-      target: ${HOMEPAGE_DATA_URL}
-      changeOrigin: true
-      # Change to "false" in case of using self-hosted cluster with a self-signed certificate
-      secure: true
-----
-
-Ensure that the API request call returns the response in JSON format.
---
-
-. Define the `HOMEPAGE_DATA_URL` as `pass:c[http://<SERVICE_NAME>:8080]. For example, `pass:c[http://rhdh-customization-provider:8080]`.
-+
---
-You can replace the `HOMEPAGE_DATA_URL` by adding the URL to `rhdh-secrets` or directly replacing it in your custom ConfigMap.
---
-
-. Delete the {product-short} Pod to pull in the changes.
-+
---
-If the images or icons do not load, then whitelist them by adding your image or icon host URLs to the content security policy’s (csp) `img-src` in your custom ConfigMap as follows:
+* If the images or icons do not load, then allowlist them by adding your image or icon host URLs to the content security policy’s (csp) `img-src` in your custom ConfigMap as follows:
 
 [source]
 ----
@@ -156,8 +151,3 @@ data:
           - <image host url 3>
     # Other Configurations
 ----
-
-After that, delete the pod to ensure that the new configurations are loaded correctly.
---
-
-

--- a/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
+++ b/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
@@ -1,10 +1,31 @@
 [id='proc-customize-rhdh-learning-paths_{context}']
 = Customizing the Learning Paths in {product}
 
+In {product}, you can configure Learning Paths by passing the data into the `app-config.yaml` file as a proxy. The base Tech Radar URL must include the `/developer-hub/learning-paths` proxy.
 
-In {product}, you can configure Learning Paths by passing the data into the `app-config.yaml` file as a proxy. You can provide data to the Learning Path using the following sources:
+[NOTE]
+====
+Due to the use of overlapping `pathRewrites` for both the `learning-path` and `homepage` quick access proxies, you must create the `learning-paths` configuration (`^api/proxy/developer-hub/learning-paths`) before you create the `homepage` configuration (`^/api/proxy/developer-hub`).
 
-* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
+For more information about customizing the Home page in {product}, see xref:proc-customize-rhdh-homepage_rhdh-getting-started[Customizing the Home page in {product}].
+====
+
+You can provide data to the Learning Path from the following sources:
+
+* JSON files hosted on GitHub or GitLab.
+* A dedicated service that provides the Learning Path data in JSON format using an API.
+
+== Using hosted JSON files to provide data to the Learning Paths
+
+.Prerequisites
+
+You have installed {product} by using either the Operator or Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+
+.Procedure
+
+To access the data from the JSON files, complete the following step:
+
+* Add the following code to the `app-config.yaml` file:
 +
 [source,yaml]
 ----
@@ -20,4 +41,39 @@ proxy:
       secure: true
 ----
 
-//* A separate service that provides the Learning Path data in JSON format using an API.
+== Using a dedicated service to provide data to the Learning Paths
+
+.Prerequisites
+
+* You have installed the {product} using Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+
+.Procedure
+
+To use a dedicated service to provide the Learning Path data, complete the following steps:
+
+. Add the following code to the `app-config-rhdh.yaml` file:
++
+[source,yaml]
+----
+   proxy:
+      endpoints:
+        # Other Proxies
+        '/developer-hub/learning-paths':
+          target: ${LEARNING_PATH_DATA_URL}
+          changeOrigin: true
+          # Change to "false" in case of using self hosted cluster with a self-signed certificate
+          secure: true
+----
+where the `LEARNING_PATH_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>/learning-paths]`, for example, `pass:c[http://rhdh-customization-provider/learning-paths]`.
++
+[NOTE]
+====
+You can define the `LEARNING_PATH_DATA_URL` by adding it to `rhdh-secrets` or by directly replacing it with its value in your custom ConfigMap.
+====
++
+[NOTE]
+====
+Ensure that the API request call returns the response in JSON format.
+====
++
+. Delete the {product-short} pod to ensure that the new configurations are loaded correctly.

--- a/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
+++ b/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
@@ -1,0 +1,23 @@
+[id='proc-customize-rhdh-learning-paths_{context}']
+= Customizing the Learning Paths in {product}
+
+
+In {product}, you can configure Learning Paths by passing the data into the `app-config.yaml` file as a proxy. You can provide data to the Learning Path using the following sources:
+
+* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
++
+[source,yaml]
+----
+proxy:
+  endpoints:
+    '/developer-hub':
+      target: https://raw.githubusercontent.com/
+      pathRewrite:
+        '^/api/proxy/developer-hub/learning-paths': '/janus-idp/backstage-showcase/main/packages/app/public/learning-paths/data.json'
+        '^/api/proxy/developer-hub/tech-radar': '/janus-idp/backstage-showcase/main/packages/app/public/tech-radar/data-default.json'
+        '^/api/proxy/developer-hub': '/janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json'
+      changeOrigin: true
+      secure: true
+----
+
+//* A separate service that provides the Learning Path data in JSON format using an API.

--- a/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
+++ b/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
@@ -43,6 +43,12 @@ proxy:
 
 == Using a dedicated service to provide data to the Learning Paths
 
+When using a dedicated service, you can do the following:
+
+* Use the same service to provide the data to all configurable {product-short} pages or use a different service for each page.
+* Use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both the Home and Tech Radar pages. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
+* Deploy the `red-hat-developer-hub-customization-provider` service and the {product-short} Helm chart on the same cluster.
+
 .Prerequisites
 
 * You have installed the {product} using Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].

--- a/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
+++ b/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
@@ -77,9 +77,4 @@ where the `LEARNING_PATH_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>/l
 You can define the `LEARNING_PATH_DATA_URL` by adding it to `rhdh-secrets` or by directly replacing it with its value in your custom ConfigMap.
 ====
 +
-[NOTE]
-====
-Ensure that the API request call returns the response in JSON format.
-====
-+
 . Delete the {product-short} pod to ensure that the new configurations are loaded correctly.

--- a/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -1,21 +1,33 @@
 [id='proc-customize-rhdh-tech-radar-page_{context}']
 = Customizing the Tech Radar page in {product}
 
-In {product}, the Tech Radar page is not enabled using the dynamic plugin feature in the Helm chart.
+In {product}, the Tech Radar page is provided by the `tech-radar` dynamic plugin, which is disabled by default. For information about enabling dynamic plugins in {product} see link:{LinkPluginsGuide}[Configuring plugins in {product}].
 
-Similar to Home page customization, the base Tech Radar URL must include the `/developer-hub/tech-radar` proxy.
+In {product}, you can configure Learning Paths by passing the data into the `app-config.yaml` file as a proxy. The base Tech Radar URL must include the `/developer-hub/tech-radar` proxy.
 
 [NOTE]
 ====
 Due to the use of overlapping `pathRewrites` for both the `tech-radar` and `homepage` quick access proxies, you must create the `tech-radar` configuration (`^api/proxy/developer-hub/tech-radar`) before you create the `homepage` configuration (`^/api/proxy/developer-hub`).
 
-For more information about customizing the Home page in {product}, see xref:proc-customize-rhdh-homepage_rhdh-getting-started[].
+For more information about customizing the Home page in {product}, see xref:proc-customize-rhdh-homepage_rhdh-getting-started[Customizing the Home page in {product}].
 ====
 
+You can provide data to the Tech Radar page from the following sources:
 
-You can provide data to the Tech Radar page by using the following sources:
+* JSON files hosted on GitHub or GitLab.
+* A dedicated service that provides the Tech Radar data in JSON format using an API.
 
-* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
+== Using hosted JSON files to provide data to the Tech Radar page
+
+.Prerequisites
+
+You have installed {product} by using either the Operator or Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+
+.Procedure
+
+To access the data from the JSON files, complete the following step:
+
+* Add the following code to the `app-config.yaml` file:
 +
 [source,yaml]
 ----
@@ -36,11 +48,11 @@ proxy:
 	<HEADER_KEY>: <HEADER_VALUE> # optional and can be passed as needed i.e Authorization can be passed for private GitHub repo and PRIVATE-TOKEN can be passed for private GitLab repo
 ----
 
-* A separate service that provides the Tech Radar data in JSON format using an API.
+== Using a dedicated service to provide data to the Tech Radar page
 
 .Prerequisites
 
-* You have installed the {product} using Helm Chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
+* You have installed the {product} using Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].
 
 .Procedure
 
@@ -63,7 +75,7 @@ where the `TECHRADAR_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>/tech-
 +
 [NOTE]
 ====
-You can define the `TECHRADAR_DATA_URL`  either by adding it to `rhdh-secrets` or directly replacing it with its value in your custom ConfigMap.
+You can define the `TECHRADAR_DATA_URL` by adding it to `rhdh-secrets` or by directly replacing it with its value in your custom ConfigMap.
 ====
 +
 [NOTE]

--- a/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -1,13 +1,22 @@
 [id='proc-customize-rhdh-tech-radar-page_{context}']
-= Customizing the Tech Radar page in the {product}
+= Customizing the Tech Radar page in {product}
 
-In {product}, the Tech Radar page is not enabled using the dynamic plugin feature in the Helm Chart.
+In {product}, the Tech Radar page is not enabled using the dynamic plugin feature in the Helm chart.
 
-Similar to Home page customization, the base Tech Radar URL must include the `/developer-hub/tech-radar` proxy. You can provide the Tech Radar page data using the following ways:
+Similar to Home page customization, the base Tech Radar URL must include the `/developer-hub/tech-radar` proxy.
 
-* Using JSON files that are hosted or GitHub or GitLab. To access the data from the JSON files, you can add the following code in the `app-config.yaml` file:
+[NOTE]
+====
+Due to the use of overlapping `pathRewrites` for both the `tech-radar` and `homepage` quick access proxies, you must create the `tech-radar` configuration (`^api/proxy/developer-hub/tech-radar`) before you create the `homepage` configuration (`^/api/proxy/developer-hub`).
+
+For more information about customizing the Home page in {product}, see xref:proc-customize-rhdh-homepage_rhdh-getting-started[].
+====
+
+
+You can provide data to the Tech Radar page by using the following sources:
+
+* JSON files hosted on GitHub or GitLab. To access the data from the JSON files, add the following code to the `app-config.yaml` file:
 +
---
 [source,yaml]
 ----
 proxy:
@@ -27,15 +36,7 @@ proxy:
 	<HEADER_KEY>: <HEADER_VALUE> # optional and can be passed as needed i.e Authorization can be passed for private GitHub repo and PRIVATE-TOKEN can be passed for private GitLab repo
 ----
 
-[NOTE]
-====
-As overlapping exist between the `pathRewrites` that are used for the `tech-radar` and `homepage` quick access proxies, the configuration for the `tech-radar` (`^api/proxy/developer-hub/tech-radar`) must exist before the configuration for the `homepage` (`^/api/proxy/developer-hub`).
-
-For more information about customizing the Home page in {product}, see xref:proc-customize-rhdh-homepage_rhdh-getting-started[].
-====
---
-
-* Using a separate service that provides the Tech Radar data in JSON format using an API.
+* A separate service that provides the Tech Radar data in JSON format using an API.
 
 .Prerequisites
 
@@ -43,9 +44,10 @@ For more information about customizing the Home page in {product}, see xref:proc
 
 .Procedure
 
+To use a separate service to provide the Tech Radar data, complete the following steps:
+
 . Add the following code to the `app-config-rhdh.yaml` file:
 +
---
 [source,yaml]
 ----
 proxy:
@@ -57,17 +59,16 @@ proxy:
       # Change to "false" in case of using self hosted cluster with a self-signed certificate
       secure: true
 ----
-
-Ensure that the API request call returns the response in JSON format.
---
-
-. Define the `TECHRADAR_DATA_URL`` as `pass:c[http://<SERVICE_NAME>/tech-radar]`, for example `pass:c[http://rhdh-customization-provider/tech-radar]`.
+where the `TECHRADAR_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>/tech-radar]`, for example, `pass:c[http://rhdh-customization-provider/tech-radar]`.
 +
---
 [NOTE]
 ====
 You can define the `TECHRADAR_DATA_URL`  either by adding it to `rhdh-secrets` or directly replacing it with its value in your custom ConfigMap.
 ====
---
-
-. Delete the {product-short} Pod to pull in the changes.
++
+[NOTE]
+====
+Ensure that the API request call returns the response in JSON format.
+====
++
+. Delete the {product-short} pod to ensure that the new configurations are loaded correctly.

--- a/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -84,9 +84,4 @@ where the `TECHRADAR_DATA_URL` is defined as `pass:c[http://<SERVICE_NAME>/tech-
 You can define the `TECHRADAR_DATA_URL` by adding it to `rhdh-secrets` or by directly replacing it with its value in your custom ConfigMap.
 ====
 +
-[NOTE]
-====
-Ensure that the API request call returns the response in JSON format.
-====
-+
 . Delete the {product-short} pod to ensure that the new configurations are loaded correctly.

--- a/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -50,6 +50,12 @@ proxy:
 
 == Using a dedicated service to provide data to the Tech Radar page
 
+When using a dedicated service, you can do the following:
+
+* Use the same service to provide the data to all configurable {product-short} pages or use a different service for each page.
+* Use the https://github.com/redhat-developer/red-hat-developer-hub-customization-provider[`red-hat-developer-hub-customization-provider`] as an example service, which provides data for both the Home and Tech Radar pages. The `red-hat-developer-hub-customization-provider` service provides the same data as default {product-short} data. You can fork the `red-hat-developer-hub-customization-provider` service repository from GitHub and modify it with your own data, if required.
+* Deploy the `red-hat-developer-hub-customization-provider` service and the {product-short} Helm chart on the same cluster.
+
 .Prerequisites
 
 * You have installed the {product} using Helm chart. For more information, see xref:proc-install-rhdh_rhdh-getting-started[].

--- a/titles/getting-started-rhdh/title-getting-started.adoc
+++ b/titles/getting-started-rhdh/title-getting-started.adoc
@@ -26,6 +26,7 @@ include::modules/getting-started/proc-add-source-control-rhdh-catalog.adoc[level
 
 include::modules/getting-started/proc-customize-rhdh-homepage.adoc[leveloffset=+1]
 include::modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc[leveloffset=+1]
+include::modules/getting-started/proc-customize-rhdh-learning-paths.adoc[leveloffset=+1]
 include::modules/getting-started/ref-additional-rhdh-customizations.adoc[leveloffset=+1]
 
 include::modules/proc-customizing-the-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**Version(s):**
1.2.2

**Issue:**
https://issues.redhat.com/browse/RHIDP-2810 (Create Learning Path config content)
https://issues.redhat.com/browse/RHIDP-3141 (Revise Home page and Tech Radar page config content)

**Link to docs preview:**
[Updated] Home page config: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-368/getting-started-rhdh/#proc-customize-rhdh-homepage_rhdh-getting-started
[Updated] Tech Radar config: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-368/getting-started-rhdh/#proc-customize-rhdh-tech-radar-page_rhdh-getting-started
[New - WIP] Learning Path config: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-368/getting-started-rhdh/#proc-customize-rhdh-learning-paths_rhdh-getting-started

**Reviews:**
- [x] SME: @invincibleJai @Zaperex 
- [x] QE: @josephca
- [x] Docs: @Gerry-Forde 
