### PR TITLE
RHIDP-6845: Move dangerouslyAllowSignInWithoutUserInCatalog from Deprecated to Breaking changes section

### DIFF
--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -9,7 +9,7 @@ This section lists breaking changes in {product} {product-version}.
 
 Previously, configuring the sign-in resolver to bypass user provisioning in the {product-short} software catalog required setting `dangerouslyAllowSignInWithoutUserInCatalog: true` at the root of the `{my-app-config-file}` file.
 
-In this release, this configuration has been removed at the root level and moved to the resolver configuration section. It now applies specifically to that resolver. For more details, see link:{authentication-book-url}[{authentication-book-title}].
+In this release, the previous root level configuration has been moved to the resolver level. For more details, see link:{authentication-book-url}[{authentication-book-title}].
 
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-5958[RHIDP-5958]

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -4,6 +4,15 @@
 
 This section lists breaking changes in {product} {product-version}.
 
+[id="deprecated-functionality-rhidp-5958"]
+== Change in sign-in resolver configuration location
+
+Previously, configuring the sign-in resolver to bypass user provisioning in the {product-short} software catalog required setting `dangerouslyAllowSignInWithoutUserInCatalog: true` at the root of the `{my-app-config-file}` file.
+
+In this release, this configuration has been deprecated at the root level and moved to the resolver configuration section. It now applies specifically to that resolver. For more details, see link:{authentication-book-url}[{authentication-book-title}].
+
+.Additional resources
+* link:https://issues.redhat.com/browse/RHIDP-5958[RHIDP-5958]
 
 [id="breaking-change-rhidp-5812"]
 == The `scopes` parameter is now required for GitLab project deploy token creation

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -4,7 +4,7 @@
 
 This section lists breaking changes in {product} {product-version}.
 
-[id="deprecated-functionality-rhidp-5958"]
+[id="breaking-change-rhidp-5958"]
 == Change in sign-in resolver configuration location
 
 Previously, configuring the sign-in resolver to bypass user provisioning in the {product-short} software catalog required setting `dangerouslyAllowSignInWithoutUserInCatalog: true` at the root of the `{my-app-config-file}` file.

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -9,7 +9,7 @@ This section lists breaking changes in {product} {product-version}.
 
 Previously, configuring the sign-in resolver to bypass user provisioning in the {product-short} software catalog required setting `dangerouslyAllowSignInWithoutUserInCatalog: true` at the root of the `{my-app-config-file}` file.
 
-In this release, this configuration has been deprecated at the root level and moved to the resolver configuration section. It now applies specifically to that resolver. For more details, see link:{authentication-book-url}[{authentication-book-title}].
+In this release, this configuration has been removed at the root level and moved to the resolver configuration section. It now applies specifically to that resolver. For more details, see link:{authentication-book-url}[{authentication-book-title}].
 
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-5958[RHIDP-5958]

--- a/modules/release-notes/ref-release-notes-deprecated-functionalities.adoc
+++ b/modules/release-notes/ref-release-notes-deprecated-functionalities.adoc
@@ -31,16 +31,6 @@ The ArgoCD front-end plugin from RoadieHQ has been deprecated and will be remove
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-2028[RHIDP-2028]
 
-[id="deprecated-functionality-rhidp-5958"]
-== Change in sign-in resolver configuration location
-
-Previously, configuring the sign-in resolver to bypass user provisioning in the {product-short} software catalog required setting `dangerouslyAllowSignInWithoutUserInCatalog: true` at the root of the `{my-app-config-file}` file.
-
-In this release, this configuration has been deprecated at the root level and moved to the resolver configuration section. It now applies specifically to that resolver. For more details, see link:{authentication-book-url}[{authentication-book-title}].
-
-.Additional resources
-* link:https://issues.redhat.com/browse/RHIDP-5958[RHIDP-5958]
-
 [id="deprecated-functionality-rhidp-6013"]
 == Deprecation of legacy dynamic plugin configurations and export options
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.5.x
**Issue:**
[RHIDP-6845](https://issues.redhat.com/browse/RHIDP-6845)
**Preview:**
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1053/rel-notes-rhdh/#breaking-change-rhidp-5958
