### PR TITLE
chore: add developer-preview.adoc as a...

### DIFF
--- a/modules/release-notes/single-source-release-notes.jira2asciidoc.yml
+++ b/modules/release-notes/single-source-release-notes.jira2asciidoc.yml
@@ -61,7 +61,28 @@ sections:
       AND "Release Note Status" = "Done"
       AND level is EMPTY
       AND status in (Closed, "Release Pending")
-      AND "Release Note Type" in ("Developer Preview", "Technology Preview")
+      AND "Release Note Type" in ("Technology Preview")
+      AND fixVersion >= "{version_minor}"
+      AND fixVersion <= "{version_patch}"
+      ORDER BY key
+    template: with-jira-link
+  - id: developer-preview
+    title: Developer Preview
+    description: |
+      This section lists Developer Preview features in {product} {product-version}.
+
+      [IMPORTANT]
+      ====
+      Developer Preview features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to functionality in advance of possible inclusion in a Red Hat product offering. Customers can use these features to test functionality and provide feedback during the development process. Developer Preview features might not have any documentation, are subject to change or removal at any time, and have received limited testing. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.
+
+      For more information about the support scope of Red Hat Developer Preview features, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+      ====
+    query: >
+      project = "Red Hat Internal Developer Platform"
+      AND "Release Note Status" = "Done"
+      AND level is EMPTY
+      AND status in (Closed, "Release Pending")
+      AND "Release Note Type" in ("Developer Preview")
       AND fixVersion >= "{version_minor}"
       AND fixVersion <= "{version_patch}"
       ORDER BY key
@@ -69,7 +90,7 @@ sections:
   - id: fixed-issues
     title: Fixed issues
     description: |
-      This section lists issues fixed in {product} {product-version} that have a significant impact on users.
+      This section lists issues fixed in {product} {product-version}.
     query: >
       project = "Red Hat Internal Developer Platform"
       AND "Release Note Status" = "Done"


### PR DESCRIPTION
### What does this PR do?

chore: add developer-preview.adoc as a separate query and template than ref-release-notes-technology-preview.adoc (RHIDP-6000, RHIDP-6749)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.