### PR TITLE
Updated about RHDH and added RHTAP content

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -40,6 +40,26 @@
 :rhbk: RHBK
 :keycloak-version: 24.0
 
+// RHTAP information
+:rhtap-version: 1.3
+:rhtap-brand-name: Red Hat Trusted Application Pipeline
+:rhtap-very-short: RHTAP
+
+// TAS information
+:rhtas-brand-name: Red Hat Trusted Artifact Signer
+:rhtas-short: Trusted Artifact Signer
+:rhtas-very-short: TAS
+
+// TPA information
+:rhtpa-brand-name: Red Hat Trusted Profile Analyzer
+:rhtpa-short: Trusted Profile Analyzer
+:rhtpa-very-short: TPA
+
+// ACS information
+:rhacs-brand-name: Red Hat Advanced Cluster Security
+:rhacs-short: Advanced Cluster Security
+:rhacs-very-short: ACS
+
 // Partner Platforms
 :aws-brand-name: Amazon Web Services
 :aws-short: AWS

--- a/assemblies/assembly-about-rhdh.adoc
+++ b/assemblies/assembly-about-rhdh.adoc
@@ -12,14 +12,12 @@ endif::[]
 
 :context: about-rhdh
 
-{product} is a fully supported, open developer platform that reduces friction and frustration of developers while boosting productivity.
+{product} ({product-very-short}) is an enterprise-grade internal developer portal designed to simplify and streamline software development processes. Combined with {ocp-brand-name}, {product-very-short} empowers platform engineering teams to create customized portals that improve developer productivity, accelerate onboarding, and enable faster application delivery. By reducing friction and complexity, {product-very-short} allows developers to focus on writing high-quality code while adhering to enterprise-class best practices.
 
-This platform is driven by a centralized software catalog, providing efficiency to your microservices and infrastructure.
-
-Use {product} to simplify decision-making through a selection of internally approved tools, programming languages, and developer resources within a self-managed portal.
-
+{product-very-short} integrates software templates, pre-designed solutions, and dynamic plugins into a centralized platform, providing tailored solutions for operations and development teams in a unified environment.
 
 include::modules/about/con-benefits-of-rhdh.adoc[leveloffset=+1]
+include::modules/about/con_integrations-in-rhdh.adoc[leveloffset=+1]
 include::modules/about/ref-supported-platforms.adoc[leveloffset=+1]
 include::modules/about/ref-rhdh-sizing.adoc[leveloffset=+1]
 include::modules/about/ref-customer-support-info.adoc[leveloffset=+1]

--- a/modules/about/con-benefits-of-rhdh.adoc
+++ b/modules/about/con-benefits-of-rhdh.adoc
@@ -3,39 +3,46 @@
 [id="benefits-of-rhdh_{context}"]
 = Benefits of {product}
 
-Increased developer productivity::
-Eliminates common organizational challenges, enabling seamless collaboration, and providing clear guidelines for creating, developing, and deploying applications.
+{product} offers targeted benefits for developers, platform engineers, and organizations by simplifying workflows, improving productivity, and enabling efficient governance.
 
-Unified Self-Service Dashboard::
-Provides development teams with a unified dashboard. Your platform engineering team can curate aspects such as:
+For developers::
 
-* Git
-* Continuous Integration/Continuous Delivery (CI/CD)
-* Static Application Security Testing (SAST)/Dynamic Application Security Testing (DAST)
-* Supply Chain
-* OpenShift/Kubernetes cluster
-* JIRA
-* Monitoring
-* API
-* Documentation
+* Simplified access to tools, resources, and workflows through a centralized dashboard.
+* Self-service capabilities with guardrails for cloud-native development.
+* Streamlined software and service creation using pre-configured templates.
 
-Best practices through software templates::
-Automates organizational best practices by encoding common tasks such as:
-* Creating new applications
-* Running Ansible jobs
-* Establishing CI/CD pipelines for production deployment in Git
+For Platform engineers::
 
