### PR TITLE
RHIDP-6550 Update URL for Ansible plug-ins docs

### DIFF
--- a/modules/dynamic-plugins/con-ansible-plugin-admin.adoc
+++ b/modules/dynamic-plugins/con-ansible-plugin-admin.adoc
@@ -3,17 +3,6 @@
 Ansible plug-ins for {product} deliver an Ansible-specific portal experience with curated learning paths,
 push-button content creation, integrated development tools, and other opinionated resources.
 
-[IMPORTANT]
-====
-The Ansible plug-ins are a Technology Preview feature only.
-
-Technology Preview features are not supported with Red Hat production service level agreements (SLAs), might not be functionally complete, and Red Hat does not recommend using them for production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-For more information on Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Scope].
-
-Additional detail on how Red Hat provides support for bundled community dynamic plugins is available on the https://access.redhat.com/policy/developerhub-support-policy[Red Hat Developer Support Policy] page.
-====
-
 To install and configure the Ansible plugins, see
-link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/installing_ansible_plug-ins_for_red_hat_developer_hub/index[_Installing Ansible plug-ins for Red Hat Developer Hub_].
+link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/installing_ansible_plug-ins_for_red_hat_developer_hub/index[_Installing Ansible plug-ins for Red Hat Developer Hub_].
 


### PR DESCRIPTION
**Version(s):**
1.4

Add the relevant labels to the Pull Request.
**Issue:**
https://issues.redhat.com/browse/RHIDP-6550

**Link to docs preview:**
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1013/plugins-rhdh-configure/#installing-ansible-plug-ins-for-red-hat-developer-hub

**Reviews:**
- [ ] SME: @ mention assignee
- [ ] QE: @ mention assignee
- [ ] Docs review: @Gerry-Forde
<!--- SME approval is required to merge a PR unless the changes are made by a subject matter expert. --->
<!--- QE approval is required to merge a PR unless there are no technical changes to the content. --->
<!--- Docs team approval is required for ALL PRs. --->

**Additional information:**
* Update the link to the AAP docs for the Ansible plug-ins.
* Remove the tech preview status for the Ansible plug-ins.
