### PR TITLE
chore: restore content removed by mistake

### DIFF
--- a/assemblies/assembly-configuring-a-proxy.adoc
+++ b/assemblies/assembly-configuring-a-proxy.adoc
@@ -5,12 +5,16 @@
 
 In a network restricted environment, configure {product} to use your proxy to access remote network resources.
 
-You can run the {product-very-short} application behind a corporate proxy by setting any of the following environment variables before starting the application:
+You can run the {product-short} application behind a corporate proxy by setting any of the following environment variables before starting the application:
 
-* `HTTP_PROXY`: Denotes the proxy to use for HTTP requests.
-* `HTTPS_PROXY`: Denotes the proxy to use for HTTPS requests.
+`HTTP_PROXY`:: Denotes the proxy to use for HTTP requests.
+`HTTPS_PROXY`:: Denotes the proxy to use for HTTPS requests.
 
-Additionally, set the `NO_PROXY` environment variable to bypass the proxy for certain domains. The variable value is a comma-separated list of hostnames or IP addresses that can be accessed without the proxy, even if one is specified.
+`NO_PROXY`:: Set the environment variable to bypass the proxy for certain domains. The variable value is a comma-separated list of hostnames or IP addresses that can be accessed without the proxy, even if one is specified.
+
+
+include::modules/configuring-a-proxy/con-understanding-the-no_proxy-exclusion-rules.adoc[leveloffset=+1]
+
 
 include::modules/configuring-a-proxy/proc-configuring-proxy-in-operator-deployment.adoc[leveloffset=+1]
 

--- a/modules/configuring-a-proxy/con-understanding-the-no_proxy-exclusion-rules.adoc
+++ b/modules/configuring-a-proxy/con-understanding-the-no_proxy-exclusion-rules.adoc
@@ -1,0 +1,34 @@
+[id='understanding-the-no-proxy-exclusion-rules']
+= Understanding the `NO_PROXY` exclusion rules
+
+`NO_PROXY` is a comma or space-separated list of hostnames or IP addresses, with optional port numbers. If the input URL matches any of the entries listed in `NO_PROXY`, a direct request fetches that URL, for example, bypassing the proxy settings.
+
+[NOTE]
+====
+The default value for `NO_PROXY` in {product-very-short} is `localhost,127.0.0.1`. If you want to override it, include at least `localhost` or `localhost:7007` in the list. Otherwise, the {product-very-short} backend might fail.
+====
+
+Matching follows the rules below:
+
+* `NO_PROXY=*` will bypass the proxy for all requests.
+
+* Space and commas might separate the entries in the `NO_PROXY` list. For example, `NO_PROXY="localhost,example.com"`, or `NO_PROXY="localhost example.com"`, or `NO_PROXY="localhost, example.com"` would have the same effect.
+
+* If `NO_PROXY` contains no entries, configuring the `HTTP(S)_PROXY` settings makes the backend send all requests through the proxy.
+
+* The backend does not perform a DNS lookup to determine if a request should bypass the proxy or not. For example, if DNS resolves `example.com` to `1.2.3.4`, setting `NO_PROXY=1.2.3.4` has no effect on requests sent to `example.com`. Only requests sent to the IP address `1.2.3.4` bypass the proxy.
+
+* If you add a port after the hostname or IP address, the request must match both the host/IP and port to bypass the proxy. For example, `NO_PROXY=example.com:1234` would bypass the proxy for requests to `http(s)://example.com:1234`, but not for requests on other ports, like `http(s)://example.com`.
+
+* If you do not specify a port after the hostname or IP address, all requests to that host/IP address will bypass the proxy regardless of the port. For example, `NO_PROXY=localhost` would bypass the proxy for requests sent to URLs like `http(s)://localhost:7077` and `http(s)://localhost:8888`.
+
+* IP Address blocks in CIDR notation will not work. So setting `NO_PROXY=10.11.0.0/16` will not have any effect, even if the backend sends a request to an IP address in that block.
+
+* Supports only IPv4 addresses. IPv6 addresses like `::1` will not work.
+
+* Generally, the proxy is only bypassed if the hostname is an exact match for an entry in the `NO_PROXY` list. The only exceptions are entries that start with a dot (`.`) or with a wildcard (`*`). In such a case, bypass the proxy if the hostname ends with the entry.
+
+[NOTE]
+====
+List the domain and the wildcard domain if you want to exclude a given domain and all its subdomains. For example, you would set `NO_PROXY=example.com,.example.com` to bypass the proxy for requests sent to `http(s)://example.com` and `http(s)://subdomain.example.com`.
+====


### PR DESCRIPTION
Restore content added by https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/709 and removed by mistake by https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/721

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.4
<!--- Specify the version(s) of RHDH that your PR applies to. -->
Add the relevant labels to the Pull Request.
**Issue:**
<!--- Add a link to the Jira issue. --->


