### PR TITLE
chore: update references to plugins to use their new locations; remove refs to plugins that can't be installed in 1.4 (Orchestrator) (RHIDP-4853, RHIDP-5349)

### DIFF
--- a/modules/authentication/proc-creating-a-custom-transformer-to-provision-users-from-rhbk-to-the-software-catalog.adoc
+++ b/modules/authentication/proc-creating-a-custom-transformer-to-provision-users-from-rhbk-to-the-software-catalog.adoc
@@ -21,7 +21,7 @@ import {
   GroupTransformer,
   keycloakTransformerExtensionPoint,
   UserTransformer,
-} from '@janus-idp/backstage-plugin-keycloak-backend';
+} from '@backstage-community/plugin-catalog-backend-module-keycloak';
 
 const customGroupTransformer: GroupTransformer = async (
   entity, // entity output from default parser

--- a/modules/authorization/proc-download-user-stats-rhdh.adoc
+++ b/modules/authorization/proc-download-user-stats-rhdh.adoc
@@ -5,7 +5,7 @@ You can download the list of users in CSV format using the {product-short} web i
 
 .Prerequisites
 
-* RBAC plugins (`@janus-idp/backstage-plugin-rbac` and `@janus-idp/backstage-plugin-rbac-backend`) must be enabled in {product}.
+* RBAC plugins (`@backstage-community/plugin-rbac` and `@backstage-community/plugin-rbac-backend`) must be enabled in {product}.
 * An administrator role must be assigned.
 
 .Procedure

--- a/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
@@ -37,8 +37,8 @@ global:
                       text: Notifications
                     config:
                       pollingIntervalMs: 5000   
-      - package: '@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic@1.3.5'
-        # https://registry.npmjs.org/@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic
+      - package: '@backstage-community/plugin-scaffolder-backend-module-kubernetes-dynamic@1.3.5'
+        # https://registry.npmjs.org/@backstage-community/plugin-scaffolder-backend-module-kubernetes-dynamic
         integrity: 'sha512-19ie+FM3QHxWYPyYzE0uNdI5K8M4vGZ0SPeeTw85XPROY1DrIY7rMm2G0XT85L0ZmntHVwc9qW+SbHolPg/qRA=='
           proxy:
             endpoints:

--- a/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
@@ -37,9 +37,9 @@ global:
                       text: Notifications
                     config:
                       pollingIntervalMs: 5000   
-      - package: '@backstage-community/plugin-scaffolder-backend-module-kubernetes-dynamic@1.3.5'
-        # https://registry.npmjs.org/@backstage-community/plugin-scaffolder-backend-module-kubernetes-dynamic
-        integrity: 'sha512-19ie+FM3QHxWYPyYzE0uNdI5K8M4vGZ0SPeeTw85XPROY1DrIY7rMm2G0XT85L0ZmntHVwc9qW+SbHolPg/qRA=='
+      - package: '@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic@2.0.3'
+        # https://registry.npmjs.org/@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic
+        integrity: 'sha512-yLh2MbNB0zSWTrG0O2MVk/oVu007k+UNm+MJzpyoUE2ziRjgwwXGqJVqW6behPCOLlJU4jizs6g9UtRfMGN/mA=='
           proxy:
             endpoints:
               /explore-backend-completed:

--- a/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/proc-rhdh-example-external-dynamic-plugins.adoc
@@ -2,41 +2,15 @@
 
 = Installing external dynamic plugins using a Helm chart
 
-The NPM registry contains external dynamic plugins that you can use for demonstration purposes. For example, the following community plugins are available in the `janus-idp` organization in the NPMJS repository:
+The NPM registry contains external dynamic plugins that you can enable in your {prod-short} instance. 
 
-* Notifications (frontend and backend)
-* Kubernetes actions (scaffolder actions)
-
-To install the Notifications and Kubernetes actions plugins, include them in the Helm chart values in the `global.dynamic.plugins` list as shown in the following example:
+To install dynamic plugins from registry.npmjs.org, include them in the Helm chart values in the `global.dynamic.plugins` list as shown in the following example:
 
 [source,yaml]
 ----
 global:
   dynamic:
     plugins:
-      - package: '@janus-idp/plugin-notifications-backend-dynamic@1.3.6'
-        # Integrity can be found at https://registry.npmjs.org/@janus-idp/plugin-notifications-backend-dynamic
-        integrity: 'sha512-Qd8pniy1yRx+x7LnwjzQ6k9zP+C1yex24MaCcx7dGDPT/XbTokwoSZr4baSSn8jUA6P45NUUevu1d629mG4JGQ=='
-      - package: '@janus-idp/plugin-notifications@1.1.12'
-        # https://registry.npmjs.org/@janus-idp/plugin-notifications
-        integrity: 'sha512-GCdEuHRQek3ay428C8C4wWgxjNpNwCXgIdFbUUFGCLLkBFSaOEw+XaBvWaBGtQ5BLgE3jQEUxa+422uzSYC5oQ=='
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              janus-idp.backstage-plugin-notifications:
-                appIcons:
-                  - name: notificationsIcon
-                    module: NotificationsPlugin
-                    importName: NotificationsActiveIcon
-                dynamicRoutes:
-                  - path: /notifications
-                    importName: NotificationsPage
-                    module: NotificationsPlugin
-                    menuItem:
-                      icon: notificationsIcon
-                      text: Notifications
-                    config:
-                      pollingIntervalMs: 5000   
       - package: '@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic@2.0.3'
         # https://registry.npmjs.org/@janus-idp/backstage-scaffolder-backend-module-kubernetes-dynamic
         integrity: 'sha512-yLh2MbNB0zSWTrG0O2MVk/oVu007k+UNm+MJzpyoUE2ziRjgwwXGqJVqW6behPCOLlJU4jizs6g9UtRfMGN/mA=='
@@ -50,4 +24,4 @@ global:
       - package: '@dfatwork-pkgs/plugin-catalog-backend-module-test-dynamic@0.0.0'
         # https://registry.npmjs.org/@dfatwork-pkgs/plugin-catalog-backend-module-test-dynamic
         integrity: 'sha512-YsrZMThxJk7cYJU9FtAcsTCx9lCChpytK254TfGb3iMAYQyVcZnr5AA/AU+hezFnXLsr6gj8PP7z/mCZieuuDA=='
----- 
+----

--- a/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
+++ b/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
@@ -19,10 +19,10 @@ The following Technology Preview plugins are not preinstalled and must be instal
 |`https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-scaffolder-backend-module-backstage-rhaap]` |1.0.0 |
 
 
-|Orchestrator Frontend|`https://www.npmjs.com/package/@janus-idp/backstage-plugin-orchestrator[@janus-idp/backstage-plugin-orchestrator]` |1.22.6| https://www.parodos.dev/1.2-rc/docs/[Learn more]
+|Orchestrator Frontend|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator[@red-hat-developer-hub/backstage-plugin-orchestrator]` |1.22.6| https://www.parodos.dev/1.2-rc/docs/[Learn more]
 
 |Orchestrator Backend
-|`https://www.npmjs.com/package/@janus-idp/backstage-plugin-orchestrator-backend-dynamic[@janus-idp/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9 |
+|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic[@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9 |
 
 
 |===
@@ -47,11 +47,11 @@ The following Technology Preview plugins are not preinstalled and must be instal
 
 |Orchestrator Frontend
 .2+|Orchestrator brings serverless workflows into Red Hat Developer Hub, focusing on the journey for application migration to the cloud, on boarding developers, and user-made workflows of Backstage actions or external systems. 
-|`https://www.npmjs.com/package/@janus-idp/backstage-plugin-orchestrator[@janus-idp/backstage-plugin-orchestrator]` |1.22.6
+|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator[@red-hat-developer-hub/backstage-plugin-orchestrator]` |1.22.6
 .2+| https://www.parodos.dev/1.2-rc/docs/[Learn more]
 
 |Orchestrator Backend
-|`https://www.npmjs.com/package/@janus-idp/backstage-plugin-orchestrator-backend-dynamic[@janus-idp/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9
+|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic[@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9
 
 
 |===

--- a/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
+++ b/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
@@ -1,6 +1,3 @@
-// This page is generated! Do not edit the .adoc file, but instead run rhdh-supported-plugins.sh to regen this page from the latest plugin metadata.
-// cd /path/to/rhdh-documentation; ./modules/dynamic-plugins/rhdh-supported-plugins.sh; ./build/scripts/build.sh; google-chrome titles-generated/main/plugin-rhdh/index.html
-
 = Other installable plugins 
 
 The following Technology Preview plugins are not preinstalled and must be installed from an external source:
@@ -26,37 +23,6 @@ The following Technology Preview plugins are not preinstalled and must be instal
 
 
 |===
-
-// Without description - for consistency i.e. no descriptions in other table and we provide a 'Learn more' link to plugin documentation for users' convenience.
-////
-[%header,cols=5*]
-|===
-|*Name* |*Description*|*Plugin*|*Version* |*Installation Details*
-
-|Ansible Automation Platform Frontend
-.3+|Ansible plug-ins for RHDH delivers an Ansible-specific portal experience with curated learning paths, push-button content creation, integrated development tools, and other opinionated resources. 
-|`https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-backstage-rhaap]` |1.0.0
-.3+| https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/installing_ansible_plug-ins_for_red_hat_developer_hub[Learn more]
-
-|Ansible Automation Platform
-| `https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-backstage-rhaap-backend]` |1.0.0
-
-|Ansible Automation Platform Scaffolder Backend
-|`https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-scaffolder-backend-module-backstage-rhaap]` |1.0.0
-
-
-|Orchestrator Frontend
-.2+|Orchestrator brings serverless workflows into Red Hat Developer Hub, focusing on the journey for application migration to the cloud, on boarding developers, and user-made workflows of Backstage actions or external systems. 
-|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator[@red-hat-developer-hub/backstage-plugin-orchestrator]` |1.22.6
-.2+| https://www.parodos.dev/1.2-rc/docs/[Learn more]
-
-|Orchestrator Backend
-|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic[@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9
-
-
-|===
-////
-
 
 [NOTE]
 ====

--- a/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
+++ b/modules/dynamic-plugins/ref-rh-compatible-plugins.adoc
@@ -10,16 +10,18 @@ The following Technology Preview plugins are not preinstalled and must be instal
 | https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/installing_ansible_plug-ins_for_red_hat_developer_hub[Learn more]
 
 |Ansible Automation Platform
-| `https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-backstage-rhaap-backend]` |1.0.0 |
+| `https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-backstage-rhaap-backend]` |1.0.0 
+| https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/installing_ansible_plug-ins_for_red_hat_developer_hub[Learn more]
 
 |Ansible Automation Platform Scaffolder Backend
-|`https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-scaffolder-backend-module-backstage-rhaap]` |1.0.0 |
+|`https://access.redhat.com/downloads/content/480/ver=2.4/rhel---9/2.4/x86_64/product-software[@ansible/plugin-scaffolder-backend-module-backstage-rhaap]` |1.0.0 
+| https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/installing_ansible_plug-ins_for_red_hat_developer_hub[Learn more]
 
