### PR TITLE
[RHDHBUGS-2954]: Fix CQA/build-orchestrator infinite recursion

### DIFF
--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -661,9 +661,13 @@ async function main() {
     lycheeResult.errors = classifyErrors(lycheeResult.output, patterns);
   }
 
-  // Run CQA content quality assessment
-  console.log('\nRunning CQA content quality assessment...');
-  const cqaResult = await runCqa(repoRoot, args.verbose);
+  // Run CQA content quality assessment (skip when invoked from CQA-14 to avoid recursion)
+  const cqaResult = process.env.CQA_RUNNING
+    ? { status: 'passed', duration: 0, output: '', stats: { total: 0, pass: 0, fail: 0 } }
+    : await (async () => {
+        console.log('\nRunning CQA content quality assessment...');
+        return runCqa(repoRoot, args.verbose);
+      })();
 
   const totalDuration = Math.round((Date.now() - totalStart) / 1000);
 

--- a/build/scripts/cqa/checks/cqa-14-no-broken-links.js
+++ b/build/scripts/cqa/checks/cqa-14-no-broken-links.js
@@ -90,10 +90,12 @@ function getLycheeIssues(root) {
 
   try {
     // Run build orchestrator (builds fresh HTML + runs lychee with remapping)
+    // Set CQA_RUNNING to prevent build-orchestrator from running CQA again (recursion)
     execFileSync('node', ['build/scripts/build-orchestrator.js', '-b', 'main'], { // NOSONAR — fixed args, no user input
       cwd: root,
       stdio: 'pipe',
       timeout: 600000, // 10 minutes
+      env: { ...process.env, CQA_RUNNING: '1' },
     });
   } catch {
     // Build may exit non-zero if lychee finds broken links — that's expected


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge.** Review and verify the changes first.

**Version(s):** 1.10

**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2954

**Preview:** N/A (build scripts only)

## Summary

- CQA-14 spawns `build-orchestrator.js` for lychee cross-title link checking
- Since #2055, the build orchestrator also runs CQA, creating an infinite recursion that hits the 10-minute timeout
- Fix: CQA-14 sets `CQA_RUNNING=1` env var when spawning the orchestrator; the orchestrator skips the CQA phase when that var is set
- CQA runtime back to ~54 seconds (was timing out at 10 minutes)

## Test plan

- [ ] `node build/scripts/cqa/index.js --all` completes in ~1 minute
- [ ] `./build/scripts/build-ccutil.sh` still runs CQA as part of the build
- [ ] CQA-14 lychee cross-title link checking still works

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>