### PR TITLE
RHIDP-6575-1 - Promote RHDH-local to Dev preview status in RHDH Docs

### DIFF
--- a/modules/release-notes/ref-release-notes-developer-preview.adoc
+++ b/modules/release-notes/ref-release-notes-developer-preview.adoc
@@ -1,0 +1,22 @@
+:_content-type: REFERENCE
+[id="developer-preview"]
+= Developer Preview
+
+This section lists Developer Preview features in {product} {product-version}.
+
+[IMPORTANT]
+====
+Developer Preview features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to functionality in advance of possible inclusion in a Red Hat product offering. Customers can use these features to test functionality and provide feedback during the development process. Developer Preview features might not have any documentation, are subject to change or removal at any time, and have received limited testing. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.
+
+For more information about the support scope of Red Hat Developer Preview features, see https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+====
+
+[id="developer-preview-rhdhpai-510"]
+== {product-local}
+
+{product-local} ({product-local-very-short}) is now available as a Developer Preview feature, providing a lightweight, self-contained version of {product-very-short} that allows developers and platform engineers to work on templates, try out plugins, validate software catalogs, and do other tasks without having to install {product-short} on a Kubernetes cluster.
+
+For more information about installing {product-local-very-short}, see link:https://github.com/redhat-developer/rhdh-local[{product-local} on Github].
+
+.Additional resources
+* For more information, see the blog post, link:https://developers.redhat.com/blog/2025/03/31/run-red-hat-developer-hub-locally-ease[Run Red Hat Developer Hub Locally with Ease]

--- a/titles/rel-notes-rhdh/title-rhdh-release-notes.adoc
+++ b/titles/rel-notes-rhdh/title-rhdh-release-notes.adoc
@@ -20,6 +20,7 @@ include::modules/release-notes/ref-release-notes-deprecated-functionalities.adoc
 
 include::modules/release-notes/ref-release-notes-technology-preview.adoc[leveloffset=+1]
 
+include::modules/release-notes/ref-release-notes-developer-preview.adoc[leveloffset=+1]
 
 include::modules/release-notes/ref-release-notes-fixed-issues.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

This is a clone of [PR-1097](https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/1097/files#diff-e3a7e67aecf3b2297b7a0e8c8f5865dbc966dbef92244be175f21876c05bc4e9) which was previously reviewed, approved and merged. It turns out the RNs script does not handle Developer Preview type, so we've had to manually reinstate this section that was previously removed in PR-1097.

**Version(s):**
1.6, main

**Issue:**
RHIDP-6575

**Preview:**
[Developer Preview: RHDH Local](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1141/rel-notes-rhdh/#developer-preview)
