### PR TITLE
[RHDHBUGS-2954]: Show CQA failures in PR build comment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -188,10 +188,23 @@ jobs:
                   return `### ${r.title}\n${errs}`;
                 }).join('\n\n');
 
+                let cqaDetails = '';
+                if (report.cqa && report.cqa.status === 'failed') {
+                  const s = report.cqa.stats || {};
+                  cqaDetails = `### CQA (Content Quality Assessment)\n` +
+                    `${s.total} checks: ${s.pass} pass, ${s.fail} fail\n\n`;
+                  if (report.cqa.output) {
+                    cqaDetails += `<details>\n<summary>CQA checklist</summary>\n\n` +
+                      `${report.cqa.output}\n</details>\n\n`;
+                  }
+                  cqaDetails += `Run \`node build/scripts/cqa/index.js --all\` locally for details.\n\n`;
+                }
+
                 body = `## :x: Build failed\n\n` +
                   `${report.titles.passed}/${report.titles.total} titles built successfully | ` +
                   `${report.titles.failed} failed | ${report.duration}s\n\n` +
                   `${details}\n\n` +
+                  `${cqaDetails}` +
                   `[View full logs](${runUrl}) | ${now}`;
               } else {
                 body = `## :x: Build failed\n\n` +

--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -585,6 +585,7 @@ function writeReport(branch, results, lycheeResult, cqaResult, concurrency, tota
     cqa: cqaResult ? {
       status: cqaResult.status,
       stats: cqaResult.stats || {},
+      output: cqaResult.output || '',
     } : null,
   };
 


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge.** Review and verify the changes first.

**Version(s):** 1.10

**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2954

**Preview:** N/A (build scripts and CI workflow)

## Summary

- When CQA fails, the PR build comment now shows CQA stats and a collapsible checklist instead of just "Build failed" with no details
- `build-orchestrator.js`: include CQA output in JSON build report
- `pr.yml`: render CQA failure section in the comment body

Before:
> :x: Build failed
> 33/33 titles built successfully | 0 failed | 142s

After:
> :x: Build failed
> 33/33 titles built successfully | 0 failed | 142s
> ### CQA (Content Quality Assessment)
> 19 checks: 12 pass, 7 fail
> <details><summary>CQA checklist</summary>...</details>

## Test plan

- [ ] PR with CQA violations shows CQA section in the build comment
- [ ] PR with no CQA violations shows normal preview comment
- [ ] Collapsible checklist renders correctly in GitHub

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>