+// temporarily removed until we have a good installation story from the Orchestrator team
+//|Orchestrator Frontend|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator[@red-hat-developer-hub/backstage-plugin-orchestrator]` | N/A for RHDH 1.4 | https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator/[Learn more]
 
-|Orchestrator Frontend|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator[@red-hat-developer-hub/backstage-plugin-orchestrator]` |1.22.6| https://www.parodos.dev/1.2-rc/docs/[Learn more]
-
-|Orchestrator Backend
-|`https://www.npmjs.com/package/@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic[@red-hat-developer-hub/backstage-plugin-orchestrator-backend-dynamic]` |1.22.9 |
+// temporarily removed until we have a good installation story from the Orchestrator team
+//|Orchestrator Backend|`https://npm.registry.redhat.com/@redhat/backstage-plugin-orchestrator-backend-dynamic/[@redhat/backstage-plugin-orchestrator-backend-dynamic]` | N/A for RHDH 1.4  | https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/orchestrator[Learn more]
 
 
 |===


### PR DESCRIPTION
### What does this PR do?

chore: update references to plugins to use their new locations; 
remove refs to plugins that can't be installed in 1.4 (Orchestrator);
remove mention of Notifications plugins as they're now bundled as wrappers in 1.4

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/RHIDP-4853
https://issues.redhat.com/browse/RHIDP-5349

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.