### PR TITLE
chore: fix pr commenter using set-default;...

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,12 +97,13 @@ jobs:
           GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
         run: |
           PR_NUM="${{ github.event.number }}"
-          gh repo set-default ${{ github.repository_owner }}/${{ github.event.repository.name }}
+          ORG_REPO="${{ github.repository_owner }}/${{ github.event.repository.name }}""
+          gh repo set-default "${ORG_REPO}"
           # for a given PR, check for existing comments from rhdh-bot; select the last one (if more than one)
-          if [[ $(gh api repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${PR_NUM}/comments -q 'map(select(.user.login=="rhdh-bot"))|last|.id') ]]; then 
+          if [[ $(gh api "repos/${ORG_REPO}/issues/${PR_NUM}/comments" -q 'map(select(.user.login=="rhdh-bot"))|last|.id') ]]; then 
             # edit that comment:
-            gh pr comment ${PR_NUM} --edit-last --body "Updated preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/ @ $(date "+%x %X")"
+            gh pr comment ${PR_NUM} -R "${ORG_REPO}" --edit-last --body "Updated preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/ @ $(date "+%x %X")"
           else
             # or create a new one:
-            gh pr comment ${PR_NUM} --body "Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/"
+            gh pr comment ${PR_NUM} -R "${ORG_REPO}" --body "Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/"
           fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,8 +97,9 @@ jobs:
           GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
         run: |
           PR_NUM="${{ github.event.number }}"
+          gh repo set-default ${{ github.repository_owner }}/${{ github.event.repository.name }}
           # for a given PR, check for existing comments from rhdh-bot; select the last one (if more than one)
-          if [[ $(gh api repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${PR_NUM}/comments | jq '.[]|select(.user.login=="rhdh-bot")|.id' | tail -1) ]]; then 
+          if [[ $(gh api repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${PR_NUM}/comments -q 'map(select(.user.login=="rhdh-bot"))|last|.id') ]]; then 
             # edit that comment:
             gh pr comment ${PR_NUM} --edit-last --body "Updated preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/ @ $(date "+%x %X")"
           else


### PR DESCRIPTION
### What does this PR do?

chore: fix pr commenter using set-default; also switch to @cdaley's faster query

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.