### PR TITLE
chore: release note updates for GKE support and other misc updates

### DIFF
--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -22,7 +22,7 @@ With this update, the following plugins, previously under the `@janus-idp` scope
 
 [cols=2,%header]
 |===
-| *RHDH 1.3 Plugin Name*
+| *RHDH 1.3 Plugin Name* 
 | *RHDH 1.4 Plugin Name*
 |`@janus-idp/backstage-plugin-acr`|`@backstage-community/plugin-acr`
 |`@janus-idp/backstage-plugin-acr`|`@backstage-community/plugin-acr`
@@ -45,7 +45,7 @@ With this update, the following plugins, previously under the `@janus-idp` scope
 The following plugins, previously under the `@backstage` scope, have now been moved to the `@backstage-community` scope:
 [cols=2,%header]
 |===
-| *RHDH 1.3 Plugin Name*
+| *RHDH 1.3 Plugin Name* 
 | *RHDH 1.4 Plugin Name*
 |`@backstage/plugin-azure-devops`|`@backstage-community/plugin-azure-devops`
 |`@backstage/plugin-azure-devops-backend`|`@backstage-community/plugin-azure-devops-backend`
@@ -64,7 +64,7 @@ Two plugins previously under the `@janus-idp` scope have moved to `@red-hat-deve
 
 [cols=2,%header]
 |===
-| *RHDH 1.3 Plugin Name*
+| *RHDH 1.3 Plugin Name* 
 | *RHDH 1.4 Plugin Name*
 
 | `@janus-idp/backstage-plugin-bulk-import`

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -7,7 +7,7 @@ This section lists breaking changes in {product} {product-version}.
 [id="removed-functionality-rhidp-4572"]
 == Updated monitoring and logging metrics
 
-Prom-client metrics have been removed and replaced with OpenTelemetry metrics. As a result, the metrics port has changed from `7007` to `9464`. Deprecated metrics have also been removed. If you had dependencies on these, ensure your prometheus queries are updated. For further information, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/{product-version}/html-single/monitoring_and_logging/index[Monitoring and logging]
+Prom-client metrics have been removed and replaced with OpenTelemetry metrics. As a result, the metrics port has changed from `7007` to `9464`. Deprecated metrics have also been removed. If you had dependencies on these, ensure your prometheus queries are updated. For further information, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/{product-version}/html-single/monitoring_and_logging/index[Monitoring and logging].
 
 
 .Additional resources

--- a/modules/release-notes/ref-release-notes-deprecated-functionalities.adoc
+++ b/modules/release-notes/ref-release-notes-deprecated-functionalities.adoc
@@ -16,7 +16,7 @@ The `./dynamic-plugins/dist/janus-idp-backstage-plugin-aap-backend-dynamic` plug
 [id="deprecated-functionality-rhidp-4913"]
 == Audit log rotation is deprecated
 
-With this update, you can evaluate your platform's log forwarding solutions to align with your security and compliance needs. Most of these solutions offer configurable options to minimize the loss of logs in the event of an outage.
+With this update, you can evaluate your platform&#39;s log forwarding solutions to align with your security and compliance needs. Most of these solutions offer configurable options to minimize the loss of logs in the event of an outage.
 
 
 .Additional resources

--- a/modules/release-notes/ref-release-notes-fixed-issues.adoc
+++ b/modules/release-notes/ref-release-notes-fixed-issues.adoc
@@ -23,18 +23,6 @@ If plugin names or configuration requirements have been changed, you may need to
 * link:https://issues.redhat.com/browse/RHIDP-4687[RHIDP-4687]
 
 
-[id="bug-fix-rhidp-5308"]
-=== notification backend and catalog backend gitlab org failing to load with MODULE_NOT_FOUND
-
-In the previous version of {product-short}, the GitLab Org catalog backend plugin (`plugin-catalog-backend-module-gitlab-org`)and the Notification backend plugin (`plugin-notifications-backend`) fail to load when configured with a `MODULE_NOT_FOUND` error.  This has been fixed by embedding the  missing dependencies in the dynamic plugins.
-
-See similar issue https://issues.redhat.com/browse/RHIDP-5319
-
-
-.Additional resources
-* link:https://issues.redhat.com/browse/RHIDP-5308[RHIDP-5308]
-
-
 [id="bug-fix-rhidp-5411"]
 === RHDH fails on table lock when deploying using RHDH Operator 1.4
 

--- a/modules/release-notes/ref-release-notes-known-issues.adoc
+++ b/modules/release-notes/ref-release-notes-known-issues.adoc
@@ -9,43 +9,16 @@ This section lists known issues in {product} {product-version}.
 
 Currently, when deploying {product-short} using the Helm Chart, two replicas cannot run on different cluster nodes. This might also affect the upgrade from 1.3 to 1.4.0 if the new pod is scheduled on a different node.
 
-Possible workarounds for the upgrade include the following actions:
-* Manually scale down the number of replicas to 0 before upgrading your Helm release. 
-* Manually remove the old {product-short} pod after upgrading the Helm release. However, this would imply some application downtime.
-* Leverage a Pod Affinity rule to force the cluster scheduler to run your {product-short} pods on the same node.
+A possible workaround for the upgrade is to manually scale down the number of replicas to 0 before upgrading your Helm release. Or manually remove the old {product-short} pod after upgrading the Helm release. However, this would imply some application downtime. You can also leverage a Pod Affinity rule to force the cluster scheduler to run your {product-short} pods on the same node.
 
 
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-5344[RHIDP-5344]
 
-[id="known-issue-rhidp-5342"]
-== [Helm] Cannot run two RHDH replicas on different nodes due to Multi-Attach errors on the dynamic plugins root PVC
-
-If you are deploying {product-short} using the Helm Chart, it is currently impossible to have 2 replicas running on different cluster nodes. This might also affect the upgrade from 1.3 to 1.4.0 if the new pod is scheduled on a different node.
-
-A possible workaround for the upgrade is to manually scale down the number of replicas to 0 before upgrading your Helm release. Or manually remove the old {product-short} pod after upgrading the Helm release. However, this would imply some application downtime.
-You can also leverage a Pod Affinity rule to force the cluster scheduler to run your {product-short} pods on the same node.
-
-
-
-.Additional resources
-* link:https://issues.redhat.com/browse/RHIDP-5342[RHIDP-5342]
-
-[id="known-issue-rhidp-4695"]
-== [Doc] OIDC refresh token behavior 
-
-When using {rhsso-brand-name} or {rhbk-brand-name} as an OIDC provider, the default access token lifespan is set to 5 minutes, which corresponds to the token refresh grace period set in {product-short}. This 5-minute grace period is the threshold used to trigger a new refresh token call. Since the token is always near expiration, frequent refresh token requests will cause performance issues.
-
-This issue will be resolved in the 1.5 release. To prevent the performance issues, increase the lifespan in the {rhsso-brand-name} or {rhbk-brand-name} server by setting *Configure &gt; Realm Settings &gt; Access Token Lifespan* to a value greater than five minutes (preferably 10 or 15 minutes).
-
-
-.Additional resources
-* link:https://issues.redhat.com/browse/RHIDP-4695[RHIDP-4695]
-
 [id="known-issue-rhidp-3396"]
 == Topology plugin permission is not displayed in the RBAC front-end UI
 
-Permissions associated only with front-end plugins do not appear in the UI because they require a backend plugin to expose the permission framework's well-known endpoint. As a workaround, you can apply these permissions by using a CSV file or directly calling the REST API of the RBAC backend plugin. Affected plugins include Topology (`topology.view.read`), Tekton (`tekton.view.read`), ArgoCD (`argocd.view.read`), and Quay (`quay.view.read`).
+Permissions associated only with front-end plugins do not appear in the UI because they require a backend plugin to expose the permission framework&#39;s well-known endpoint. As a workaround, you can apply these permissions by using a CSV file or directly calling the REST API of the RBAC backend plugin. Affected plugins include Topology (`topology.view.read`), Tekton (`tekton.view.read`), ArgoCD (`argocd.view.read`), and Quay (`quay.view.read`).
 
 
 .Additional resources

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -60,12 +60,11 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 With this update, the `backstage-plugin-catalog-backend-module-logs` is enabled and converted to a static plugin improving performance and stability. The dynamic plugin was disabled in version `1.3`.
 
 [id="feature-rhidp-5734"]
-== Google Kubernetes Engine now supported
+== {gke-brand-name} now supported
 
-Google Kubernetes Engine (Google GKE) is out of Developer Preview and is now fully supported as of RHDH 1.4. 
+{gke-brand-name} ({gke-short}) is out of Developer Preview and is now fully supported as of {product-very-short} {product-version}.
 
-See the full list of supported platforms at https://access.redhat.com/support/policy/updates/developerhub
-
+See the full list of supported platforms on the link:https://access.redhat.com/support/policy/updates/developerhub[Life Cycle page].
 
 
 

--- a/modules/release-notes/ref-release-notes-new-features.adoc
+++ b/modules/release-notes/ref-release-notes-new-features.adoc
@@ -26,10 +26,10 @@ With this update, you can use the `developerHub.flavor` field to identify whethe
 
 .`app-config.yaml` fragment with the `developerhub.flavor` field
 
-[source,yaml,subs="+quotes"]
+[source,yaml,subs=&#34;+quotes&#34;]
 ----
 developerHub:
-  flavor: <flavor>
+  flavor: &lt;flavor&gt;
 ----
 
 `flavor`::
@@ -58,6 +58,14 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 ==  The catalog backend module logs plugin is enabled
 
 With this update, the `backstage-plugin-catalog-backend-module-logs` is enabled and converted to a static plugin improving performance and stability. The dynamic plugin was disabled in version `1.3`.
+
+[id="feature-rhidp-5734"]
+== Google Kubernetes Engine now supported
+
+Google Kubernetes Engine (Google GKE) is out of Developer Preview and is now fully supported as of RHDH 1.4. 
+
+See the full list of supported platforms at https://access.redhat.com/support/policy/updates/developerhub
+
 
 
 


### PR DESCRIPTION
### What does this PR do?

chore: release note updates: 
* remove RHIDP-5308 (dupe of RHIDP-5319, affects 1.5); 
* add RHIDP-5734 for GKE support; 
* Judy's copy update for RHIDP-5344; 
* dedupe RHIDP-5342 vs RHIDP-5344; 
* temporarily remove RHIDP-4695 as it's not quite done

You can ignore whitespace changes at https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/887/files?w=1 (?w=1 suffix) so that you're not wondering about all the line ending diffs

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [x] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.