### PR TITLE
RHIDP-1925 Fix GitHub integration procedure

### DIFF
--- a/assemblies/assembly-authenticating-with-github.adoc
+++ b/assemblies/assembly-authenticating-with-github.adoc
@@ -1,5 +1,5 @@
-[id="assembly-auth-provider-github"]
-= Enabling the GitHub authentication provider
+[id="authenticating-with-github"]
+= Authenticating with GitHub
 
 To authenticate users with GitHub or GitHub Enterprise:
 

--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -161,7 +161,10 @@ auth:
 
 [TIP]
 ====
-To enable GitHub integration with another authentication provider you have already configured, omit the `auth` and `signInPage` sections from this procedure:
+To enable GitHub integration with another authentication provider you have already configured:
+
+* Add the GitHub provider to the existing `auth` section.
+* Keep the `signInPage` section from your authentication provider.
 
 .`app-config-rhdh.yaml` fragment with mandatory fields to enable integration with GitHub and use a different authentication provider
 [source,yaml]

--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -161,12 +161,12 @@ auth:
 
 [TIP]
 ====
-To enable GitHub integration with another authentication provider you have already configured:
+To enable GitHub integration with a different authentication provider, complete the following configurations:
 
 * Add the GitHub provider to the existing `auth` section.
-* Keep the `signInPage` section from your authentication provider.
+* Keep the `signInPage` section from your authentication provider configuration.
 
-.`app-config-rhdh.yaml` fragment with mandatory fields to enable integration with GitHub and use a different authentication provider
+.`app-config-rhdh.yaml` fragment with mandatory fields to enable GitHub integration and use a different authentication provider
 [source,yaml,subs="+quotes"]
 ----
 auth:

--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -167,7 +167,7 @@ To enable GitHub integration with another authentication provider you have alrea
 * Keep the `signInPage` section from your authentication provider.
 
 .`app-config-rhdh.yaml` fragment with mandatory fields to enable integration with GitHub and use a different authentication provider
-[source,yaml]
+[source,yaml,subs="+quotes"]
 ----
 auth:
   environment: production

--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -169,6 +169,14 @@ To enable GitHub integration with another authentication provider you have alrea
 .`app-config-rhdh.yaml` fragment with mandatory fields to enable integration with GitHub and use a different authentication provider
 [source,yaml]
 ----
+auth:
+  environment: production
+  providers:
+    github:
+      production:
+        clientId: ${AUTH_GITHUB_CLIENT_ID}
+        clientSecret: ${AUTH_GITHUB_CLIENT_SECRET}
+    __<your_other_authentication_providers_configuration>__
 integrations:
   github:
     - host: ${GITHUB_HOST_DOMAIN}
@@ -180,6 +188,7 @@ integrations:
           webhookSecret: ${GITHUB_WEBHOOK_SECRET}
           privateKey: |
             ${GITHUB_PRIVATE_KEY_FILE}
+signInPage: __<your_main_authentication_provider>__
 ----
 ====
 

--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -159,6 +159,27 @@ auth:
         enterpriseInstanceUrl: ${GITHUB_HOST_DOMAIN}
 ----
 
+[TIP]
+====
+To enable GitHub integration with another authentication provider you have already configured, omit the `auth` and `signInPage` sections from this procedure:
+
+.`app-config-rhdh.yaml` fragment with mandatory fields to enable integration with GitHub and use a different authentication provider
+[source,yaml]
+----
+integrations:
+  github:
+    - host: ${GITHUB_HOST_DOMAIN}
+      apps:
+        - appId: ${AUTH_GITHUB_APP_ID}
+          clientId: ${AUTH_GITHUB_CLIENT_ID}
+          clientSecret: ${GITHUB_CLIENT_SECRET}
+          webhookUrl: ${GITHUB_WEBHOOK_URL}
+          webhookSecret: ${GITHUB_WEBHOOK_SECRET}
+          privateKey: |
+            ${GITHUB_PRIVATE_KEY_FILE}
+----
+====
+
 --
 
 .Verification

--- a/modules/importing-repositories/procedure-enabling-the-bulk-import-from-github-feature.adoc
+++ b/modules/importing-repositories/procedure-enabling-the-bulk-import-from-github-feature.adoc
@@ -3,7 +3,7 @@
 You can enable the Bulk Import feature for users and give them the necessary permissions to access it.
 
 .Prerequisites
-* You have link:{authentication-book-url}#enabling-authentication-with-github[configured GitHub authentication and integration].
+* You have link:{authentication-book-url}#enabling-authentication-with-github[configured GitHub integration].
 
 .Procedure
 

--- a/modules/importing-repositories/procedure-importing-multiple-repositories-from-github.adoc
+++ b/modules/importing-repositories/procedure-importing-multiple-repositories-from-github.adoc
@@ -4,7 +4,6 @@
 In {product}, you can select your GitHub repositories and automate their onboarding to the {product-short} catalog.
 
 .Prerequisites
-* You have link:{authentication-book-url}#enabling-authentication-with-github[configured GitHub authentication and integration].
 * You have xref:enabling-and-giving-access-to-the-bulk-import-feature[enabled the Bulk Import feature and gave access to it].
 
 .Procedure


### PR DESCRIPTION
@rm3l said:

> I think the most important prerequisite for Bulk Import is to configure one or more GH integrations. It doesn't rely on GH authentication.
> Also, the link points to [Enabling authentication with GitHub](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.3/html-single/authentication/index#enabling-authentication-with-github), but there is nowhere in this page how to configure a GH integration



**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.3.1
<!--- Specify the version(s) of RHDH that your PR applies to. -->

**Issue:** https://issues.redhat.com/browse/RHIDP-1925
<!--- Add a link to the Bugzilla, Jira, or GitHub issue. --->

**Link to docs preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-646/authentication/#enabling-authentication-with-github
<!--- Add direct link(s) to the exact page(s) that contain the updated content from the preview build. --->

**Reviews:**
- [x] SME: @rm3l 
- [x] QE: @subhashkhileri
- [x] Docs review: @jmagak 
- [ ] Additional review: @mention assignee (by writer)
<!--- SME approval is required to merge a PR unless the changes are made by a subject matter expert. --->
<!--- QE approval is required to merge a PR unless there are no technical changes to the content. --->
<!--- Docs team approval is required for ALL PRs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, request reviews from all required stakeholders via Slack GitHub, or Jira. --->

