### PR TITLE
RHDHBUGS-232: Changes to RHDH 1.5 release notes

### DIFF
--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -23,9 +23,9 @@ The `scopes` parameter is now mandatory for the `gitlab:projectDeployToken:creat
 * link:https://issues.redhat.com/browse/RHIDP-5812[RHIDP-5812]
 
 [id="breaking-change-rhidp-5568"]
-== The `dynamicPlugins.cache.volumeClaimSpec` field is removed from the Helm Chart, dynamic plugin storage is now ephemeral
+== The `dynamicPlugins.cache.volumeClaimSpec` field is removed from the Helm Chart, dynamic plugin storage is now ephemeral by default
 
-The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making all dynamic plugin storage ephemeral by default. Instead of the Helm chart managing persistent volume claim (PVC) creation, you must now manually configure ephemeral volume claims under `extraVolumes`.
+The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making dynamic plugin storage ephemeral by default using `emptyDir: {}`. Persistent plugin caching remains fully supported, and you must now manually configure `PersistentVolumeClaim` and mount it using the `extraVolumes` and `extraVolumeMounts` fields in the Helm chart values.
 
 This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts.
 

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -27,7 +27,7 @@ The `scopes` parameter is now mandatory for the `gitlab:projectDeployToken:creat
 
 The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making dynamic plugin storage ephemeral by default. If you want to enable plugin caching persistence, you must now manually configure a `PersistentVolumeClaim` and mount it using the `extraVolumes` and `extraVolumeMounts` fields in the Helm chart values.
 
-This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts. For more details, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/configuring_red_hat_developer_hub/index#creating-a-pvc-for-the-dynamic-plugin-cache-using-the-helm-chart[Creating a PVC for the dynamic plugin cache using the Helm Chart].
+This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/configuring_red_hat_developer_hub/index#creating-a-pvc-for-the-dynamic-plugin-cache-using-the-helm-chart[Creating a PVC for the dynamic plugin cache using the Helm Chart].
 
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-5568[RHIDP-5568]

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -25,7 +25,7 @@ The `scopes` parameter is now mandatory for the `gitlab:projectDeployToken:creat
 [id="breaking-change-rhidp-5568"]
 == The `dynamicPlugins.cache.volumeClaimSpec` field is removed from the Helm Chart, dynamic plugin storage is now ephemeral by default
 
-The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making dynamic plugin storage ephemeral by default using `emptyDir: {}`. Persistent plugin caching remains fully supported, and you must now manually configure `PersistentVolumeClaim` and mount it using the `extraVolumes` and `extraVolumeMounts` fields in the Helm chart values.
+The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making dynamic plugin storage ephemeral by default. If you want to enable plugin caching persistence, you must now manually configure a `PersistentVolumeClaim` and mount it using the `extraVolumes` and `extraVolumeMounts` fields in the Helm chart values.
 
 This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts.
 

--- a/modules/release-notes/ref-release-notes-breaking-changes.adoc
+++ b/modules/release-notes/ref-release-notes-breaking-changes.adoc
@@ -27,7 +27,7 @@ The `scopes` parameter is now mandatory for the `gitlab:projectDeployToken:creat
 
 The `dynamicPlugins.cache.volumeClaimSpec` field has been removed from `values.yaml`, making dynamic plugin storage ephemeral by default. If you want to enable plugin caching persistence, you must now manually configure a `PersistentVolumeClaim` and mount it using the `extraVolumes` and `extraVolumeMounts` fields in the Helm chart values.
 
-This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts.
+This change also resolves issues with running multi-replica {product-very-short} deployments, as using a PVC for the Dynamic Plugins cache previously led to potential write conflicts. For more details, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.5/html-single/configuring_red_hat_developer_hub/index#creating-a-pvc-for-the-dynamic-plugin-cache-using-the-helm-chart[Creating a PVC for the dynamic plugin cache using the Helm Chart].
 
 .Additional resources
 * link:https://issues.redhat.com/browse/RHIDP-5568[RHIDP-5568]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.5
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-232
<!--- Add a link to the Jira issue. --->
**Preview:** [2.3. The dynamicPlugins.cache.volumeClaimSpec field is removed from the Helm Chart, dynamic plugin storage is now ephemeral by default](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1078/rel-notes-rhdh/#breaking-change-rhidp-5568)
<!--- Add a link to the preview of the changed file(s). --->
