### PR TITLE
[RHDHBUGS-413]: Fix incorrect auth provider resolvers for GitHub

### DIFF
--- a/modules/shared/snip-enabling-user-authentication-with-github-optional-authentication-provider-steps.adoc
+++ b/modules/shared/snip-enabling-user-authentication-with-github-optional-authentication-provider-steps.adoc
@@ -47,7 +47,7 @@ Enter the sign-in resolver name.
 Available resolvers:
 
 * `usernameMatchingUserEntityName`
-* `preferredUsernameMatchingUserEntityName`
+* `emailLocalPartMatchingUserEntityName`
 * `emailMatchingUserEntityProfileEmail`
 
 `dangerouslyAllowSignInWithoutUserInCatalog`::::
@@ -55,5 +55,5 @@ Enter `true` to configure the sign-in resolver to bypass the user provisioning r
 +
 [WARNING]
 ====
-In production more, do not enable `dangerouslyAllowSignInWithoutUserInCatalog`.
+In production mode, do not enable `dangerouslyAllowSignInWithoutUserInCatalog`.
 ====


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** All (1.5+)
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-413
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2038/control-access_authentication-in-rhdh/

## Summary

- Remove `preferredUsernameMatchingUserEntityName` from GitHub available resolvers (not supported for GitHub, only for Keycloak/OIDC)
- Add `emailLocalPartMatchingUserEntityName` to GitHub available resolvers (supported via `commonSignInResolvers` but was undocumented)
- Fix typo "production more" -> "production mode"

Microsoft resolver docs are already correct on main (default `userIdMatchingUserEntityAnnotation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>