### PR TITLE
RHIDP-3440 Update product version to fix broken Pantheon builds

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -10,9 +10,9 @@
 :product: Red Hat Developer Hub
 :product-short: Developer Hub
 :product-very-short: RHDH
-:product-version: 1.4
-:product-bundle-version: 1.4.0
-:product-chart-version: 1.4.0
+:product-version: 1.3
+:product-bundle-version: 1.3.0
+:product-chart-version: 1.3.0
 :product-backstage-version: 1.27.7
 :rhdeveloper-name: Red Hat Developer
 :rhel: Red Hat Enterprise Linux


### PR DESCRIPTION
We are using `main` to preview 1.3 docs in Pantheon, so we need to update the product versions to match the Pantheon build version.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**Version(s):**
1.3

**Issue:**
<!--- Add a link to the Bugzilla, Jira, or GitHub issue. --->

**Link to docs preview:**
<!--- Add direct link(s) to the exact page(s) that contain the updated content from the preview build. --->

**Reviews:**
- [ ] Docs review: @ mention assignee
<!--- SME approval is required to merge a PR unless the changes are made by a subject matter expert. --->
<!--- QE approval is required to merge a PR unless there are no technical changes to the content. --->
<!--- Docs team approval is required for ALL PRs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, request reviews from all required stakeholders via Slack GitHub, or Jira. --->
