### PR TITLE
[RHDHBUGS-2481]: Add LDAP UUID sign-in resolver setup instructions

### DIFF
--- a/assemblies/shared/assembly-enable-authentication-in-rhdh-with-mandatory-steps-only.adoc
+++ b/assemblies/shared/assembly-enable-authentication-in-rhdh-with-mandatory-steps-only.adoc
@@ -23,6 +23,8 @@ include::../modules/shared/proc-import-users-and-groups-from-rhbk.adoc[leveloffs
 
 include::../modules/shared/proc-enable-authentication-with-rhbk.adoc[leveloffset=+1]
 
+include::../modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc[leveloffset=+2]
+
 
 include::../modules/shared/proc-share-a-secret-with-github.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-enable-authentication-with-your-identity-provider.adoc
+++ b/assemblies/shared/assembly-enable-authentication-with-your-identity-provider.adoc
@@ -12,6 +12,8 @@ Enable authentication with your main identity provider to allow users to sign in
 
 include::../modules/shared/proc-enable-authentication-with-rhbk.adoc[leveloffset=+1]
 
+include::../modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc[leveloffset=+2]
+
 include::../modules/shared/proc-enable-authentication-with-github.adoc[leveloffset=+1]
 
 include::../modules/shared/proc-enable-authentication-with-microsoft-azure.adoc[leveloffset=+1]

--- a/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
+++ b/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
@@ -4,7 +4,7 @@
 = Configure the LDAP UUID sign-in resolver for {rhbk-brand-name}
 
 [role="_abstract"]
-When you use {rhbk-brand-name} with LDAP user federation, you can configure the `oidcLdapUuidMatchingAnnotation` sign-in resolver to match users by their immutable LDAP UUID.
+When you use {rhbk-brand-name} with LDAP user federation, configure the `oidcLdapUuidMatchingAnnotation` sign-in resolver to match users by their immutable LDAP UUID for secure user resolution.
 This requires a custom client scope in {rhbk-brand-name} that exposes the LDAP UUID as a token claim.
 
 .Prerequisites

--- a/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
+++ b/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
@@ -34,7 +34,7 @@ Configure the mapper with the following values:
 . Go to *Clients* > your {product} client > *Client scopes*.
 Click *Add client scope* and add `ldap_uuid` as a *Default* scope.
 
-. Optionally, add the `oidcLdapUuidMatchingAnnotation` resolver to your `{my-app-config-file}` file, to replace the default `ldap_uuid` resolver:
+. Optional: Add the `oidcLdapUuidMatchingAnnotation` resolver to your `{my-app-config-file}` file, to replace the default `ldap_uuid` resolver:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
+++ b/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-the-ldap-uuid-sign-in-resolver-for-rhbk_{context}"]
+= Configure the LDAP UUID sign-in resolver for {rhbk-brand-name}
+
+[role="_abstract"]
+When you use {rhbk-brand-name} with LDAP user federation, you can configure the `oidcLdapUuidMatchingAnnotation` sign-in resolver to match users by their immutable LDAP UUID.
+This requires a custom client scope in {rhbk-brand-name} that exposes the LDAP UUID as a token claim.
+
+.Prerequisites
+
+* LDAP user federation is configured in {rhbk-brand-name}.
+* LDAP provisioning is enabled in {product}.
+For more information, see xref:enable-user-provisioning-with-ldap_{context}[Enable user provisioning with LDAP].
+* A {product} client is created in {rhbk-brand-name}.
+
+.Procedure
+
+. In the {rhbk-brand-name} admin console, go to *Client scopes* and click *Create client scope*.
+Name the scope `ldap_uuid`.
+
+. In the `ldap_uuid` scope, click the *Mappers* tab, then click *Add mapper* > *Configure a new mapper* > *User Attribute*.
+Configure the mapper with the following values:
++
+--
+* *Name*: `LDAP_ID`
+* *User Attribute*: `LDAP_ID`
+* *Token Claim Name*: `ldap_uuid`
+* *Claim JSON Type*: `String`
+* *Add to ID token*: *ON*
+* *Add to userinfo*: *ON*
+--
+
+. Go to *Clients* > your {product} client > *Client scopes*.
+Click *Add client scope* and add `ldap_uuid` as a *Default* scope.
+
+. Add the `oidcLdapUuidMatchingAnnotation` resolver to your `{my-app-config-file}` file:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+auth:
+  providers:
+    oidc:
+      production:
+        signIn:
+          resolvers:
+            - resolver: oidcLdapUuidMatchingAnnotation
+              ldapUuidKey: ldap_uuid
+----
++
+`ldapUuidKey`::
+Enter the token claim name containing the LDAP UUID value.
+The default value is `ldap_uuid`.
+This value must match the *Token Claim Name* configured in step 2.
+
+. Restart the {product} application to apply the changes.

--- a/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
+++ b/modules/shared/proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc
@@ -34,7 +34,7 @@ Configure the mapper with the following values:
 . Go to *Clients* > your {product} client > *Client scopes*.
 Click *Add client scope* and add `ldap_uuid` as a *Default* scope.
 
-. Add the `oidcLdapUuidMatchingAnnotation` resolver to your `{my-app-config-file}` file:
+. Optionally, add the `oidcLdapUuidMatchingAnnotation` resolver to your `{my-app-config-file}` file, to replace the default `ldap_uuid` resolver:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/shared/proc-enable-authentication-with-rhbk.adoc
+++ b/modules/shared/proc-enable-authentication-with-rhbk.adoc
@@ -103,6 +103,12 @@ Available values:
 Matches the user with the immutable `sub` parameter from OIDC to the {rhbk} user ID.
 Consider using this resolver for enhanced security.
 
+`oidcLdapUuidMatchingAnnotation`::::
+Matches the user by their immutable LDAP UUID.
+Requires a custom client scope in {rhbk-brand-name}.
++
+For setup instructions, see xref:configure-the-ldap-uuid-sign-in-resolver-for-rhbk_{context}[Configure the LDAP UUID sign-in resolver for {rhbk-brand-name}].
+
 `emailLocalPartMatchingUserEntityName`::::
 Matches the email local part with the user entity name.
 


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.8+
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-2481
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2042/control-access_authentication-in-rhdh/

## Summary

- Add new procedure `proc-configure-the-ldap-uuid-sign-in-resolver-for-rhbk.adoc` documenting how to set up the `oidcLdapUuidMatchingAnnotation` resolver when using Keycloak with LDAP user federation
- Add `oidcLdapUuidMatchingAnnotation` to the Keycloak resolver reference list with xref to the new procedure
- Include the new procedure in `assembly-enable-authentication-with-rhbk.adoc`

The procedure covers Keycloak client scope setup (custom `ldap_uuid` scope with User Attribute mapper) and RHDH resolver configuration (`ldapUuidKey` parameter).

Source material: redhat-developer/rhdh#2937, redhat-developer/rhdh#2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>