### PR TITLE
RHIDP-6882 - RHBK authentication: sub claim OIDC resolver is default

### DIFF
--- a/modules/authentication/proc-enabling-authentication-with-rhbk.adoc
+++ b/modules/authentication/proc-enabling-authentication-with-rhbk.adoc
@@ -147,7 +147,9 @@ auth:
 
 `signIn`::
 `resolvers`:::
-After successful authentication, the user signing in must be resolved to an existing user in the {product-short} catalog. To best match users securely for your use case, consider configuring a specific resolver. Enter the resolver list to override the default resolver: `emailLocalPartMatchingUserEntityName`.
+After successful authentication, the user signing in must be resolved to an existing user in the {product-short} catalog.
+To best match users securely for your use case, consider configuring a specific resolver.
+Enter the resolver list to override the default resolver: `oidcSubClaimMatchingKeycloakUserId`.
 +
 The authentication provider tries each sign-in resolver in order until it succeeds, and fails if none succeed.
 +
@@ -156,10 +158,11 @@ WARNING: In production mode, only configure one resolver to ensure users are sec
 `resolver`::::
 Enter the sign-in resolver name.
 Available values:
+* `oidcSubClaimMatchingKeycloakUserId`
 * `emailLocalPartMatchingUserEntityName`
 * `emailMatchingUserEntityProfileEmail`
 * `preferredUsernameMatchingUserEntityName`
-
++
 .`{my-app-config-file}` fragment with optional `resolvers` list
 [source,yaml]
 ----
@@ -169,6 +172,7 @@ auth:
       production:
         signIn:
           resolvers:
+            - resolver: oidcSubClaimMatchingKeycloakUserId
             - resolver: preferredUsernameMatchingUserEntityName
             - resolver: emailMatchingUserEntityProfileEmail
             - resolver: emailLocalPartMatchingUserEntityName
@@ -192,7 +196,7 @@ auth:
         clientSecret: ${AUTH_OIDC_CLIENT_SECRET}
         signIn:
           resolvers:
-            - resolver: emailLocalPartMatchingUserEntityName
+            - resolver: oidcSubClaimMatchingKeycloakUserID
               dangerouslyAllowSignInWithoutUserInCatalog: true
 signInPage: oidc
 ----


### PR DESCRIPTION
RHBK authentication: sub claim OIDC resolver is default

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** release-1.6

**Issue:**  https://issues.redhat.com/browse/RHIDP-6882

**Preview:**

