### PR TITLE
[RHDHBUGS-2954]: Print full CQA checklist in build logs on failure

### DIFF
--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -527,6 +527,9 @@ function printCqaSummary(cqaResult) {
   const s = cqaResult.stats || {};
   console.log(`Checks: ${s.total} total, ${s.pass} pass, ${s.fail} fail`);
   if (cqaResult.status === 'failed') {
+    if (cqaResult.output) {
+      console.log(cqaResult.output);
+    }
     console.log('CQA validation failed — run `node build/scripts/cqa/index.js --all` for details');
   }
 }


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge.** Review and verify the changes first.

**Version(s):** 1.10

**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2954

**Preview:** N/A (build script only)

## Summary

- When CQA fails, `printCqaSummary` in `build-orchestrator.js` only showed stats and a "run locally" message
- Now prints the full CQA checklist output so `pr.yml` build logs include detailed per-check results

Follow-up to #2057.

## Test plan

- [ ] PR with CQA violations shows full checklist in build logs (not just stats)
- [ ] Clean PR still shows concise stats-only summary

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>