### PR TITLE
chore: exclude techdocs from the .csv (RHIDP-4196)

### DIFF
--- a/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
@@ -17,10 +17,8 @@ global:
       - package: '@janus-idp/plugin-notifications-backend-dynamic@1.3.6'
         # Integrity can be found at https://registry.npmjs.org/@janus-idp/plugin-notifications-backend-dynamic
         integrity: 'sha512-Qd8pniy1yRx+x7LnwjzQ6k9zP+C1yex24MaCcx7dGDPT/XbTokwoSZr4baSSn8jUA6P45NUUevu1d629mG4JGQ=='
-      - package: '@janus-idp/plugin-notifications@1.1.12
-'
+      - package: '@janus-idp/plugin-notifications@1.1.12'
         # https://registry.npmjs.org/@janus-idp/plugin-notifications
-
         integrity: 'sha512-GCdEuHRQek3ay428C8C4wWgxjNpNwCXgIdFbUUFGCLLkBFSaOEw+XaBvWaBGtQ5BLgE3jQEUxa+422uzSYC5oQ=='
         pluginConfig:
           dynamicPlugins:

--- a/modules/dynamic-plugins/rhdh-supported-plugins.csv
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.csv
@@ -12,8 +12,6 @@
 "Quay ","@janus-idp/backstage-scaffolder-backend-module-quay","Backend","1.7.1","Production","./dynamic-plugins/dist/janus-idp-backstage-scaffolder-backend-module-quay-dynamic",";","Enabled"
 "RBAC ","@janus-idp/backstage-plugin-rbac","Frontend","1.29.5","Production","./dynamic-plugins/dist/janus-idp-backstage-plugin-rbac",";","Disabled"
 "Regex ","@janus-idp/backstage-scaffolder-backend-module-regex","Backend","1.7.1","Production","./dynamic-plugins/dist/janus-idp-backstage-scaffolder-backend-module-regex-dynamic",";","Enabled"
-"TechDocs ","@backstage/plugin-techdocs","Frontend","1.10.7","Production","./dynamic-plugins/dist/backstage-plugin-techdocs",";","Enabled"
-"TechDocs ","@backstage/plugin-techdocs-backend","Backend","1.10.9","Production","./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic",";","Enabled"
 "Tekton ","@janus-idp/backstage-plugin-tekton","Frontend","3.12.7","Production","./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton",";","Disabled"
 "Topology ","@janus-idp/backstage-plugin-topology","Frontend","1.27.5","Production","./dynamic-plugins/dist/janus-idp-backstage-plugin-topology",";","Disabled"
 "AAP ","@janus-idp/backstage-plugin-aap-backend","Backend","1.9.3","Red Hat Tech Preview","./dynamic-plugins/dist/janus-idp-backstage-plugin-aap-backend-dynamic","`AAP_BASE_URL`;`AAP_AUTH_TOKEN`;","Disabled"

--- a/modules/dynamic-plugins/rhdh-supported-plugins.sh
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.sh
@@ -269,7 +269,12 @@ num_plugins=()
 # append to .csv and .adocN files
 rm -f "${0/.sh/.adoc1}"
 sorted=(); while IFS= read -rd '' key; do sorted+=( "$key" ); done < <(printf '%s\0' "${!adoc1[@]}" | sort -z)
-for key in "${sorted[@]}"; do echo -e "${adoc1[$key]}" >> "${0/.sh/.ref-rh-supported-plugins}"; echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"; done
+for key in "${sorted[@]}"; do 
+    echo -e "${adoc1[$key]}" >> "${0/.sh/.ref-rh-supported-plugins}"
+    if [[ $key != *"techdocs"* ]]; then
+        echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"
+    fi
+done
 num_plugins+=(${#adoc1[@]})
 
 rm -f "${0/.sh/.adoc2}"


### PR DESCRIPTION
### What does this PR do?

chore: exclude techdocs from the .csv (RHIDP-4196); also fix a typo in modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-4196

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.