### PR TITLE
Include the support preface content only once in the entire doc set

### DIFF
--- a/.asciidoctorconfig
+++ b/.asciidoctorconfig
@@ -9,7 +9,6 @@ include::{asciidoctorconfigdir}/artifacts/attributes.adoc[]
 :chapter-signifier: Chapter
 :docinfo: shared
 :docinfodir: {asciidoctorconfigdir}/.asciidoctor
-:doctype: book
 :sectnumlevels: 5
 :sectnums:
 :source-highlighter: coderay

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -1,6 +1,7 @@
 :red-hat-developers-documentation:
 :imagesdir:
 :idseparator: -
+:doctype: article
 
 // Company names
 :company-name: Red Hat

--- a/artifacts/snip-customer-support-info.adoc
+++ b/artifacts/snip-customer-support-info.adoc
@@ -1,8 +1,0 @@
-[preface]
-[id='snip-customer-support-info_{context}']
-= Red Hat Developer Hub support
-
-If you experience difficulty with a procedure described in this documentation, visit the http://access.redhat.com[Red Hat Customer Portal]. You can use the Red Hat Customer Portal for the following purposes:
-
-* To search or browse through the Red Hat Knowledgebase of technical support articles about Red Hat products. 
-* To create a https://access.redhat.com/support/cases/#/case/new/get-support?caseCreate=true[support case] for {company-name} Global Support Services (GSS). For support case creation, select *{product}* as the product and select the appropriate product version. For detailed information about supported platforms, see link:{release-notes-url}#con-release-notes-overview.adoc[Supported Platforms] and the link:https://access.redhat.com/support/policy/updates/developerhub[{product} Life Cycle].

--- a/assemblies/assembly-about-rhdh.adoc
+++ b/assemblies/assembly-about-rhdh.adoc
@@ -22,3 +22,4 @@ Use {product} to simplify decision-making through a selection of internally appr
 include::modules/about/con-benefits-of-rhdh.adoc[leveloffset=+1]
 include::modules/about/ref-supported-platforms.adoc[leveloffset=+1]
 include::modules/about/ref-rhdh-sizing.adoc[leveloffset=+1]
+include::modules/about/ref-customer-support-info.adoc[leveloffset=+1]

--- a/modules/about/ref-customer-support-info.adoc
+++ b/modules/about/ref-customer-support-info.adoc
@@ -1,0 +1,7 @@
+[id="ref-customer-support-info_{context}"]
+= Red Hat Developer Hub support
+
+If you experience difficulty with a procedure described in this documentation, visit the http://access.redhat.com[Red Hat Customer Portal]. You can use the Red Hat Customer Portal for the following purposes:
+
+* To search or browse through the Red Hat Knowledgebase of technical support articles about Red Hat products.
+* To create a https://access.redhat.com/support/cases/#/case/new/get-support?caseCreate=true[support case] for {company-name} Global Support Services (GSS). For support case creation, select *{product}* as the product and select the appropriate product version. For detailed information about supported platforms, see link:{release-notes-url}#con-release-notes-overview.adoc[Supported Platforms] and the link:https://access.redhat.com/support/policy/updates/developerhub[{product} Life Cycle].

--- a/titles/about/master.adoc
+++ b/titles/about/master.adoc
@@ -1,7 +1,6 @@
 [id="title-about_red_hat_developer_hub"]
 include::artifacts/attributes.adoc[]
 = About {product}
-:doctype: book
 :imagesdir: images
 :title: About {product}
 :subtitle: Introduction to {product}

--- a/titles/admin-rhdh/title-admin.adoc
+++ b/titles/admin-rhdh/title-admin.adoc
@@ -2,13 +2,9 @@
 include::artifacts/attributes.adoc[]
 = Administration guide for {product}
 :context: admin-rhdh
-:doctype: book
 :imagesdir: images
 
 {product} is an enterprise-grade, open developer platform that you can use to build developer portals. This platform contains a supported and opinionated framework that helps reduce the friction and frustration of developers while boosting their productivity.
