### PR TITLE
Revert "chore: tagRelease.sh: bump to 1.4.0 in main branch"

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -10,9 +10,9 @@
 :product: Red Hat Developer Hub
 :product-short: Developer Hub
 :product-very-short: RHDH
-:product-version: 1.4
-:product-bundle-version: 1.4.0
-:product-chart-version: 1.4.0
+:product-version: 1.3
+:product-bundle-version: 1.3.0
+:product-chart-version: 1.3.0
 :product-backstage-version: 1.27.7
 :rhdeveloper-name: Red Hat Developer
 :rhel: Red Hat Enterprise Linux


### PR DESCRIPTION
Reverts redhat-developer/red-hat-developers-documentation-rhdh#457

It is too soon. 1.3 has not been released yet. It breaks the preview build in Pantheon.