### PR TITLE
chore: tagRelease.sh: bump to 1.2.4 in 1.2.x branch

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -11,8 +11,8 @@
 :product-short: Developer Hub
 :product-very-short: RHDH
 :product-version: 1.2
-:product-bundle-version: 1.2.3
-:product-chart-version: 1.2.3
+:product-bundle-version: 1.2.4
+:product-chart-version: 1.2.4
 :product-backstage-version: 1.26.5
 :rhdeveloper-name: Red Hat Developer
 :rhel: Red Hat Enterprise Linux


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>

With the release of 1.2.4, the docs need a quick update:

https://issues.redhat.com/browse/RHIDP-4124?jql=project%20%3D%20RHIDP%20and%20fixversion%20%3D%201.2.4
