### PR TITLE
[RHIDP-12466]: Add release notes link to GitHub Pages preview index

### DIFF
--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -26,6 +26,7 @@ const EXCLUDED_TITLES = /rhdh-plugins-reference/;
 const CCUTIL_IMAGE = 'quay.io/ivanhorvath/ccutil:amazing';
 const LYCHEE_VERSION = 'v0.23.0';
 const PAGES_BASE = 'https://redhat-developer.github.io/red-hat-developers-documentation-rhdh';
+const RELEASE_NOTES_BASE = 'https://red-hat-developers-documentation.pages.redhat.com/red-hat-developer-hub-release-notes';
 const SAFE_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
 
 // ── Argument parsing ─────────────────────────────────────────────────────────
@@ -384,6 +385,15 @@ async function traceUrlToSource(url, repoRoot) {
 
 // ── Index HTML generation ────────────────────────────────────────────────────
 
+function getReleaseNotesLink(branch) {
+  if (branch === 'main') return `${RELEASE_NOTES_BASE}/main/index.html`;
+  const match = branch.match(/^release-(\d+)\.(\d+)$/);
+  if (match && (Number(match[1]) > 1 || Number(match[2]) >= 9)) {
+    return `${RELEASE_NOTES_BASE}/release-${match[1]}-${match[2]}/index.html`;
+  }
+  return null;
+}
+
 function generateBranchIndex(branch, results, repoRoot) {
   const indexDir = join(repoRoot, 'titles-generated', branch);
   mkdirSync(indexDir, { recursive: true });
@@ -393,7 +403,12 @@ function generateBranchIndex(branch, results, repoRoot) {
     `<li><a href="./${r.title}">${r.title}</a></li>`
   ).join('\n');
 
-  const html = `<html><head><title>Red Hat Developer Hub Documentation Preview - ${branch}</title></head><body><ul>\n${links}\n</ul></body></html>`;
+  const rnUrl = getReleaseNotesLink(branch);
+  const rnSection = rnUrl
+    ? `\n<hr>\n<ul>\n<li><a href="${rnUrl}">Release Notes (external)</a></li>\n</ul>`
+    : '';
+
+  const html = `<html><head><title>Red Hat Developer Hub Documentation Preview - ${branch}</title></head><body><ul>\n${links}\n</ul>${rnSection}</body></html>`;
   writeFileSync(join(indexDir, 'index.html'), html);
 }
 


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** All (build tooling)
**Issue:** https://issues.redhat.com/browse/RHIDP-12466
**Preview:** N/A (build script change, no content preview)

## Summary

- Adds an external "Release Notes" link to the GitHub Pages preview index pages
- Link appears for `main` and `release-X.Y` branches (>= 1.9), pointing to the GitLab Pages release notes deployment
- No link appears for PR preview pages
- No content is copied or mirrored — only a link is added to the HTML index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>