### PR TITLE
RHIDP-4780: Document per-ConfigMap/Secret configuration of mountPath

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -28,6 +28,7 @@
 :my-product-database-certificates-secrets: my-rhdh-database-certificates-secrets
 :my-product-database-secrets: my-rhdh-database-secrets
 :my-product-url: https://__<my_developer_hub_url>__
+:my-extra-file-configmap: my-project-configmap
 
 // Red Hat Platforms
 :ocp-brand-name: Red Hat OpenShift Container Platform

--- a/assemblies/assembly-provisioning-a-custom-configuration.adoc
+++ b/assemblies/assembly-provisioning-a-custom-configuration.adoc
@@ -22,6 +22,7 @@ include::modules/configuring/proc-provisioning-your-custom-configuration.adoc[le
 
 include::modules/configuring/proc-using-the-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1]
 
+include::modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc[][leveloffset=+2]
 
 include::modules/configuring/proc-using-the-helm-chart-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1]
 

--- a/assemblies/assembly-provisioning-a-custom-configuration.adoc
+++ b/assemblies/assembly-provisioning-a-custom-configuration.adoc
@@ -22,7 +22,7 @@ include::modules/configuring/proc-provisioning-your-custom-configuration.adoc[le
 
 include::modules/configuring/proc-using-the-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1]
 
-include::modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc[][leveloffset=+2]
+include::modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc[leveloffset=+2]
 
 include::modules/configuring/proc-using-the-helm-chart-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1]
 

--- a/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
+++ b/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
@@ -1,7 +1,7 @@
 [id="mounting-additional-files-in-your-custom-configuration-using-rhdh-operator"]
 = Mounting additional files in your custom configuration using the {product} operator
 
-You can use the {product-short} Operator to mount extra files, such as config maps and secrets, to the container in a preferred location.
+You can use the {product-short} Operator to mount extra files, such as a ConfigMap or Secret, to the container in a preferred location.
 
 The `mountPath` field specifies the location where a ConfigMap or Secret is mounted. The behavior of the mount, whether it includes or excludes a `subPath`, depends on the specification of the `key` or `mountPath` fields.
 
@@ -22,9 +22,9 @@ The `mountPath` field specifies the location where a ConfigMap or Secret is moun
 
 .Procedure
 
-. In {ocp-short}, create your config map or secret with the following YAML codes:
+. In {ocp-short}, create your ConfigMap or Secret with the following YAML codes:
 +
-.Minimal `{my-extra-file-configmap}` config map example
+.Minimal `{my-extra-file-configmap}` ConfigMap example
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -40,7 +40,7 @@ data:
 ----
 ====
 +
-.Minimal `{my-product-secrets}` secret example
+.Minimal `{my-product-secrets}` Secret example
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
+++ b/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
@@ -11,7 +11,7 @@ The `mountPath` field specifies the location where a ConfigMap or Secret is moun
 
 [NOTE]
 ====
-* {ocp-short} does not automatically update a volume mounted with subPath. By default, the {product-very-short} operator monitors these ConfigMaps or Secrets and refreshes the {product-very-short} Pod when changes occur.
+* {ocp-short} does not automatically update a volume mounted with `subPath`. By default, the {product-very-short} operator monitors these ConfigMaps or Secrets and refreshes the {product-very-short} Pod when changes occur.
 * For security purposes, {product} does not give the Operator Service Account read access to Secrets. As a result, mounting files from Secrets without specifying both mountPath and key is not supported.
 ====
 
@@ -56,6 +56,7 @@ StringData:
 For more information, see xref:provisioning-your-custom-configuration[Provisioning and using your custom {product} configuration].
 
 . Set the value of the `configMaps name` to the name of the ConfigMap or `secrets name` to the name of the Secret in your `{product-custom-resource-type}` CR. For example:
