### PR TITLE
[RHDHBUGS-2905]: Source trusted build scripts from main for backport compatibility

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -86,10 +86,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout base branch to get trusted build script
+      - name: Checkout main branch to get trusted build scripts
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: main
           path: trusted-scripts
 
       - name: Checkout PR branch for content to build


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** all
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-2905
**Preview:** N/A

## Summary

- Source trusted build scripts from `main` instead of the PR base branch in the PR preview workflow
- Fixes backport PR builds that fail because release branches lack newer build scripts (`build-orchestrator.js`, `error-patterns.json`, `lychee.toml`)
- Aligns `pr.yml` with the existing pattern used by `content-quality-assessment.yml`

## Test plan

- [ ] PR preview build succeeds for PRs targeting `main`
- [ ] PR preview build succeeds for backport PRs targeting release branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>