### PR TITLE
chore(pr comments): reuse pr comments so we...

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,14 +90,15 @@ jobs:
           keep_files: true
           publish_dir: ./titles-generated
 
-      - name: PR comment with doc preview
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.RHDH_BOT_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'PR Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${{ github.event.number }}/' 
-            });
+      - name: PR comment with doc preview, replacing existing comments with a new one each time
+        shell: bash
+        run: |
+          PR_NUM="${{ github.event.number }}"
+          # for a given PR, check for an existing comments from the bot; select the last one if more than one
+          if [[ $(gh api repos/{owner}/{repo}/issues/${PR_NUM}/comments | jq '.[]|select(.user.login=="rhdh-bot")|.id' | tail -1) ]]; then 
+            # edit that comment:
+            gh pr comment ${PR_NUM} --edit-last --body "Updated preview PR: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/ @ $(date "+%x %X")"
+          else
+            # or create a new one:
+            gh pr comment ${PR_NUM} --body "Preview PR: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/"
+          fi


### PR DESCRIPTION
### What does this PR do?

chore(pr comments): reuse pr comments so we don't have dozens of identical links

Signed-off-by: rhdh-bot service account <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.