### PR TITLE
chore(dynamic plugins): fix scope references for rhdh-plugins: should be @red-hat-developer-hub/ not @red/hat-developer-hub-

### DIFF
--- a/modules/dynamic-plugins/ref-community-plugins.adoc
+++ b/modules/dynamic-plugins/ref-community-plugins.adoc
@@ -15,5 +15,4 @@ Details on how {company-name} provides support for bundled community dynamic plu
 [%header,cols=4*]
 |===
 |*Name* |*Plugin* |*Version* |*Path and required variables*
-
 |===

--- a/modules/dynamic-plugins/ref-rh-tech-preview-plugins.adoc
+++ b/modules/dynamic-plugins/ref-rh-tech-preview-plugins.adoc
@@ -88,11 +88,11 @@
 |`./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic`
 
 
-|Bulk Import  |`https://npmjs.com/package/@red/hat-developer-hub-backstage-plugin-bulk-import/v/1.10.3[@red/hat-developer-hub-backstage-plugin-bulk-import]` |1.10.3 
+|Bulk Import  |`https://npmjs.com/package/@red-hat-developer-hub/backstage-plugin-bulk-import/v/1.10.3[@red-hat-developer-hub/backstage-plugin-bulk-import]` |1.10.3 
 |`./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import`
 
 
-|Bulk Import  |`https://npmjs.com/package/@red/hat-developer-hub-backstage-plugin-bulk-import-backend/v/5.2.0[@red/hat-developer-hub-backstage-plugin-bulk-import-backend]` |5.2.0 
+|Bulk Import  |`https://npmjs.com/package/@red-hat-developer-hub/backstage-plugin-bulk-import-backend/v/5.2.0[@red-hat-developer-hub/backstage-plugin-bulk-import-backend]` |5.2.0 
 |`./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic`
 
 

--- a/modules/dynamic-plugins/rhdh-supported-plugins.csv
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.csv
@@ -28,8 +28,8 @@
 "Bitbucket Cloud ","@backstage/plugin-scaffolder-backend-module-bitbucket-cloud","Backend","0.2.2","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic",";","Disabled"
 "Bitbucket Server ","@backstage/plugin-catalog-backend-module-bitbucket-server","Backend","0.2.3","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic","`BITBUCKET_HOST`;","Disabled"
 "Bitbucket Server ","@backstage/plugin-scaffolder-backend-module-bitbucket-server","Backend","0.2.2","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic",";","Disabled"
-"Bulk Import ","@red/hat-developer-hub-backstage-plugin-bulk-import","Frontend","1.10.3","Red Hat Tech Preview","./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import",";","Disabled"
-"Bulk Import ","@red/hat-developer-hub-backstage-plugin-bulk-import-backend","Backend","5.2.0","Red Hat Tech Preview","./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic",";","Disabled"
+"Bulk Import ","@red-hat-developer-hub/backstage-plugin-bulk-import","Frontend","1.10.3","Red Hat Tech Preview","./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import",";","Disabled"
+"Bulk Import ","@red-hat-developer-hub/backstage-plugin-bulk-import-backend","Backend","5.2.0","Red Hat Tech Preview","./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic",";","Disabled"
 "Datadog ","@roadiehq/backstage-plugin-datadog","Frontend","2.4.0","Red Hat Tech Preview","./dynamic-plugins/dist/roadiehq-backstage-plugin-datadog",";","Disabled"
 "Dynatrace ","@backstage-community/plugin-dynatrace","Frontend","10.0.8","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-community-plugin-dynatrace",";","Disabled"
 "Gerrit ","@backstage/plugin-scaffolder-backend-module-gerrit","Backend","0.2.2","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gerrit-dynamic",";","Disabled"
@@ -69,4 +69,3 @@
 "Tech Radar ","@backstage-community/plugin-tech-radar","Frontend","1.0.0","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-community-plugin-tech-radar",";","Disabled"
 "Tech Radar ","@backstage-community/plugin-tech-radar-backend","Backend","1.0.0","Red Hat Tech Preview","./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic","`TECH_RADAR_DATA_URL`;","Disabled"
 "Utils ","@roadiehq/scaffolder-backend-module-utils","Backend","3.0.0","Red Hat Tech Preview","./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic",";","Disabled"
