### PR TITLE
RHIDP-5605  - Plugin installation documentation improvement for adding 'forceDownload' field

### DIFF
--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -57,7 +57,7 @@ Future versions of the {product-very-short} operator are planned to automaticall
 == Configuring the dynamic plugins cache
 You can set the following optional dynamic plugin cache parameters in your `dynamic-plugins.yaml` file:
 
-* `forceDownload`: Set to `true` to force a reinstall of the plugin, bypassing the cache. Default is `false`. For example, modify your `dynamic-plugins.yaml` file as follows:
+* `forceDownload`: Set the value to `true` to force a reinstall of the plugin, bypassing the cache. The default value is `false`. 
 
 * `pullPolicy`: this is similar to the `forceDownload` parameter and is consistent with other image container platforms. The possible settings for `pullPolicy` are:
 

--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -55,7 +55,7 @@ Future versions of the {product-very-short} operator are planned to automaticall
 ====
 
 == Configuring the dynamic plugins cache
-You can set the following optional dynamic plugin cache parameters:
+You can set the following optional dynamic plugin cache parameters in your `dynamic-plugins.yaml` file:
 
 * `forceDownload`: Set to `true` to force a reinstall of the plugin, bypassing the cache. Default is `false`. For example, modify your `dynamic-plugins.yaml` file as follows:
 

--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -58,11 +58,21 @@ Future versions of the {product-very-short} operator are planned to automaticall
 You can set the following optional dynamic plugin cache parameters:
 
 * `forceDownload`: Set to `true` to force a reinstall of the plugin, bypassing the cache. Default is `false`. For example, modify your `dynamic-plugins.yaml` file as follows:
+
+* `pullPolicy`: this is similar to the `forceDownload` parameter and is consistent with other image container platforms. The possible settings for `pullPolicy` are:
+
+** `Always`: compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
+** `IfNotPresent`: downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
 +
+[NOTE] 
+The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however,the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
+
+For example, modify your dynamic-plugins.yaml file as follows to download the remote artifact without a digest check :
+
 [source,yaml]
 ----
 plugins:
   - disabled: false
-    forceDownload: true
+    pullPolicy: Always
     package: 'oci://quay.io/example-org/example-plugin:v1.0.0!internal-backstage-plugin-example'
 ----

--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -59,7 +59,7 @@ You can set the following optional dynamic plugin cache parameters in your `dyna
 
 * `forceDownload`: Set the value to `true` to force a reinstall of the plugin, bypassing the cache. The default value is `false`. 
 
-* `pullPolicy`: this is similar to the `forceDownload` parameter and is consistent with other image container platforms. The possible settings for `pullPolicy` are:
+* `pullPolicy`: Similar to the `forceDownload` parameter and is consistent with other image container platforms. You can use one of the following values for this key:
 
 ** `Always`: compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
 ** `IfNotPresent`: downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.

--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -61,11 +61,11 @@ You can set the following optional dynamic plugin cache parameters in your `dyna
 
 * `pullPolicy`: Similar to the `forceDownload` parameter and is consistent with other image container platforms. You can use one of the following values for this key:
 
-** `Always`: compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
-** `IfNotPresent`: downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
+** `Always`: This value compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
+** `IfNotPresent`: This value downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
 +
 [NOTE] 
-The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however,the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
+The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however, the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
 
 .Example `dynamic-plugins.yaml` file configuration to download the remote artifact without a digest check:
 

