### PR TITLE
[RHDHBUGS-2954]: Fix empty CQA output in CI when checks fail

### DIFF
--- a/.github/workflows/content-quality-assessment.yml
+++ b/.github/workflows/content-quality-assessment.yml
@@ -121,10 +121,11 @@ jobs:
           cd pr-content
           git remote add base https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
           git fetch base ${{ github.event.pull_request.base.ref }}
-          OUTPUT=$(node build/scripts/cqa/index.js --all 2>&1)
+          OUTPUT=$(node build/scripts/cqa/index.js --all 2>&1) || CQA_EXIT=$?
           echo "output<<EOF" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+          exit ${CQA_EXIT:-0}
 
       - name: Post CQA checklist as PR comment
         if: always()


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge.** Review and verify the changes first.

**Version(s):** 1.10

**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2954

**Preview:** N/A (CI workflow fix only)

## Summary

- When CQA exits non-zero (violations found), GitHub Actions `set -e` kills the shell before writing output to `$GITHUB_OUTPUT`
- The PR comment step runs (`if: always()`) but gets empty output
- Fix: capture exit code with `|| CQA_EXIT=$?`, write output, then `exit ${CQA_EXIT:-0}`

Regression from #2055 which removed `|| true` from the CQA step.

## Test plan

- [ ] PR with CQA violations shows the full CQA checklist in the PR comment
- [ ] PR with CQA violations still fails the workflow
- [ ] Clean PR passes the workflow

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>