### PR TITLE
RHIDP-5469 Update proc-enabling-authentication-with-github.adoc

### DIFF
--- a/modules/authentication/proc-enabling-authentication-with-github.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-github.adoc
@@ -55,7 +55,7 @@ TIP: If you plan to make changes using the GitHub API, ensure that `Read and wri
 +
 `AUTH_GITHUB_APP_ID`:: Enter the saved **App ID**.
 `AUTH_GITHUB_CLIENT_ID`:: Enter the saved **Client ID**.
-`GITHUB_HOST_DOMAIN`:: Enter your GitHub host domain: `pass:c[https://github.com]` unless you are using GitHub Enterprise.
+`GITHUB_HOST_DOMAIN`:: Enter your GitHub host domain: `github.com` unless you are using GitHub Enterprise.
 `GITHUB_ORGANIZATION`:: Enter your GitHub organization name, such as `__<your_github_organization_name>__'.
 `GITHUB_ORG_URL`:: Enter `$GITHUB_HOST_DOMAIN/$GITHUB_ORGANIZATION`.
 `GITHUB_CLIENT_SECRET`:: Enter the saved **Client Secret**.


### PR DESCRIPTION

In the docs at https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/authentication/authenticating-with-github#enabling-authentication-with-github

we provide the example
"
GITHUB_HOST_DOMAIN }}Enter your GitHub host domain: {{https://github.com/ unless you are using GitHub Enterprise.
"

This should be "github.com", not "https://github.com"
See https://redhat-internal.slack.com/archives/C05HGAR2DT5/p1736374261642889

Critical as this is incorrect documentation for installation
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->
Add the relevant labels to the Pull Request.
**Issue:** https://issues.redhat.com/browse/RHIDP-5469
<!--- Add a link to the Jira issue. --->

