### PR TITLE
chore(branch): create release-1.3 branch from 1.3.x; refactor actions (RHIDP-4031)

### DIFF
--- a/.github/workflows/build-asciidoc.yml
+++ b/.github/workflows/build-asciidoc.yml
@@ -21,6 +21,7 @@ on:
     - main
     - rhdh-1.**
     - 1.**.x
+    - release-1.[0-9]+
 
 jobs:
   adoc_build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,7 @@ on:
     - main
     - rhdh-1.**
     - 1.**.x
+    - release-1.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.ref }}


### PR DESCRIPTION
### What does this PR do?

chore(branch): create release-1.3 branch from 1.3.x; refactor actions (RHIDP-4031)

---

Adds support for building from the new `release-1.3` branch as the 1.3.x branch is now readonly.

The purpose of this change is to support doing plugin releases from a stable branch with `multi-semantic-release` (as we do in main branch), and to keep all the repos consistent, that means refactoring them to all use `release-1.y` instead of `1.y.x` for stable branches.

See discussions in slack about this issue and please merge ASAP. 

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/RHIDP-4031

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.