-Scalable technical documentation::
-Code and documentation is in the same repository, eliminating dependencies on proprietary document systems.
+* Tailored platforms with curated tools to support developers efficiently.
+* Centralized repositories for consistent configuration management.
+* Simplified governance of technology choices and operational processes.
 
-Efficient onboarding for new developers::
-New developers can adapt quickly and become productive within a short time frame.
+For organizations::
 
-Robust enterprise Role-Based Access Control (RBAC)::
-Empowers administrators to:
-* Create roles
-* Assign users or groups to roles
-* Implement robust security policies for enhanced access control
+* Scalability to onboard new teams quickly while maintaining consistency.
+* Enhanced security with enterprise-grade Role-Based Access Control (RBAC).
+* Cost and time efficiency by mitigating cognitive load and eliminating workflow bottlenecks.
 
+== Key features
+
+Centralized Dashboard::
+Provides a single interface for accessing developer tools, CI/CD pipelines, APIs, monitoring tools, and documentation. Integrated with systems like Git, OpenShift, Kubernetes, and JIRA.
+
+Dynamic Plugins::
+Add, update, or remove plugins dynamically without downtime. Popular plugins like Tekton, GitOps, Nexus Repository, and JFrog Artifactory are supported and verified by Red Hat.
+
+Software Templates::
+Simplify development processes by automating tasks such as repository setup, variable insertion, and production pipeline creation.
+
+Role-Based Access Control (RBAC)::
+Manage user access with robust security permissions tailored to organizational needs.
+
+Scalability::
+Support growing teams and applications while maintaining access to the same tools and services.
+
+Configuration Management::
+Centralized repositories ensure synchronized updates, improving version control and environment configuration.
+
+[role="_additional-resources"]
 .Additional resources
   * For more information about the different features of {product} and how to extend it, see link:https://developers.redhat.com/rhdh/overview[{product} overview].

--- a/modules/about/con_integrations-in-rhdh.adoc
+++ b/modules/about/con_integrations-in-rhdh.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="integrations-in-rhdh_{context}"]
+= Integrations in {product}
+
+{product} integrates seamlessly with {ocp-brand-name} and other tools, enabling comprehensive development and deployment workflows across enterprise.
+
+== Integration with {ocp-brand-name}
+{product} is fully integrated with {ocp-brand-name}, offering:
+
+* Operators to manage application lifecycle.
+* Access to advanced OpenShift capabilities such as service mesh, serverless functions, GitOps, and distributed tracing.
+* Pipelines and GitOps plugins for streamlined cloud-native workflows.
+
+== Integration with {rhtap-brand-name}
+{rhtap-brand-name} ({rhtap-very-short}) enhances {product} by providing secure CI/CD capabilities that integrate security measures into every stage of the development process.
+
+While {product} focuses on the inner loop (code, build, and test), {rhtap-very-short} manages the outer loop, automating:
+
+* Code scanning
+* Image building
+* Vulnerability detection
+* Deployment
+
+{rhtap-very-short} includes tools like {rhtas-brand-name} ({rhtas-very-short}) for code integrity, {rhtpa-brand-name} ({rhtpa-very-short}) for automated Software build of Materials (SBOM) creation, and {rhacs-brand-name} ({rhacs-very-short}) for vulnerability scanning. 
+
+== Extending Backstage with {product}
+{product} which is a fully supported, enterprise-grade productized version of upstream Backstage extends the upstream project by adding:
+
+* Enhanced search capabilities that aggregate data from CI/CD pipelines, cloud providers, source control, and more.
+* A centralized software catalog for locating applications, APIs, and resources.
+* Automation through open-source plugins that expand Backstage’s core functionality.
+* Simplified technical documentation using Markdown and GitHub, with integrated search for easy navigation.


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

In this PR:

- I restructured about RHDH content
- Added content around RHTAP
- Renamed Discover to About at a couple of places
- Updated attributes to add references for RHTAP

**Version(s):** RHDH 1.4 and RHTAP 1.3

**Issue:**
[HACDOCS-1118](https://issues.redhat.com/browse/HACDOCS-1118)

**Output:**
[About](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-724/about/)

