### PR TITLE
[RHDHBUGS-2777]: Fix typo connexion -> connection in LDAP docs

### DIFF
--- a/modules/shared/proc-enable-user-provisioning-with-ldap.adoc
+++ b/modules/shared/proc-enable-user-provisioning-with-ldap.adoc
@@ -21,12 +21,12 @@ LDAP secret::
 Your LDAP secret.
 
 Recommended: LDAP certificates and keys::
-To use a secure LDAP connexion (`ldaps://`):
+To use a secure LDAP connection (`ldaps://`):
 you stored your LDAP certificates in the `ldap_certs.pem` file and your LDAP keys in the `ldap_keys.pem` file.
 +
 [WARNING]
 ====
-In production mode, use a secure LDAP connexion.
+In production mode, use a secure LDAP connection.
 ====
 
 .Procedure


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.8, 1.9, 1.10
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-2777
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2039/control-access_authentication-in-rhdh/

## Summary

- Fix typo "connexion" -> "connection" (2 occurrences) in `proc-enable-user-provisioning-with-ldap.adoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>