### PR TITLE
chore(release notes): move the accidentally...

### DIFF
--- a/modules/release-notes/single-source-release-notes.jira2asciidoc.yml
+++ b/modules/release-notes/single-source-release-notes.jira2asciidoc.yml
@@ -1,0 +1,94 @@
+---
+jira:
+  server: 'https://issues.redhat.com'
+product:
+  version:
+    minor_glob: 1.3.*
+    patch: 1.3
+sections:
+  - id: new-features
+    title: New features
+    description: |
+      This section highlights new features in {product} {product-version}.
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" in ("Feature", "Enhancement")
+      AND (fixVersion ~ "{version_minor_glob}" OR fixVersion = "{version_patch}")
+      ORDER BY key
+    template: without-jira-link
+  - id: breaking-changes
+    title: Breaking changes
+    description: |
+      This section lists breaking changes in {product} {product-version}.
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" in ("Removed Functionality")
+      AND (fixVersion ~ "{version_minor_glob}" OR fixVersion = "{version_patch}")
+      ORDER BY key
+    template: with-jira-link
+  - id: deprecated-functionalities
+    title: Deprecated functionalities
+    description: |
+      This section lists deprecated functionalities in {product} {product-version}.
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" in ("Deprecated Functionality")
+      AND (fixVersion ~ "{version_minor_glob}" OR fixVersion = "{version_patch}")
+      ORDER BY key
+    template: with-jira-link
+  - id: technology-preview
+    title: Technology Preview
+    description: |
+      This section lists Technology Preview features in {product} {product-version}.
+
+      [IMPORTANT]
+      ====
+      Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+      However, these features are not fully supported under Red Hat Subscription Level Agreements, may not be functionally complete, and are not intended for production use.
+      As Red Hat considers making future iterations of Technology Preview features generally available, we will attempt to resolve any issues that customers experience when using these features.
+      See: link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview support scope].
+      ====
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" in ("Developer Preview", "Technology Preview")
+      AND (fixVersion ~ "{version_minor_glob}" OR fixVersion = "{version_patch}")
+      ORDER BY key
+    template: with-jira-link
+  - id: fixed-issues
+    title: Fixed issues
+    description: |
+      This section lists issues fixed in {product} {product-version}.
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" = "Bug Fix"
+      AND (fixVersion ~ "{version_minor_glob}" OR fixVersion = "{version_patch}")
+      ORDER BY key
+    template: with-jira-link
+  - id: known-issues
+    title: Known issues
+    description: |
+      This section lists known issues in {product} {product-version}.
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND "Release Note Type" in ("Known Issue")
+      AND affectedVersion <= "{version_patch}"
+      AND (fixVersion > "{version_patch}" OR fixVersion is EMPTY)
+      ORDER BY key DESC
+    template: with-jira-link

--- a/modules/release-notes/single-source-release-notes.py
+++ b/modules/release-notes/single-source-release-notes.py
@@ -38,7 +38,7 @@ env = jinja2.Environment(
 )
 # Load configuration file
 with open(
-  root_dir + '/jira2asciidoc.yml',
+  modules_dir + '/single-source-release-notes.jira2asciidoc.yml',
   'r'
 ) as file:
   config = yaml.safe_load(file)


### PR DESCRIPTION
### What does this PR do?

chore(release notes): move the accidentally deleted file jira2asciidoc.yml into modules/release-notes and rename so it's associated with the single-source-release-notes.py script that uses it

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.