### PR TITLE
Fix PR preview comment duplication

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -130,20 +130,38 @@ jobs:
           keep_files: true
           publish_dir: ./pr-content/titles-generated
 
-      - name: PR comment with doc preview, replacing existing comments with a new one each time
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
-        run: |
-          PR_NUM="${{ github.event.number }}"
-          ORG_REPO="${{ github.repository_owner }}/${{ github.event.repository.name }}"
-          cd pr-content
-          gh repo set-default "${ORG_REPO}"
-          # for a given PR, check for existing comments from rhdh-bot; select the last one (if more than one)
-          if [[ $(gh api "repos/${ORG_REPO}/issues/${PR_NUM}/comments" -q 'map(select(.user.login=="rhdh-bot"))|last|.id') ]]; then 
-            # edit that comment:
-            gh pr comment ${PR_NUM} -R "${ORG_REPO}" --edit-last --body "Updated preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/ @ $(date "+%x %X")"
-          else
-            # or create a new one:
-            gh pr comment ${PR_NUM} -R "${ORG_REPO}" --body "Preview: https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${PR_NUM}/"
-          fi
+      - name: Post or update PR comment with doc preview link
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RHDH_BOT_TOKEN }}
+          script: |
+            const prNum = context.issue.number;
+            const previewUrl = `https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${prNum}/`;
+            const now = new Date().toLocaleString('en-US', { timeZone: 'UTC' });
+            const body = `Updated preview: ${previewUrl} @ ${now}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+            });
+
+            const existing = comments.find(c =>
+              c.body.includes('preview: https://redhat-developer.github.io/')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNum,
+                body: body
+              });
+            }


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** N/A (CI workflow)
**Issue:** N/A
**Preview:** N/A

## Summary

- Replace shell-based PR preview comment logic with `actions/github-script` that finds existing comments by body content instead of user login
- Ensures the preview comment is updated on each push rather than creating a new one every time

## Test plan

- [ ] Verify only one preview comment exists per PR after multiple pushes
- [ ] Verify the comment body is updated with the latest timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)