### PR TITLE
chore(migration): move from...

### DIFF
--- a/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
+++ b/modules/getting-started/proc-customize-rhdh-learning-paths.adoc
@@ -36,9 +36,9 @@ proxy:
     '/developer-hub':
       target: https://raw.githubusercontent.com/
       pathRewrite:
-        '^/api/proxy/developer-hub/learning-paths': '/janus-idp/backstage-showcase/main/packages/app/public/learning-paths/data.json'
-        '^/api/proxy/developer-hub/tech-radar': '/janus-idp/backstage-showcase/main/packages/app/public/tech-radar/data-default.json'
-        '^/api/proxy/developer-hub': '/janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json'
+        '^/api/proxy/developer-hub/learning-paths': '/redhat-developer/rhdh/main/packages/app/public/learning-paths/data.json'
+        '^/api/proxy/developer-hub/tech-radar': '/redhat-developer/rhdh/main/packages/app/public/tech-radar/data-default.json'
+        '^/api/proxy/developer-hub': '/redhat-developer/rhdh/main/packages/app/public/homepage/data.json'
       changeOrigin: true
       secure: true
 ----

--- a/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
+++ b/modules/getting-started/proc-customize-rhdh-tech-radar-page.adoc
@@ -40,8 +40,8 @@ proxy:
     '/developer-hub':
       target: <DOMAIN_URL> # i.e https://raw.githubusercontent.com/
       pathRewrite:
-        '^/api/proxy/developer-hub/tech-radar': <path to json file> # i.e /janus-idp/backstage-showcase/main/packages/app/public/tech-radar/data-default.json
-	 '^/api/proxy/developer-hub': <path to json file> # i.e /janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json
+        '^/api/proxy/developer-hub/tech-radar': <path to json file> # i.e /redhat-developer/rhdh/main/packages/app/public/tech-radar/data-default.json
+	 '^/api/proxy/developer-hub': <path to json file> # i.e /redhat-developer/rhdh/main/packages/app/public/homepage/data.json
       changeOrigin: true
       secure: true
 

--- a/modules/getting-started/proc-customizing-the-home-page-cards.adoc
+++ b/modules/getting-started/proc-customizing-the-home-page-cards.adoc
@@ -184,7 +184,7 @@ dynamicPlugins:
                 ### RHDH
                 * [Website](https://developers.redhat.com/rhdh/overview)
                 * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
-                * [GitHub Showcase](https://github.com/janus-idp/backstage-showcase)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
                 * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
         - mountPoint: home.page/cards
           importName: Markdown
@@ -202,7 +202,7 @@ dynamicPlugins:
                 ### RHDH
                 * [Website](https://developers.redhat.com/rhdh/overview)
                 * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
-                * [GitHub Showcase](https://github.com/janus-idp/backstage-showcase)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
                 * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
 ----
 --

--- a/modules/getting-started/proc-using-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc
+++ b/modules/getting-started/proc-using-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc
@@ -26,7 +26,7 @@ proxy:
     '/developer-hub':
       target: <DOMAIN_URL> # i.e https://raw.githubusercontent.com/
       pathRewrite:
-        '^/api/proxy/developer-hub': <path to json file> # i.e /janus-idp/backstage-showcase/main/packages/app/public/homepage/data.json
+        '^/api/proxy/developer-hub': <path to json file> # i.e /redhat-developer/rhdh/main/packages/app/public/homepage/data.json
       changeOrigin: true
       secure: true
       # Change to "false" in case of using self hosted cluster with a self-signed certificate

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -83,8 +83,8 @@ As the scope of the previous plugins has been updated, the dynamic plugin config
 |===
 |*RHDH 1.2 Configuration* |*RHDH 1.3 Configuration*
 
-| link:https://github.com/janus-idp/backstage-showcase/blob/1.2.x/dynamic-plugins.default.yaml[dynamic-plugins.default.yaml]
-| link:https://github.com/janus-idp/backstage-showcase/blob/release-1.3/dynamic-plugins.default.yaml[dynamic-plugins.default.yaml]
+| link:https://github.com/redhat-developer/rhdh/blob/1.2.x/dynamic-plugins.default.yaml[dynamic-plugins.default.yaml]
+| link:https://github.com/redhat-developer/rhdh/blob/release-1.3/dynamic-plugins.default.yaml[dynamic-plugins.default.yaml]
 |===
 
 .Procedure


### PR DESCRIPTION
### What does this PR do?

chore(migration): move from janus-idp/backstage-showcase to redhat-developer/rhdh and add more plugin repo links too (RHIDP-1022)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.