-
-//customer support links
-include::artifacts/snip-customer-support-info.adoc[]
 
 //add a custom application config file to OCP
 include::assemblies/assembly-add-custom-app-file-openshift.adoc[leveloffset=+1]

--- a/titles/audit-log/master.adoc
+++ b/titles/audit-log/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-audit-log
-:doctype: book
 :imagesdir: images
 :title: Audit log
 :subtitle: Tracking user activities, system events, and data changes with {product} audit logs

--- a/titles/authentication/master.adoc
+++ b/titles/authentication/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-authentication
-:doctype: book
 :imagesdir: images
 :title: Authentication
 :subtitle: Configuring authentication to external services in {product}

--- a/titles/authorization/master.adoc
+++ b/titles/authorization/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-authorization
-:doctype: book
 :imagesdir: images
 :title: Authorization
 :subtitle: Configuring authorization by using role based access control (RBAC) in {product}

--- a/titles/getting-started-rhdh/title-getting-started.adoc
+++ b/titles/getting-started-rhdh/title-getting-started.adoc
@@ -2,13 +2,9 @@
 include::artifacts/attributes.adoc[]
 = Getting started with {product}
 :context: rhdh-getting-started
-:doctype: book
 :imagesdir: images
 
 As a developer, you can use {product} to experience a streamlined development environment. {product} is driven by a centralized software catalog, providing efficiency to your microservices and infrastructure. It enables your product team to deliver quality code without any compromises.
-
-//customer support links
-include::artifacts/snip-customer-support-info.adoc[]
 
 // supported configs and customization
 include::modules/getting-started/ref-rhdh-supported-configs.adoc[leveloffset=+1]

--- a/titles/install-rhdh-air-gapped/master.adoc
+++ b/titles/install-rhdh-air-gapped/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} in an air-gapped environment
 :context: title-install-rhdh-air-grapped
-:doctype: book
 :imagesdir: images
 
 include::modules/installation/con-airgapped-environment.adoc[leveloffset=+1]

--- a/titles/install-rhdh-aks/master.adoc
+++ b/titles/install-rhdh-aks/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} on {aks-brand-name}
 :context: title-install-rhdh-aks
-:doctype: book
 :imagesdir: images
 
 // aks deployment

--- a/titles/install-rhdh-eks/master.adoc
+++ b/titles/install-rhdh-eks/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} on {eks-brand-name}
 :context: title-install-rhdh-eks
-:doctype: book
 :imagesdir: images
 
 // aws eks deployment

--- a/titles/install-rhdh-gke/master.adoc
+++ b/titles/install-rhdh-gke/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} on {gke-brand-name}
 :context: title-install-rhdh-gke
-:doctype: book
 :imagesdir: images
 
 // Google gke deployment - is this required for 1.4 release [TBC]

--- a/titles/install-rhdh-ocp/master.adoc
+++ b/titles/install-rhdh-ocp/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} on {ocp-short}
 :context: title-install-rhdh-ocp
-:doctype: book
 :imagesdir: images
 
 // ocp deployment

--- a/titles/install-rhdh-osd-gcp/master.adoc
+++ b/titles/install-rhdh-osd-gcp/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Installing {product} on {osd-short} on {gcp-brand-name}
 :context: title-install-rhdh-osd-gcp
-:doctype: book
 :imagesdir: images
 
 You can install {product-short} on {osd-short} on {gcp-brand-name} ({gcp-short}) using one of the following methods:

--- a/titles/monitoring-and-logging/master.adoc
+++ b/titles/monitoring-and-logging/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-monitoring-logging
-:doctype: book
 :imagesdir: images
 :title: Monitoring and logging
 :subtitle: Tracking performance and capturing insights with monitoring and logging tools in {product}

--- a/titles/plugin-rhdh/title-plugin.adoc
+++ b/titles/plugin-rhdh/title-plugin.adoc
@@ -2,13 +2,9 @@
 include::artifacts/attributes.adoc[]
 = Configuring plugins in {product}
 :context: plugin-rhdh
