### PR TITLE
chore: fix list of enabled-by-default plugins in 1.5 (missing GA global-floating-action-button and 3 TP marketplace plugins)

### DIFF
--- a/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.adoc
+++ b/modules/dynamic-plugins/con-preinstalled-dynamic-plugins.adoc
@@ -2,7 +2,7 @@
 
 = Preinstalled dynamic plugins
 
-{product} is preinstalled with a selection of dynamic plugins. 
+{product} is preinstalled with a selection of dynamic plugins.
 //For a complete list of dynamic plugins that are included in this release of {product-short}, see the xref:rhdh-supported-plugins[Dynamic plugins support matrix].
 
 The following preinstalled dynamic plugins are enabled by default:
@@ -14,7 +14,11 @@ The following preinstalled dynamic plugins are enabled by default:
 * `@backstage/plugin-techdocs-module-addons-contrib`
 * `@backstage/plugin-techdocs`
 * `@red-hat-developer-hub/backstage-plugin-dynamic-home-page`
+* `@red-hat-developer-hub/backstage-plugin-global-floating-action-button`
 * `@red-hat-developer-hub/backstage-plugin-global-header`
+* `@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace`
+* `@red-hat-developer-hub/backstage-plugin-marketplace-backend`
+* `@red-hat-developer-hub/backstage-plugin-marketplace`
 
 The dynamic plugins that require custom configuration are disabled by default.
 


### PR DESCRIPTION
### What does this PR do?

chore: fix list of enabled-by-default plugins in 1.5 (missing GA global-floating-action-button and 3 TP marketplace plugins)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.