### PR TITLE
RHIDP-3017: Updated the installation note for clarity

### DIFF
--- a/modules/installation/proc-install-operator.adoc
+++ b/modules/installation/proc-install-operator.adoc
@@ -20,11 +20,16 @@ Containers are available for the following CPU architectures:
 .Prerequisites
 
 * You are logged in as an administrator on the {ocp-short} web console.
-* You have configured the appropriate roles and permissions within your project to create an application. For more information, see the link:https://docs.openshift.com/container-platform/{ocp-version}/applications/index.html[Red Hat OpenShift documentation on Building applications].
+* You have configured the appropriate roles and permissions within your project to create or access an application. For more information, see the link:https://docs.openshift.com/container-platform/{ocp-version}/applications/index.html[Red Hat OpenShift documentation on Building applications].
 
-[NOTE]
+[IMPORTANT]
 ====
-For enhanced security, deploy the {product} Operator in a dedicated default namespace such as `rhdh-operator`. The cluster administrator can restrict other users' access to the Operator resources through role bindings or cluster role bindings.
+For enhanced security, better control over the Operator lifecycle, and preventing potential privilege escalation, install the {product} Operator in a dedicated default `rhdh-operator` namespace. You can restrict other users' access to the Operator resources through role bindings or cluster role bindings.
+
+You can also install the Operator in another namespace by creating the necessary resources, such as an Operator group. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-globa[Installing global Operators in custom namespaces].
+
+However, if the {product} Operator shares a namespace with other Operators, then it shares the same update policy as well, preventing the customization of the update policy. For example, if one Operator is set to manual updates, the {product} Operator update policy is also set to manual. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-colocation.html[Colocation of Operators in a namespace].
+
 ====
 
 .Procedure

--- a/modules/installation/proc-install-operator.adoc
+++ b/modules/installation/proc-install-operator.adoc
@@ -26,9 +26,9 @@ Containers are available for the following CPU architectures:
 ====
 For enhanced security, better control over the Operator lifecycle, and preventing potential privilege escalation, install the {product} Operator in a dedicated default `rhdh-operator` namespace. You can restrict other users' access to the Operator resources through role bindings or cluster role bindings.
 
-You can also install the Operator in another namespace by creating the necessary resources, such as an Operator group. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-globa[Installing global Operators in custom namespaces].
+You can also install the Operator in another namespace by creating the necessary resources, such as an Operator group. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-global-namespaces_olm-adding-operators-to-a-cluster[Installing global Operators in custom namespaces].
 
-However, if the {product} Operator shares a namespace with other Operators, then it shares the same update policy as well, preventing the customization of the update policy. For example, if one Operator is set to manual updates, the {product} Operator update policy is also set to manual. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-colocation.html[Colocation of Operators in a namespace].
+However, if the {product} Operator shares a namespace with other Operators, then it shares the same update policy as well, preventing the customization of the update policy. For example, if one Operator is set to manual updates, the {product} Operator update policy is also set to manual. For more information, see link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm/olm-colocation.html#olm-colocation-namespaces_olm-colocation[Colocation of Operators in a namespace].
 
 ====
 


### PR DESCRIPTION
**Version(s):**
1.2, 1.1

**Issue:**
https://issues.redhat.com/browse/RHIDP-3017

**Link to docs preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-376/admin-rhdh/#assembly-installing-rhdh-on-ocp-by-using-the-operator

**Reviews:**
- [x] SME: @rm3l 
- [x] QE: @josephca 
- [x] Docs review: @Gerry-Forde 