-:doctype: book
 :imagesdir: images
 
 The {product} is an enterprise-grade, integrated developer platform, extended through plugins, that helps reduce the friction and frustration of developers while boosting their productivity.
-
-//customer support links
-include::artifacts/snip-customer-support-info.adoc[]
 
 //overview
 include::modules/con-rhdh-plugins.adoc[leveloffset=+1]

--- a/titles/plugins-rhdh-about/master.adoc
+++ b/titles/plugins-rhdh-about/master.adoc
@@ -1,7 +1,6 @@
 [id="title-plugins-rhdh-about"]
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-about
-:doctype: book
 :imagesdir: images
 :title: Introduction to plugins
 :subtitle: Introduction to {product-very-short} plugins

--- a/titles/plugins-rhdh-configure/master.adoc
+++ b/titles/plugins-rhdh-configure/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-configure
-:doctype: book
 :imagesdir: images
 
 :title: Configuring dynamic plugins

--- a/titles/plugins-rhdh-install/master.adoc
+++ b/titles/plugins-rhdh-install/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-about
-:doctype: book
 :imagesdir: images
 
 :title: Installing and viewing dynamic plugins

--- a/titles/plugins-rhdh-reference/master.adoc
+++ b/titles/plugins-rhdh-reference/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-about
-:doctype: book
 :imagesdir: images
 
 :title: Dynamic plugins reference

--- a/titles/plugins-rhdh-troubleshooting/master.adoc
+++ b/titles/plugins-rhdh-troubleshooting/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-about
-:doctype: book
 :imagesdir: images
 :title: Troubleshooting {product} plugins
 :subtitle: Troubleshooting {product-very-short} plugins

--- a/titles/plugins-rhdh-using/master.adoc
+++ b/titles/plugins-rhdh-using/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-plugins-rhdh-using
-:doctype: book
 :imagesdir: images
 :title: Using dynamic plugins
 :subtitle: Using {product-very-short} plugins as an end-user

--- a/titles/rel-notes-rhdh/title-rhdh-release-notes.adoc
+++ b/titles/rel-notes-rhdh/title-rhdh-release-notes.adoc
@@ -4,13 +4,9 @@ include::artifacts/attributes.adoc[]
 :subtitle: Release notes for {product} {product-version}
 = {title}: {subtitle}
 :context: release-notes-rhdh
-:doctype: book
 :imagesdir: images
 
 {product} ({product-short}) {product-version} is now generally available. {product-short} is a fully supported, enterprise-grade productized version of upstream Backstage v{product-backstage-version}. You can access and download the {product} application from the {company-name} https://access.redhat.com/downloads[Customer Portal] or from the https://catalog.redhat.com/search?gs&q=rhdh&searchType=containers[Ecosystem Catalog].
-
-//customer support links
-include::artifacts/snip-customer-support-info.adoc[]
 
 include::assemblies/assembly-release-notes-new-features.adoc[leveloffset=+1]
 

--- a/titles/telemetry/master.adoc
+++ b/titles/telemetry/master.adoc
@@ -1,6 +1,5 @@
 include::artifacts/attributes.adoc[]
 :context: title-telemetry
-:doctype: book
 :imagesdir: images
 :title: Telemetry data collection
 :subtitle: Collecting and analyzing telemetry data to enhance {product} experience

--- a/titles/upgrade-rhdh/master.adoc
+++ b/titles/upgrade-rhdh/master.adoc
@@ -2,7 +2,6 @@
 include::artifacts/attributes.adoc[]
 = Upgrading {product}
 :context: title-upgrade-rhdh
-:doctype: book
 :imagesdir: images
 
 include::modules/upgrade/proc-upgrade-rhdh-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
* Change the content about support to a reference module and include in the About title.
* Remove the current preface about support from all titles.
* To avoid that the introduction paragraph has the *Preface* title, use the `article` document type, rather than `book`.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.3.x, 1.4.x
<!--- Specify the version(s) of RHDH that your PR applies to. -->
Add the relevant labels to the Pull Request.
**Issue:** https://issues.redhat.com/browse/RHIDP-5099
<!--- Add a link to the Jira issue. --->



