### PR TITLE
chore: ccutil to use the article doctype

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -1,7 +1,6 @@
 :red-hat-developers-documentation:
 :imagesdir:
 :idseparator: -
-:doctype: article
 
 // Company names
 :company-name: Red Hat

--- a/build/scripts/build-ccutil.sh
+++ b/build/scripts/build-ccutil.sh
@@ -36,7 +36,7 @@ for t in $(find titles -name master.adoc | sort -uV | grep -E -v "${EXCLUDED_TIT
     CMD="podman run --interactive --rm --tty \
           --volume "$(pwd)":/docs:Z \
           --workdir "/docs/$d" \
-          quay.io/ivanhorvath/ccutil:amazing ccutil compile --format html-single --lang en-US";
+          quay.io/ivanhorvath/ccutil:amazing ccutil compile --format html-single --lang en-US --doctype article";
     echo -e -n "\nBuilding $t into $dest ...\n  ";
     echo "${CMD}" | sed -r -e "s/\  +/ \\\\\n    /g"
     $CMD


### PR DESCRIPTION
* Ccutil and Pantheon are not using the `:doctype:` attribute.
* Ccutil doctype defaults to `book`.
* To change the doctype with ccutil, use the CLI:

```
  --doctype DOCTYPE           The document type. If no type is passed, the
                              type is assumed to be a book.
```