### PR TITLE
chore(typo): remove duplicate backtick and fix CSS rendering on MacOS Safari

### DIFF
--- a/.asciidoctor/docs.css
+++ b/.asciidoctor/docs.css
@@ -220,7 +220,7 @@ table {
   border:0;
   font-size:1rem;
   line-height:1.6667;
-  /* table-layout:fixed */
+  /* commented out as it breaks on Safari on Mac // table-layout:fixed */
 }
 table caption {
   color:#585858;

--- a/.asciidoctor/docs.css
+++ b/.asciidoctor/docs.css
@@ -220,7 +220,7 @@ table {
   border:0;
   font-size:1rem;
   line-height:1.6667;
-  table-layout:fixed
+  /* table-layout:fixed */
 }
 table caption {
   color:#585858;

--- a/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.adoc
@@ -35,4 +35,4 @@ global:
 ----
 
 [NOTE]
-The default configuration for a plugin is extracted from the `dynamic-plugins.default.yaml`` file, however, you can use a `pluginConfig` entry to override the default configuration.
+The default configuration for a plugin is extracted from the `dynamic-plugins.default.yaml` file, however, you can use a `pluginConfig` entry to override the default configuration.

--- a/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.template.adoc
+++ b/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.template.adoc
@@ -31,4 +31,4 @@ global:
 ----
 
 [NOTE]
-The default configuration for a plugin is extracted from the `dynamic-plugins.default.yaml`` file, however, you can use a `pluginConfig` entry to override the default configuration.
+The default configuration for a plugin is extracted from the `dynamic-plugins.default.yaml` file, however, you can use a `pluginConfig` entry to override the default configuration.


### PR DESCRIPTION
### What does this PR do?

chore(typo): remove duplicate backtick and fix CSS rendering on MacOS Safari

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

* remove duplicate backtick 
* fix CSS rendering on MacOS Safari

Note that the asciidoctor CSS is not used by Pantheon -- this is only for the HTML previews on https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.