### PR TITLE
RHIDP-3160: Update links in Helm CLI doc

### DIFF
--- a/modules/installation/proc-installing-rhdh-on-openshift-with-helm-cli.adoc
+++ b/modules/installation/proc-installing-rhdh-on-openshift-with-helm-cli.adoc
@@ -5,10 +5,10 @@ You can use the Helm CLI to install {product} on {ocp-brand-name}.
 
 .Prerequisites
 * You have installed the {openshift-cli} on your workstation.
-* You are logged in to your OpenShift Container Platform account.
-* A user with the OpenShift Container Platform admin role has configured the appropriate roles and permissions within your project to create an application. For more information about OpenShift Container Platform roles, see [Using RBAC to define and apply permissions](https://docs.openshift.com/container-platform/4.15/authentication/using-rbac.html).
-* You have created a project in OpenShift Container Platform. For more information about creating a project in OpenShift Container Platform, see [Red Hat OpenShift Container Platform documentation](https://docs.openshift.com/container-platform/4.15/applications/projects/working-with-projects.html#odc-creating-projects-using-developer-perspective_projects).
-* You have installed the link:https://helm.sh/docs/intro/install[Helm CLI].
+* You are logged in to your {ocp-short} account.
+* A user with the {ocp-short} admin role has configured the appropriate roles and permissions within your project to create an application. For more information about {ocp-short} roles, see link:https://docs.openshift.com/container-platform/4.15/authentication/using-rbac.html[Using RBAC to define and apply permissions].
+* You have created a project in {ocp-short}. For more information about creating a project in {ocp-short}, see link:https://docs.openshift.com/container-platform/4.15/applications/projects/working-with-projects.html#odc-creating-projects-using-developer-perspective_projects[{ocp-brand-name} documentation].
+* You have installed the Helm CLI tool.
 
 .Procedure
 . Create and activate the _<rhdh>_ {ocp-short} project:
@@ -46,3 +46,5 @@ echo "https://redhat-developer-hub-$NAMESPACE.$CLUSTER_ROUTER_BASE"
 .Verification
 * Open the running {product-short} instance URL in your browser to use {product-short}.
 
+.Additional resources
+* For more information, see link:https://docs.openshift.com/container-platform/4.16/applications/working_with_helm_charts/installing-helm.html[Installing Helm] in the {ocp-short} documentation.


### PR DESCRIPTION
**Version(s):**
1.2 

**Issue:**
https://issues.redhat.com/browse/RHIDP-3160

**Link to docs preview:**
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-369/admin-rhdh/#proc-installing-rhdh-on-openshift-with-helm-cli_assembly-installing-rhdh-on-ocp-by-using-the-helm-chart

**Reviews:**
- [ ] SME: @nickboldt (optional)
- [ ] QE: N/A
- [x] Docs: @Preeticp 