### PR TITLE
RHIDP-7455: Adding ArgoCD and Quay permissions

### DIFF
--- a/modules/authorization/ref-rbac-permission-policies.adoc
+++ b/modules/authorization/ref-rbac-permission-policies.adoc
@@ -293,3 +293,37 @@ Tekton permissions::
 |`use`
 |Allows a user or role to access the proxy endpoint, allowing the user or role to read pod logs and events within {product-very-short}
 |===
+
+
+ArgoCD permissions::
+
+.ArgoCD permissions
+[cols="15%,25%,15%,45%", frame="all", options="header"]
+|===
+|Name
+|Resource type
+|Policy
+|Description
+
+|`argocd.view.read`
+|
+|`read`
+|Allows a user to view the ArgoCD plugin
+|===
+
+
+Quay permissions::
+
+.Quay permissions
+[cols="15%,25%,15%,45%", frame="all", options="header"]
+|===
+|Name
+|Resource type
+|Policy
+|Description
+
+|`quay.view.read`
+|
+|`read`
+|Allows a user to view the Quay plugin
+|===


### PR DESCRIPTION
Added ArgoCD and Quay permissions from the upstream permission policies doc: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac-backend/docs/permissions.md?plain=1#L138-L148 to downstream.

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.6 (technically 1.6.1)
**Issue:**
[RHIDP-7455](https://issues.redhat.com/browse/RHIDP-7455)
**Preview:**