### PR TITLE
RHIDP-5494: Doc air-gapped installation using Operator

### DIFF
--- a/modules/installation/artifacts
+++ b/modules/installation/artifacts
@@ -1,1 +1,0 @@
-../../artifacts

--- a/modules/installation/proc-install-rhdh-airgapped-environment-ocp-operator.adoc
+++ b/modules/installation/proc-install-rhdh-airgapped-environment-ocp-operator.adoc
@@ -153,4 +153,10 @@ The script can take several minutes to complete as it automatically installs the
 kubectl -n rhdh-operator get pods
 ----
 
-include::../../artifacts/snip-rhdh-install-operator-next-steps.adoc[]
+.Next steps
+* Use the Operator to create a {product} instance on a supported platform. For more information, see the following documentation for the platform that you want to use:
+** link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_container_platform/assembly-install-rhdh-ocp-operator[Installing {product} on {ocp-short} with the Operator]
+** link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_amazon_elastic_kubernetes_service/proc-rhdh-deploy-eks-operator_title-install-rhdh-eks[Installing {product-short} on {eks-short} with the Operator]
+** link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_microsoft_azure_kubernetes_service/proc-rhdh-deploy-aks-operator_title-install-rhdh-aks[Installing {product-short} on {aks-short} with the Operator]
+** link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_openshift_dedicated_on_google_cloud_platform/proc-install-rhdh-osd-gcp-operator_title-install-rhdh-osd-gcp[Installing {product-short} on {gcp-short} with the Operator]
+** link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html/installing_red_hat_developer_hub_on_google_kubernetes_engine/proc-rhdh-deploy-gke-operator.adoc_title-install-rhdh-gke#proc-deploy-rhdh-instance-gke.adoc_title-install-rhdh-gke[Deploying {product-short} on {gke-short} with the Operator]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.5

**Issue:**
RHIDP-5494

**Preview:**
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-935/install-rhdh-air-gapped/#proc-install-rhdh-airgapped-environment-ocp-operator_title-install-rhdh-air-grapped
