### PR TITLE
RHIDP-4506: Docs sample for 'default.main-menu-items' is missing 'menuItems' field

### DIFF
--- a/modules/customization/proc-customize-rhdh-sidebar-menuitems.adoc
+++ b/modules/customization/proc-customize-rhdh-sidebar-menuitems.adoc
@@ -93,7 +93,7 @@ dynamicPlugins:
 ----
 --
 
-. To ensure that a menu item is identified as a main menu item, you must add `default.` prefix to its key. For example:
+. To ensure that a menu item is identified as a main menu item, you must add the `default.` prefix to its key. For example:
 +
 --
 .Example configuration of main menu items in sidebar navigation
@@ -102,13 +102,14 @@ dynamicPlugins:
 dynamicPlugins:
   frontend:
     default.main-menu-items: # key for configuring static main menu items
-      default.<menu_item_name>: # key of the menu item configuration. `default.` prefix is required for a main menu item key <1>
-        parent: my_menu_group # optional, specifies the parent menu item for this item
-        priority: 10 # optional, specifies the order of this menu item within its menu level
-      default.<menu_group_parent_item_name>: # must be configured if it is specified as the parent of any menu items. `default.` prefix is required for a main menu item key
-        icon: my_menu_group_icon # required for parent menu items, defines the icon for the menu group
-        title: my_menu_group_title # required for parent menu items, defines the icon for the menu group
-        priority: 100 # optional, specifies the order of the parent menu item in the sidebar
+      menuItems: 
+        default.<menu_item_name>: # key of the menu item configuration. `default.` prefix is required for a main menu item key <1>
+          parent: my_menu_group # optional, specifies the parent menu item for this item
+          priority: 10 # optional, specifies the order of this menu item within its menu level
+        default.<menu_group_parent_item_name>: # must be configured if it is specified as the parent of any menu items. `default.` prefix is required for a main group parent item key <1>
+          icon: my_menu_group_icon # required for parent menu items, defines the icon for the menu group
+          title: my_menu_group_title # required for parent menu items, defines the icon for the menu group
+          priority: 100 # optional, specifies the order of the parent menu item in the sidebar
 ----
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: Docs sample for 'default.main-menu-items' is missing 'menuItems' field

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.3.x, 1.4.x, and main
Add the relevant labels to the Pull Request.
**Issue:** RHIDP-4506

