### PR TITLE
RHIDP-6571 - remove configuring the base URL for Operator-based

### DIFF
--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -25,7 +25,7 @@ This is the main {product-short} configuration file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
-The base URL is be what the user see in their browser when accessing {product-short}.
+The base URL is what the user sees in their browser when accessing {product-short}.
 The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backend.cors` subsection:
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -22,6 +22,7 @@ It contains one secret per line in `KEY=value` form.
 This is the main {product-short} configuration file.
 
 ** To prepare a deployment with the {product} Operator on OpenShift, you can start with an empty file.
+Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 Specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -21,7 +21,7 @@ It contains one secret per line in `KEY=value` form.
 . Author your custom `{my-app-config-file}` file.
 This is the main {product-short} configuration file.
 
-** To prepare a deployment with the {product} Operator, you can start with an empty file.
+** To prepare a deployment with the {product} Operator on OpenShift, you can start with an empty file.
 
 ** To prepare a deployment with the {product} Helm chart, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 Specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -21,7 +21,7 @@ It contains one secret per line in `KEY=value` form.
 . Author your custom `{my-app-config-file}` file.
 This is the main {product-short} configuration file.
 
-** To prepare a deployment with the {product} Operator on OpenShift, you can start with an empty file.
+** To prepare a deployment with the {product} Operator on {ocp-short}, you can start with an empty file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields your `{my-app-config-file}` file to ensure proper functionality of {product-short}.

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -20,6 +20,8 @@ It contains one secret per line in `KEY=value` form.
 
 . Author your custom `{my-app-config-file}` file.
 This is the main {product-short} configuration file.
+You need a custom `{my-app-config-file}` file to avoid the {product-short} installer to revert user edits during upgrades.
+When your custom `{my-app-config-file}` file is empty, {product-short} is using default values.
 
 ** To prepare a deployment with the {product} Operator on {ocp-short}, you can start with an empty file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -20,8 +20,11 @@ It contains one secret per line in `KEY=value` form.
 
 . Author your custom `{my-app-config-file}` file.
 This is the main {product-short} configuration file.
-+
-The `baseUrl` field is mandatory in your `{my-app-config-file}` file to ensure proper functionality of {product-short}. You must specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.
+
+** To prepare a deployment with the {product} Operator, you can start with an empty file.
+
+** To prepare a deployment with the {product} Helm chart, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
+Specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`
 ====
@@ -43,13 +46,13 @@ backend:
     origin: {my-product-url}
 ----
 ====
-+
-Optionally, enter your configuration such as:
 
-* link:{authentication-book-url}[{authentication-book-title}].
-* link:{authorization-book-url}[{authorization-book-title}].
-* link:{customizing-book-url}[Customization].
-* xref:proc-configuring-an-rhdh-instance-with-tls-in-kubernetes_running-behind-a-proxy[Configure your {ocp-short} integration].
+** Optionally, enter your configuration such as:
+
+*** link:{authentication-book-url}[{authentication-book-title}].
+*** link:{authorization-book-url}[{authorization-book-title}].
+*** link:{customizing-book-url}[Customization].
+*** xref:proc-configuring-an-rhdh-instance-with-tls-in-kubernetes_running-behind-a-proxy[Configure your {ocp-short} integration].
 
 . Provision your custom configuration files to your {ocp-short} cluster.
 

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -26,7 +26,7 @@ Creating a custom file, even an empty one, is required to avoid the {product} Op
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 The base URL is what the user sees in their browser when accessing {product-short}.
-The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backend.cors` subsection:
+The relevant fields are `baseUrl` in the `app` and `backend` sections, and `origin` in the `backend.cors` subsection:
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`
 ====

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -23,7 +23,7 @@ This is the main {product-short} configuration file.
 
 ** To prepare a deployment with the {product} Operator on OpenShift, you can start with an empty file.
 
-** To prepare a deployment with the {product} Helm chart, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
+** To prepare a deployment with the {product} Helm chart, or on Kubernetes, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 Specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -24,7 +24,6 @@ You need a custom `{my-app-config-file}` file to avoid the {product-short} insta
 When your custom `{my-app-config-file}` file is empty, {product-short} is using default values.
 
 ** To prepare a deployment with the {product} Operator on {ocp-short}, you can start with an empty file.
-Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 The base URL is what the user sees in their browser when accessing {product-short}.

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -24,8 +24,8 @@ This is the main {product-short} configuration file.
 ** To prepare a deployment with the {product} Operator on OpenShift, you can start with an empty file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
-** To prepare a deployment with the {product} Helm chart, or on Kubernetes, add the `baseUrl` field in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
-Specify the `baseUrl` in both the `app` and `backend` sections to avoid errors during initialization.
+** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
+The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backernd.cors` subsection:
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`
 ====

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -24,7 +24,7 @@ This is the main {product-short} configuration file.
 ** To prepare a deployment with the {product} Operator on {ocp-short}, you can start with an empty file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
-** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
+** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
 The base URL is be what the user see in their browser when accessing {product-short}.
 The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backend.cors` subsection:
 +

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -25,7 +25,8 @@ This is the main {product-short} configuration file.
 Creating a custom file, even an empty one, is required to avoid the {product} Operator to revert user edits during upgrades.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
-The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backernd.cors` subsection:
+The base URL is be what the user see in their browser when accessing {product-short}.
+The relevant fields are `baseUrl` in the `app` and `backend` section, and `origin` in the `backend.cors` subsection:
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`
 ====

--- a/modules/configuring/proc-provisioning-your-custom-configuration.adoc
+++ b/modules/configuring/proc-provisioning-your-custom-configuration.adoc
@@ -26,7 +26,7 @@ When your custom `{my-app-config-file}` file is empty, {product-short} is using 
 ** To prepare a deployment with the {product} Operator on {ocp-short}, you can start with an empty file.
 
 ** To prepare a deployment with the {product} Helm chart, or on Kubernetes, enter the {product-short} base URL in the relevant fields in your `{my-app-config-file}` file to ensure proper functionality of {product-short}.
-The base URL is what the user sees in their browser when accessing {product-short}.
+The base URL is what a {product-short} user sees in their browser when accessing {product-short}.
 The relevant fields are `baseUrl` in the `app` and `backend` sections, and `origin` in the `backend.cors` subsection:
 +
 .Configuring the `baseUrl` in `{my-app-config-file}`


### PR DESCRIPTION
on Operator-based deployments configuring the base URL is no longer required

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 

/cherry-pick release-1.6
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** 

https://issues.redhat.com/browse/RHIDP-6571
https://issues.redhat.com/browse/RHIDP-6174
https://issues.redhat.com/browse/RHIDP-6670

<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
