### PR TITLE
chore(support): minimum supported OCP version is 4.14, not 4.16

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -37,7 +37,7 @@
 :logging-brand-name: Red Hat OpenShift Logging
 :logging-short: OpenShift Logging
 // minimum and current latest supported versions
-:ocp-version-min: 4.16
+:ocp-version-min: 4.14
 :ocp-version: 4.17
 :kubernetes-version: 1.24
 // First mention of OpenShift CLI or `oc` in a module


### PR DESCRIPTION
### What does this PR do?

chore(support): minimum supported OCP version is 4.14, not 4.16

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

Error introduced in RHIDP-4929 /RHIDP-4930 via https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/721

cherry-pick of https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/808

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.