### PR TITLE
RHIDP-4801 - Plugins should be able to know on which Backstage they are running on.

### DIFF
--- a/assemblies/dynamic-plugins/assembly-installing-rhdh-plugins.adoc
+++ b/assemblies/dynamic-plugins/assembly-installing-rhdh-plugins.adoc
@@ -21,5 +21,8 @@ include::../modules/dynamic-plugins/proc-using-custom-npm-registry.adoc[leveloff
 // Viewing installed plugins
 include::../modules/dynamic-plugins/proc-viewing-installed-plugins.adoc[leveloffset=+1]
 
+// Identifying Backstage flavor for plugins
+include::../modules/dynamic-plugins/proc-identifying-backstage-flavor-for-plugins.adoc[leveloffset=+1]
+
 //basic plugin configuration
 //include::../modules/dynamic-plugins/con-basic-config-dynamic-plugins.adoc[leveloffset=+1]

--- a/modules/dynamic-plugins/proc-identifying-backstage-flavor-for-plugins.adoc
+++ b/modules/dynamic-plugins/proc-identifying-backstage-flavor-for-plugins.adoc
@@ -1,0 +1,15 @@
+[id="proc-identifying-backstage-flavor-for-plugins_{context}"]
+= Identifying Backstage flavor for plugins
+
+You can use the `developerHub.flavor` field to identify whether plugins are running on {product-very-short}, RHTAP, or vanilla Backstage, as shown in the following example:
+
+.`app-config.yaml` fragment with the `developerhub.flavor` field
+
+[source,yaml]
+----
+developerHub:
+  flavor: <flavor>
+----
+
+`flavor`::
+Identify the flavor of Backstage that is running. Default value: `rhdh`


### PR DESCRIPTION
RHIDP-4768 - Plugins should be able to know on which Backstage they are running on.

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.4

Add the relevant labels to the Pull Request.
**Issue:**
[RHIDP-4801](https://issues.redhat.com/browse/RHIDP-4801)


