### PR TITLE
RHDHBUGS-2055: Incorrect configuration for orchestrator plugins in operator upstream and downstream docs

### DIFF
--- a/modules/orchestrator/proc-enable-orchestrator-plugin.adoc
+++ b/modules/orchestrator/proc-enable-orchestrator-plugin.adoc
@@ -27,20 +27,45 @@ kind: ConfigMap
 metadata:
   name: orchestrator-plugin
 data:
-  dynamic-plugins.yaml: |
-    includes:
-      - dynamic-plugins.default.yaml
-    plugins:
-      - package: "@redhat/backstage-plugin-orchestrator@1.6.0"
-        disabled: false
-      - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.0"
-        disabled: false
-        dependencies:
-          - ref: sonataflow
-      - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.0"
-        disabled: false
-      - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.6.0"
-        disabled: false
+    dynamic-plugins.yaml: |
+      includes:
+        - dynamic-plugins.default.yaml
+      plugins:
+        - package: "@redhat/backstage-plugin-orchestrator@1.7.1"
+          disabled: false
+          pluginConfig:
+            dynamicPlugins:
+                frontend:
+                  red-hat-developer-hub.backstage-plugin-orchestrator:
+                    appIcons:
+                      - importName: OrchestratorIcon
+                        name: orchestratorIcon
+                    dynamicRoutes:
+                      - importName: OrchestratorPage
+                        menuItem:
+                          icon: orchestratorIcon
+                          text: Orchestrator
+                        path: /orchestrator
+        - package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.7.1"
+          disabled: false
+          pluginConfig:
+            orchestrator:
+              dataIndexService:
+                url: http://sonataflow-platform-data-index-service
+          dependencies:
+            - ref: sonataflow
+        - package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.7.1"
+          disabled: false
+          pluginConfig:
+            orchestrator:
+              dataIndexService:
+                url: http://sonataflow-platform-data-index-service
+        - package: "@redhat/backstage-plugin-orchestrator-form-widgets@1.7.1"
+          disabled: false
+          pluginConfig:
+            dynamicPlugins:
+              frontend:
+                red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: { }
 ---
 apiVersion: rhdh.redhat.com/v1alpha3
 kind: Backstage


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.7, main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHDHBUGS-2055](https://issues.redhat.com/browse/RHDHBUGS-2055)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[2.1. Enabling the Orchestrator plugin using Operator](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-1394/orchestrator/#proc-enable-orchestrator-plugin_install-rhdh-orchestrator)