-

--- a/modules/dynamic-plugins/rhdh-supported-plugins.sh
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.sh
@@ -121,6 +121,7 @@ for j in $jsons; do
     if [[ $Plugin != "@"* ]]; then # don't update janus-idp/backstage-plugins plugin names
         Plugin="$(echo "${Plugin}" | sed -r -e 's/([^-]+)-(.+)/\@\1\/\2/' \
             -e 's|janus/idp-|janus-idp/|' \
+            -e 's|red/hat-developer-hub-|red-hat-developer-hub/|' \
             -e 's|backstage/community-|backstage-community/|' \
             -e 's|parfuemerie/douglas-|parfuemerie-douglas/|')"
     fi
@@ -179,8 +180,9 @@ for j in $jsons; do
         # curl -sSLko- https://registry.npmjs.org/@janus-idp%2fcli | jq -r '.versions[]|(.version+", "+.gitHead)' | sort -uV
         # for timestamp when tag is created
         # curl -sSLko- https://registry.npmjs.org/@janus-idp%2fcli | jq -r '.time' | grep -v -E "created|modified|{|}" | sort -uV
+        # echo "Searching for ${Plugin/\//%2f} at npmjs.org..."
         allVersionsPublished="$(curl -sSLko- "https://registry.npmjs.org/${Plugin/\//%2f}" | jq -r '.versions[].version')"
-        # echo $allVersionsPublished
+        # echo "Found $allVersionsPublished"
         # clean out any pre-release versions
         latestXYRelease="$(echo "$allVersionsPublished" | grep -v -E -- "next|alpha|-" | grep -E "^${Version%.*}" | sort -uV | tail -1)"
         # echo "[DEBUG] Latest x.y version at https://registry.npmjs.org/${Plugin/\//%2f} : $latestXYRelease"
@@ -295,16 +297,24 @@ num_plugins+=(${#adoc1[@]})
 
 rm -f "${0/.sh/.adoc2}"
 sorted=(); while IFS= read -rd '' key; do sorted+=( "$key" ); done < <(printf '%s\0' "${!adoc2[@]}" | sort -z)
-for key in "${sorted[@]}"; do 
-    echo -e "${adoc2[$key]}" >> "${0/.sh/.ref-rh-tech-preview-plugins}"; 
-    echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"; done
+# shellcheck disable=SC2128
+if [[ $sorted ]] ;then 
+    for key in "${sorted[@]}"; do 
+        echo -e "${adoc2[$key]}" >> "${0/.sh/.ref-rh-tech-preview-plugins}"; 
+        echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"
+    done
+fi
 num_plugins+=(${#adoc2[@]})
 
 rm -f "${0/.sh/.adoc3}"
 sorted=(); while IFS= read -rd '' key; do sorted+=( "$key" ); done < <(printf '%s\0' "${!adoc3[@]}" | sort -z)
-for key in "${sorted[@]}"; do 
-    echo -e "${adoc3[$key]}" >> "${0/.sh/.ref-community-plugins}"; 
-    echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"; done
+# shellcheck disable=SC2128
+if [[ $sorted ]] ;then 
+    for key in "${sorted[@]}"; do 
+        echo -e "${adoc3[$key]}" >> "${0/.sh/.ref-community-plugins}"; 
+        echo -e "${csv[$key]}" >>  "${0/.sh/.csv}"
+    done
+fi
 num_plugins+=(${#adoc3[@]})
 
 # merge the content from the three .adocX files into the .template.adoc file, replacing the TABLE_CONTENT markers


### PR DESCRIPTION
### What does this PR do?

* chore(dynamic plugins): fix scope references for rhdh-plugins: should be @red-hat-developer-hub/ not @red/hat-developer-hub- 
* regenerate adoc and csv with the corrected links

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
RHIDP-5103

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.