--- a/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
+++ b/modules/dynamic-plugins/con-dynamic-plugins-cache.adoc
@@ -67,7 +67,7 @@ You can set the following optional dynamic plugin cache parameters in your `dyna
 [NOTE] 
 The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however,the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
 
-For example, modify your dynamic-plugins.yaml file as follows to download the remote artifact without a digest check :
+.Example `dynamic-plugins.yaml` file configuration to download the remote artifact without a digest check:
 
 [source,yaml]
 ----

--- a/modules/dynamic-plugins/con-install-dynamic-plugin-helm.adoc
+++ b/modules/dynamic-plugins/con-install-dynamic-plugin-helm.adoc
@@ -11,20 +11,20 @@ You can deploy a {product-short} instance by using a Helm chart, which is a flex
 
 To install dynamic plugins in {product-short} using Helm, add the following `global.dynamic` parameters in your Helm chart:
 
-* `plugins`: the dynamic plugins list intended for installation. By default, the list is empty. You can populate the plugins list with the following fields:
-** `package`: a package specification for the dynamic plugin package that you want to install. You can use a package for either a local or an external dynamic plugin installation. For a local installation, use a path to the local folder containing the dynamic plugin. For an external installation, use a package specification from a public NPM repository.
-** `integrity` (required for external packages): an integrity checksum in the form of `<alg>-<digest>` specific to the package. Supported algorithms include `sha256`, `sha384` and `sha512`.
-** `pluginConfig`: an optional plugin-specific `app-config` YAML fragment. See plugin configuration for more information.
+* `plugins`: The dynamic plugins list intended for installation. By default, the list is empty. You can populate the plugins list with the following fields:
+** `package`: A package specification for the dynamic plugin package that you want to install. You can use a package for either a local or an external dynamic plugin installation. For a local installation, use a path to the local folder containing the dynamic plugin. For an external installation, use a package specification from a public NPM repository.
+** `integrity` (required for external packages): An integrity checksum in the form of `<alg>-<digest>` specific to the package. Supported algorithms include `sha256`, `sha384` and `sha512`.
+** `pluginConfig`: An optional plugin-specific `app-config` YAML fragment. See plugin configuration for more information.
 ** `disabled`: disables the dynamic plugin if set to `true`. Default: `false`.
+** `forceDownload`: Set the value to `true` to force a reinstall of the plugin, bypassing the cache. The default value is `false`. 
 
-** `forceDownload`: set to `true` to force a reinstall of the plugin, bypassing the cache. Default is `false`.
-** `pullPolicy`: this is similar to the `forceDownload` parameter and is consistent with other image container platforms. The possible settings for `pullPolicy` are:
+** `pullPolicy`: Similar to the `forceDownload` parameter and is consistent with other image container platforms. You can use one of the following values for this key:
 
-*** `Always`: compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
-*** `IfNotPresent`: downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
+*** `Always`: This value compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
+*** `IfNotPresent`: This value downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
 +
 [NOTE] 
-The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however,the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
+The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however, the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
 
 * `includes`: a list of YAML files utilizing the same syntax.
 

--- a/modules/dynamic-plugins/con-install-dynamic-plugin-helm.adoc
+++ b/modules/dynamic-plugins/con-install-dynamic-plugin-helm.adoc
@@ -7,7 +7,7 @@
 [id="con-install-dynamic-plugin-helm_{context}"]
 = Installing dynamic plugins using the Helm chart
 
-You can deploy a {product-short} instance using a Helm chart, which is a flexible installation method. With the Helm chart, you can sideload dynamic plugins into your {product-short} instance without having to recompile your code or rebuild the container.
+You can deploy a {product-short} instance by using a Helm chart, which is a flexible installation method. With the Helm chart, you can sideload dynamic plugins into your {product-short} instance without having to recompile your code or rebuild the container.
 
 To install dynamic plugins in {product-short} using Helm, add the following `global.dynamic` parameters in your Helm chart:
 
@@ -16,6 +16,16 @@ To install dynamic plugins in {product-short} using Helm, add the following `glo
 ** `integrity` (required for external packages): an integrity checksum in the form of `<alg>-<digest>` specific to the package. Supported algorithms include `sha256`, `sha384` and `sha512`.
 ** `pluginConfig`: an optional plugin-specific `app-config` YAML fragment. See plugin configuration for more information.
 ** `disabled`: disables the dynamic plugin if set to `true`. Default: `false`.
+
+** `forceDownload`: set to `true` to force a reinstall of the plugin, bypassing the cache. Default is `false`.
+** `pullPolicy`: this is similar to the `forceDownload` parameter and is consistent with other image container platforms. The possible settings for `pullPolicy` are:
+
+*** `Always`: compares the image digest in the remote registry and downloads the artifact if it has changed, even if the plugin was previously downloaded.
+*** `IfNotPresent`: downloads the artifact if it is not already present in the dynamic-plugins-root folder, without checking image digests.
++
+[NOTE] 
+The `pullPolicy` setting is also applied to the NPM downloading method, although `Always` will download the remote artifact without a digest check. The existing `forceDownload` option remains functional, however,the `pullPolicy` option takes precedence. The `forceDownload` option may be deprecated in a future {product-short} release.
+
 * `includes`: a list of YAML files utilizing the same syntax.
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->
RHIDP-5605  - Plugin installation documentation improvement for adding 'forceDownload' field

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.5

**Issue:**
[RHIDP-5605](https://issues.redhat.com/browse/RHIDP-5605)

**Previews:**
[Configuring the dynamic plugins cache](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-988/configuring/#configuring-the-dynamic-plugins-cache)
[Installing dynamic plugins using the Helm chart](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-988/plugins-rhdh-install/#con-install-dynamic-plugin-helm_rhdh-installing-rhdh-plugins)