++
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
+++ b/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
@@ -1,0 +1,75 @@
+[id="mounting-additional-files-in-your-custom-configuration-using-rhdh-operator"]
+= Mounting additional files in your custom configuration using the {product} operator
+
+You can use the {product-short} operator to mount extra files, such as ConfigMaps and Secrets, to the container in a preferred location.
+
+The `mountPath` field specifies the location where a ConfigMap or Secret is mounted. The behavior of the mount, whether it includes or excludes a `subPath`, depends on the specification of the `key` or `mountPath` fields.
+
+* If `key` and `mountPath` are not specified: Each key or value is mounted as a `filename` or content with a `subPath`.
+* If `key` is specified with or without `mountPath`: The specified key or value is mounted with a `subPath`.
+* If only `mountPath` is specified: A directory containing all the keys or values is mounted without a `subPath`.
+
+[NOTE]
+====
+* {ocp-short} does not automatically update a volume mounted with subPath. By default, the {product-very-short} operator monitors these Config Maps or Secrets and refreshes the {product-very-short} Pod when changes occur.
+* For security purposes, {product} restricts the Operator Service Account's read access to Secrets. As a result, mounting files from Secrets without specifying both mountPath and key is not supported.
+====
+
+
+.Prerequisites
+* You have developer permissions to access the {ocp-short} cluster containing your {product-short} instance using the {openshift-cli}.
+* link:{installing-on-ocp-book-url}[Your {ocp-short} administrator has installed the {product} Operator in {ocp-short}].
+
+.Procedure
+
+. In {ocp-short}, author your ConfigMap or Secret custom resource in a YAML file. For more information, see link:{installing-on-ocp-book-url}#provisioning-your-custom-configuration[].
++
+.Minimal `{my-app-config-config-map}` custom resource example
+====
+[source,yaml,subs="+attributes,+quotes"]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {my-product-cr-name}
+data:
+  file11.txt: |
+    My file11 content
+  file 12.txt: |
+    My file12 content
+----
+====
++
+.Minimal `{my-product-secrets}` custom resource example
+====
+[source,yaml,subs="+attributes,+quotes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {my-product-secrets}
+StringData:
+  secret11.txt: |
+    secret-content
+----
+====
+
+. Declare the ConfigMap or Secret file in your `{product-custom-resource-type}` custom resource.
+====
+[source,yaml,subs="+attributes,+quotes"]
+----
+spec:
+  application:
+    extraFiles:
+      mountPath: /my/path
+      configMaps:
+        - name: {my-app-config-config-map}
+          key: file12.txt
+          mountPath: /my/my-rhdh-config-map/path
+      secrets:
+        - name: my-rhdh-secret
+          key: secret11.txt
+          mountPath: /my/my-rhdh-secret/path
+
+----
+====

--- a/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
+++ b/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
@@ -55,7 +55,7 @@ StringData:
 ====
 For more information, see xref:provisioning-your-custom-configuration[Provisioning and using your custom {product} configuration].
 
-. Set the value of the `configMaps name` to the name of the config map or `secrets name` to the name of the secret file in your `{product-custom-resource-type}` CR. For example:
+. Set the value of the `configMaps name` to the name of the ConfigMap or `secrets name` to the name of the Secret in your `{product-custom-resource-type}` CR. For example:
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
+++ b/modules/configuring/proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator.adoc
@@ -1,7 +1,7 @@
 [id="mounting-additional-files-in-your-custom-configuration-using-rhdh-operator"]
 = Mounting additional files in your custom configuration using the {product} operator
 
-You can use the {product-short} operator to mount extra files, such as ConfigMaps and Secrets, to the container in a preferred location.
+You can use the {product-short} Operator to mount extra files, such as config maps and secrets, to the container in a preferred location.
 
 The `mountPath` field specifies the location where a ConfigMap or Secret is mounted. The behavior of the mount, whether it includes or excludes a `subPath`, depends on the specification of the `key` or `mountPath` fields.
 
@@ -11,8 +11,8 @@ The `mountPath` field specifies the location where a ConfigMap or Secret is moun
 
 [NOTE]
 ====
-* {ocp-short} does not automatically update a volume mounted with subPath. By default, the {product-very-short} operator monitors these Config Maps or Secrets and refreshes the {product-very-short} Pod when changes occur.
-* For security purposes, {product} restricts the Operator Service Account's read access to Secrets. As a result, mounting files from Secrets without specifying both mountPath and key is not supported.
+* {ocp-short} does not automatically update a volume mounted with subPath. By default, the {product-very-short} operator monitors these ConfigMaps or Secrets and refreshes the {product-very-short} Pod when changes occur.
+* For security purposes, {product} does not give the Operator Service Account read access to Secrets. As a result, mounting files from Secrets without specifying both mountPath and key is not supported.
 ====
 
 
@@ -22,16 +22,16 @@ The `mountPath` field specifies the location where a ConfigMap or Secret is moun
 
 .Procedure
 
-. In {ocp-short}, author your ConfigMap or Secret custom resource in a YAML file. For more information, see link:{installing-on-ocp-book-url}#provisioning-your-custom-configuration[].
+. In {ocp-short}, create your config map or secret with the following YAML codes:
 +
-.Minimal `{my-app-config-config-map}` custom resource example
+.Minimal `{my-extra-file-configmap}` config map example
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {my-product-cr-name}
+  name: {my-extra-file-configmap}
 data:
   file11.txt: |
     My file11 content
@@ -40,7 +40,7 @@ data:
 ----
 ====
 +
-.Minimal `{my-product-secrets}` custom resource example
+.Minimal `{my-product-secrets}` secret example
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -53,8 +53,9 @@ StringData:
     secret-content
 ----
 ====
+For more information, see xref:provisioning-your-custom-configuration[Provisioning and using your custom {product} configuration].
 
-. Declare the ConfigMap or Secret file in your `{product-custom-resource-type}` custom resource.
+. Set the value of the `configMaps name` to the name of the config map or `secrets name` to the name of the secret file in your `{product-custom-resource-type}` CR. For example:
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -63,11 +64,11 @@ spec:
     extraFiles:
       mountPath: /my/path
       configMaps:
-        - name: {my-app-config-config-map}
+        - name: {my-extra-file-configmap}
           key: file12.txt
           mountPath: /my/my-rhdh-config-map/path
       secrets:
-        - name: my-rhdh-secret
+        - name: {my-product-secrets}
           key: secret11.txt
           mountPath: /my/my-rhdh-secret/path
 

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -34,7 +34,7 @@ With this update, you can use the `developerHub.flavor` field to identify whethe
 [source,yaml,subs=&#34;quotes&#34;]
 ----
 developerHub:
-  flavor: &lt;flavor&gt;;
+  flavor: <flavor>
 ----
 
 `flavor`::
@@ -44,8 +44,7 @@ Identify the flavor of Backstage that is running. Default value: `rhdh`
 [id="feature-rhidp-4419"]
 == Ability to manage PVCs in RHDH Operator
 
-You can now mount directories from pre-created PersistentVolumeClaims (PVCs) using the `spec.application.extraFiles.pvcs` field, while configuring RHDH Operator.
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/configuring/index#configuring-the-deployment[Persistent Volume Claim (PVC)].
+You can now mount directories from pre-created PersistentVolumeClaims (PVCs) using the `spec.application.extraFiles.pvcs` field, while configuring {product-very-short} Operator.
 
 
 [id="feature-rhidp-4805"]

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -7,7 +7,7 @@ This section highlights new features in {product} {product-version}.
 [id="enhancement-rhidp-2200"]
 == Added an individual `mountPath`
 
-This update adds an additional individual `mountPath` for extra configmaps or secrets.
+This update adds an individual `mountPath` for link:{configuring-book-url}#proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator[extra configmaps or secrets].
 
 [id="feature-rhidp-3621"]
 == `PersistentVolumeClaims` support is available

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -7,7 +7,7 @@ This section highlights new features in {product} {product-version}.
 [id="enhancement-rhidp-2200"]
 == Added an individual `mountPath`
 
-This update adds an individual `mountPath` for link:{configuring-book-url}#proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator[extra configmaps or secrets].
+This update adds an individual `mountPath` for link:{configuring-book-url}#proc-mounting-additional-files-in-your-custom-configuration-using-rhdh-operator[extra ConfigMaps or Secrets].
 
 [id="feature-rhidp-3621"]
 == `PersistentVolumeClaims` support is available

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -31,10 +31,10 @@ With this update, you can use the `developerHub.flavor` field to identify whethe
 
 .`app-config.yaml` fragment with the `developerhub.flavor` field
 
-[source,yaml,subs=&#34;quotes&#34;]
+[source,yaml,subs="+quotes"]
 ----
 developerHub:
-  flavor: <flavor>
+  flavor: &lt;flavor&gt;;
 ----
 
 `flavor`::


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.4.x, main
**Issue:** RHIDP-4780
**Preview link:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-842/configuring/#mounting-additional-files-in-your-custom-configuration-using-rhdh-operator

(This is showing the new procedure as Chapter 2, but it's supposed to be under 1.2. So, technically, as Chapter 1.2.1.. I've made the correction in the second commit but for some reason it isn't reflecting in the preview link)
