### PR TITLE
chore: allow comments and empty lines in the list*.txt files; tweak formatting so there's a space after the section title; support the option to generate new adoc files for a future or past version (not the same as the :product-bundle-version: value)

### DIFF
--- a/modules/release-notes/single-source-fixed-security-issues.sh
+++ b/modules/release-notes/single-source-fixed-security-issues.sh
@@ -14,7 +14,8 @@
 set -e
 
 # get the z-stream version from the bundle-version attribute. Note that while chart-version could be larger, this is the correct value for CVE tracking
-product_version="$(grep ':product-bundle-version:' artifacts/attributes.adoc | cut -d' ' -f2 )"
+# if a different version is passed in than the value in 'product-bundle-version', generate content for that version instead
+if [[ $1 ]]; then product_version="$1"; else product_version="$(grep ':product-bundle-version:' artifacts/attributes.adoc | cut -d' ' -f2 )"; fi
 
 single_source_from_security_data () {
   sectionname="fixed-security-issues-in-${section}-${product_version}"
@@ -27,27 +28,20 @@ single_source_from_security_data () {
     echo "ERROR: The ${list} file is missing. You must create it to proceed. For a given version, can collect the list of CVEs from a JIRA query like https://issues.redhat.com/issues/?jql=labels%3DSecurityTracking+and+project%3DRHIDP+and+fixversion%3D1.3.1 or list of Erratas from https://errata.devel.redhat.com/advisory/filters/4213"
     exit 1
   fi
-  # Cleanup the destination files.
-  rm -f "$destination"
-  # Send output to the destination file.
-  exec 3>&1 1>> "$destination"
-  echo "= ${title}"
-  for cve in $(cat ${list} | sort | uniq)
-  do
-  # Start the list.
-  echo "link:https://access.redhat.com/security/cve/$cve[$cve]::"
-  # Call the API to return a list of details.
-  # Red Hat is last if there is one.
-  # Red Hat details is single line.
-  # MITRE details are multiline.
-  # We keep Red Hat details if present.
-  # We keep only the first two lines on MITRE details.
-  curl -s "https://access.redhat.com/hydra/rest/securitydata/cve/$cve.json" | jq -r '.details[-1]' | head -n 2
-  # Add a separation
-  echo ""
-  done
-  # Stop sending output to the destination file
-  exec 1>&3 3>&-
+  echo -e "= ${title}" > "$destination"
+  while IFS="" read -r cve || [ -n "$cve" ]; do
+    if [[ ${cve} != "#"* ]] && [[ $cve != "" ]]; then # skip commented and blank lines
+      # Start the list.
+      echo -e "\nlink:https://access.redhat.com/security/cve/$cve[$cve]::" >> "$destination"
+      # Call the API to return a list of details.
+      # Red Hat is last if there is one.
+      # Red Hat details is single line.
+      # MITRE details are multiline.
+      # We keep Red Hat details if present.
+      # We keep only the first two lines on MITRE details.
+      curl -s "https://access.redhat.com/hydra/rest/securitydata/cve/$cve.json" | jq -r '.details[-1]' | head -n 2 >> "$destination"
+  fi
+  done < "$list"
   echo "include::${destination}[leveloffset=+2]"
 }
 

--- a/modules/release-notes/snip-fixed-security-issues-in-product-1.3.0.adoc
+++ b/modules/release-notes/snip-fixed-security-issues-in-product-1.3.0.adoc
@@ -1,4 +1,5 @@
 = {product} dependency updates
+
 link:https://access.redhat.com/security/cve/CVE-2024-24790[CVE-2024-24790]::
 A flaw was found in the Go language standard library net/netip. The method Is*() (IsPrivate(), IsPublic(), etc) doesn't behave properly when working with IPv6 mapped to IPv4 addresses. The unexpected behavior can lead to integrity and confidentiality issues, specifically when these methods are used to control access to resources or data.
 
@@ -16,4 +17,3 @@ A flaw was found in the fast-loops Node.js package. This flaw allows an attacker
 
 link:https://access.redhat.com/security/cve/CVE-2024-39249[CVE-2024-39249]::
 A flaw was found in the async Node.js package. A Regular expression Denial of Service (ReDoS) attack can potentially be triggered via the autoinject function while parsing specially crafted input.
-

--- a/modules/release-notes/snip-fixed-security-issues-in-rpm-1.3.0.adoc
+++ b/modules/release-notes/snip-fixed-security-issues-in-rpm-1.3.0.adoc
@@ -1,10 +1,14 @@
 = RHEL 9 platform RPM updates
+
 link:https://access.redhat.com/security/cve/CVE-2023-52439[CVE-2023-52439]::
 A flaw was found in the Linux kernel’s uio subsystem. A use-after-free memory flaw in the uio_open functionality allows a local user to crash or escalate their privileges on the system.
 
 link:https://access.redhat.com/security/cve/CVE-2023-52884[CVE-2023-52884]::
 In the Linux kernel, the following vulnerability has been resolved:
 Input: cyapa - add missing input core locking to suspend/resume functions
+
+link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]::
+A flaw was found in OpenSSL. Applications performing certificate name checks (e.g., TLS clients checking server certificates) may attempt to read an invalid memory address resulting in abnormal termination of the application process.
 
 link:https://access.redhat.com/security/cve/CVE-2024-26739[CVE-2024-26739]::
 A use-after-free flaw was found in net/sched/act_mirred.c in the Linux kernel. This may result in a crash.
@@ -86,7 +90,3 @@ An issue was found in libexpat’s internal dtdCopy function in xmlparse.c, It c
 
 link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]::
 A flaw was found in libexpat's internal nextScaffoldPart function in xmlparse.c. It can have an integer overflow for m_groupSize on 32-bit platforms where UINT_MAX equals SIZE_MAX.
-
-link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]::
-A flaw was found in OpenSSL. Applications performing certificate name checks (e.g., TLS clients checking server certificates) may attempt to read an invalid memory address resulting in abnormal termination of the application process.
-


### PR DESCRIPTION
### What does this PR do?

chore: allow comments and empty lines in the list*.txt files; tweak formatting so there's a space after the section title; support the option to generate new adoc files for a future or past version (not the same as the :product-bundle-version: value)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.