### PR TITLE
[RHDHBUGS-2983]: Align release-1.9-post-cqa build scripts and PR workflow with main

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -277,7 +277,7 @@ jobs:
                 if (s.total) {
                   body += `${s.total} checks: ${s.pass} pass, ${s.fail} fail\n\n`;
                 }
-                body += `Run \`node build/scripts/cqa/index.js --all\` locally for details.\n\n`;
+                body += `Run \`node build/scripts/cqa/index.js --all --fix\` locally to review and auto-fix issues.\n\n`;
                 body += `---\n\n`;
               }
             } else {

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,17 +23,16 @@ on:
   # will prevent the job from running until it's approved manually by human intervention.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: 
+    branches:
     - main
-    - rhdh-1.**
-    - 1.**.x
     - release-1.**
+    - release-2.**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
-env: 
+env:
   GH_TEAM: rhdh
   GH_ORGANIZATION: redhat-developer
 jobs:
@@ -47,7 +46,7 @@ jobs:
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ secrets.RHDH_GITHUB_APP_ID }}
-          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }} 
+          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
       - name: Check team membership
         uses: redhat-developer/rhdh/.github/actions/check-author@main
         id: check-team-membership
@@ -86,10 +85,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout main branch to get trusted build scripts
+      - name: Checkout trusted build scripts from ${{ github.event.pull_request.base.ref }} branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.base.ref }}
           path: trusted-scripts
 
       - name: Checkout PR branch for content to build
@@ -115,6 +114,17 @@ jobs:
             | sudo tar xz -C /usr/local/bin lychee
           lychee --version
 
+      - name: Install Vale
+        run: |
+          wget -q https://github.com/errata-ai/vale/releases/download/v3.9.5/vale_3.9.5_Linux_64-bit.tar.gz
+          tar -xzf vale_3.9.5_Linux_64-bit.tar.gz -C /usr/local/bin vale
+          vale --version
+
+      - name: Sync Vale styles
+        run: |
+          cd pr-content
+          vale sync
+
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
@@ -129,24 +139,69 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+          # Used by CQA-15 (redirects check) to diff against the base branch
+          CQA_BASE_REF: base/${{ github.event.pull_request.base.ref }}
         run: |
           echo "Building PR ${{ github.event.pull_request.number }}"
-          cp trusted-scripts/build/scripts/build-ccutil.sh pr-content/build/scripts/build-ccutil.sh
-          cp trusted-scripts/build/scripts/build-orchestrator.js pr-content/build/scripts/build-orchestrator.js
-          cp trusted-scripts/build/scripts/error-patterns.json pr-content/build/scripts/error-patterns.json
-          cp trusted-scripts/lychee.toml pr-content/lychee.toml
-          cp trusted-scripts/.lycheeignore pr-content/.lycheeignore
+          # Copy trusted build scripts from base branch (not content)
+          # Guard each file — older branches may not have them
+          for f in build/scripts/build-ccutil.sh build/scripts/build-orchestrator.js build/scripts/error-patterns.json lychee.toml .lycheeignore; do
+            if [[ -f "trusted-scripts/$f" ]]; then cp "trusted-scripts/$f" "pr-content/$f"; fi
+          done
+          if [[ -d "trusted-scripts/build/scripts/cqa" ]]; then
+            rm -rf pr-content/build/scripts/cqa
+            cp -r trusted-scripts/build/scripts/cqa pr-content/build/scripts/cqa
+          fi
           touch pr-content/.lycheecache
           cd pr-content
-          build/scripts/build-ccutil.sh -b "pr-${{ github.event.number }}"
+          # Add base branch as remote so CQA checks can diff PR content against it
+          git remote add base https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
+          git fetch base ${{ github.event.pull_request.base.ref }}
+          # Orchestrator runs ccutil + lychee + CQA; older branches fall back to ccutil only
+          if [[ -f "build/scripts/build-orchestrator.js" ]]; then
+            node build/scripts/build-orchestrator.js -b "pr-${{ github.event.number }}"
+          else
+            build/scripts/build-ccutil.sh -b "pr-${{ github.event.number }}"
+          fi
 
+      # Determine if HTML was generated, so deploy runs even when only CQA/lychee fail.
+      # Sets html_built=true when all titles built, false when any title failed or no report exists.
+      - name: Check if HTML was built
+        id: check_html
+        if: always() && steps.build.outcome != 'skipped'
+        run: |
+          # Older branches (release-1.8/1.9) use build-ccutil.sh and produce no report;
+          # fall back to the build step outcome
+          if [[ ! -f "pr-content/build-report.json" ]]; then
+            if [[ "${{ steps.build.outcome }}" == "success" ]]; then
+              echo "html_built=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "html_built=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          # Parse the report to check for title build failures specifically;
+          # CQA/lychee failures do NOT prevent deployment
+          title_failures=$(node -e "
+            const r = JSON.parse(require('fs').readFileSync('pr-content/build-report.json','utf8'));
+            console.log(r.results.some(t => t.status === 'failed') ? 'true' : 'false');
+          " 2>&1) || { echo "html_built=false" >> "$GITHUB_OUTPUT"; exit 0; }
+          if [[ "$title_failures" == "true" ]]; then
+            echo "html_built=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "html_built=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Avoid push conflicts: pull latest gh-pages before deploying new preview content
       - name: Pull from origin before pushing (if possible)
+        if: steps.check_html.outputs.html_built == 'true'
         run: |
           cd pr-content
           /usr/bin/git pull origin gh-pages || true
 
-      # repo must be public for this to work
+      # Always publish the preview when HTML has been built, even with broken links or CQA alerts
       - name: Deploy
+        if: steps.check_html.outputs.html_built == 'true'
         uses: peaceiris/actions-gh-pages@v4
         # if: github.ref == 'refs/heads/main'
         with:
@@ -155,16 +210,87 @@ jobs:
           keep_files: true
           publish_dir: ./pr-content/titles-generated
 
+      # Post one consolidated PR comment with build results, preview link, and CQA checklist.
+      # Preview link is always shown; marked stale when title build failed (HTML not generated).
+      # CQA section is absent on older branches without CQA.
+      # Detects existing comments from both old (two-comment) and new (consolidated) formats.
       - name: Post or update PR comment with doc preview link
+        if: always() && steps.build.outcome != 'skipped'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.RHDH_BOT_TOKEN }}
           script: |
+            const fs = require('fs');
             const prNum = context.issue.number;
             const previewUrl = `https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-${prNum}/`;
-            const now = new Date().toLocaleString('en-US', { timeZone: 'UTC' });
-            const body = `Updated preview: ${previewUrl} @ ${now}`;
+            const now = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync('pr-content/build-report.json', 'utf8'));
+            } catch { report = null; }
 
+            // ── Section 1: Build status + preview ──
+            let body = '## PR Build Results\n\n';
+
+            if (report) {
+              const titlesFailed = report.results.filter(r => r.status === 'failed');
+              const hasTitleFailure = titlesFailed.length > 0;
+              const overallFailed = hasTitleFailure
+                || (report.lychee && report.lychee.status === 'failed')
+                || (report.cqa && report.cqa.status === 'failed');
+
+              if (overallFailed) {
+                body += `**Build failed** -- ${report.titles.passed}/${report.titles.total} titles | ${report.duration}s\n`;
+              } else {
+                body += `**Build passed** -- ${report.titles.passed}/${report.titles.total} titles | ${report.duration}s\n`;
+              }
+
+              if (hasTitleFailure) {
+                body += `Preview: ${previewUrl} (stale -- title build failed, showing previous version)\n\n`;
+              } else {
+                body += `Preview: ${previewUrl}\n\n`;
+              }
+
+              // ── Section 2: Build error details (title failures only) ──
+              if (hasTitleFailure) {
+                const details = titlesFailed.map(r => {
+                  const errs = (r.errors || []).map(e =>
+                    `  **Error:** \`${e.line}\`\n  **Cause:** ${e.cause}\n  **Fix:** ${e.fix}`
+                  ).join('\n\n');
+                  return `### ${r.title}\n${errs}`;
+                }).join('\n\n');
+                body += `${details}\n\n`;
+              }
+
+              if (overallFailed) {
+                body += `[View full logs](${runUrl})\n\n`;
+              }
+
+              body += `---\n\n`;
+
+              // ── Section 3: CQA checklist ──
+              if (report.cqa && report.cqa.output) {
+                body += `## Content Quality Assessment\n\n`;
+                body += report.cqa.output + '\n\n';
+                const s = report.cqa.stats || {};
+                if (s.total) {
+                  body += `${s.total} checks: ${s.pass} pass, ${s.fail} fail\n\n`;
+                }
+                body += `Run \`node build/scripts/cqa/index.js --all\` locally for details.\n\n`;
+                body += `---\n\n`;
+              }
+            } else {
+              // No report -- early crash
+              body += `**Build failed** -- build crashed before producing a report.\n`;
+              body += `Preview: ${previewUrl} (stale -- build crashed, showing previous version)\n\n`;
+              body += `[View full logs](${runUrl})\n\n`;
+              body += `---\n\n`;
+            }
+
+            body += `*Updated ${now}*`;
+
+            // ── Upsert comment ──
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -172,7 +298,9 @@ jobs:
             });
 
             const existing = comments.find(c =>
-              c.body.includes('preview: https://redhat-developer.github.io/')
+              c.body.includes('## PR Build Results') ||
+              c.body.includes('preview: https://redhat-developer.github.io/') ||
+              c.body.includes('Build failed')
             );
 
             if (existing) {
@@ -190,3 +318,20 @@ jobs:
                 body: body
               });
             }
+
+            // ── Clean up old standalone CQA comment ──
+            const oldCqa = comments.find(c =>
+              c.body.includes('Content Quality Assessment Results') &&
+              (!existing || c.id !== existing.id)
+            );
+            if (oldCqa) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: oldCqa.id,
+              });
+            }
+
+      - name: Fail job if build failed
+        if: steps.build.outcome == 'failure'
+        run: exit 1

--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -32,12 +32,13 @@ const SAFE_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 // ── Argument parsing ─────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { branch: 'main', verbose: false, jobs: cpus().length };
+  const args = { branch: 'main', verbose: false, jobs: cpus().length, noCqa: false };
   for (let i = 2; i < argv.length; i++) {
     switch (argv[i]) {
       case '-b': args.branch = argv[++i]; break;
       case '--verbose': args.verbose = true; break;
       case '--jobs': args.jobs = Number.parseInt(argv[++i], 10); break;
+      case '--no-cqa': args.noCqa = true; break;
     }
   }
   return args;
@@ -268,11 +269,53 @@ async function ensureLychee(repoRoot) {
   return lychee;
 }
 
-async function runLychee(repoRoot, verbose) {
+// ── Cross-title link remapping ───────────────────────────────────────────────
+
+function buildRemapArgs(repoRoot, branch) {
+  const attrsPath = join(repoRoot, 'artifacts', 'attributes.adoc');
+  if (!existsSync(attrsPath)) return [];
+
+  const attrs = readFileSync(attrsPath, 'utf8');
+  const generatedDir = join(repoRoot, 'titles-generated', branch);
+  if (!existsSync(generatedDir)) return [];
+
+  // Extract key-prefix -> slug from book-link attributes
+  const bookLinks = {};
+  const bookLinkRe = /^:([\w-]+)-book-link:\s+\{product-docs-link\}\/html-single\/([^/\s]+)\/index/gm;
+  let m;
+  while ((m = bookLinkRe.exec(attrs)) !== null) {
+    bookLinks[m[1]] = m[2];
+  }
+
+  // For each title dir, read :title: to extract the book-title key prefix
+  // Expects normalized titles: :title: {<name>-book-title}
+  const titleDirs = readdirSync(generatedDir).filter(d =>
+    existsSync(join(generatedDir, d, 'index.html'))
+  );
+  const remaps = [];
+  for (const dir of titleDirs) {
+    const masterPath = join(repoRoot, 'titles', dir, 'master.adoc');
+    if (!existsSync(masterPath)) continue;
+    const masterHead = readFileSync(masterPath, 'utf8').slice(0, 500);
+    const titleMatch = masterHead.match(/^:title:\s+\{([\w-]+)-book-title\}$/m);
+    if (!titleMatch) continue;
+    const keyPrefix = titleMatch[1];
+    const slug = bookLinks[keyPrefix];
+    if (!slug) continue;
+    const localUrl = `file://${join(generatedDir, dir, 'index.html')}`;
+    remaps.push(String.raw`https://docs\.redhat\.com/en/documentation/red_hat_developer_hub/[^/]+/html-single/${slug}/index ${localUrl}`);
+  }
+
+  return remaps.flatMap(r => ['--remap', r]);
+}
+
+async function runLychee(repoRoot, branch, verbose) {
   const lycheeBin = await ensureLychee(repoRoot);
+  const remapArgs = buildRemapArgs(repoRoot, branch);
   const { code, duration, output } = await spawnCapture(lycheeBin, [
     '--config', join(repoRoot, 'lychee.toml'),
     '--format', 'json',
+    ...remapArgs,
     join(repoRoot, 'titles-generated'),
   ], { cwd: repoRoot, verbose, groupName: 'lychee' });
 
@@ -339,6 +382,31 @@ async function traceUrlToSource(url, repoRoot) {
   ], { cwd: repoRoot, verbose: false });
   if (code !== 0 || !output.trim()) return [];
   return output.trim().split('\n').map(f => f.replace(repoRoot + '/', ''));
+}
+
+// ── CQA content quality assessment ─────────────────────────────────────────
+
+async function runCqa(repoRoot, verbose) {
+  const cqaScript = join(__dirname, 'cqa', 'index.js');
+  const { code, duration, output } = await spawnCapture('node', [cqaScript, '--all'], {
+    cwd: repoRoot, verbose, groupName: 'CQA',
+  });
+
+  // Parse summary line from output: "Checks: 19 total, 19 pass, 0 fail"
+  let checksTotal = 0, checksPass = 0, checksFail = 0;
+  const summaryMatch = output.match(/Checks:\s+(\d+)\s+total,\s+(\d+)\s+pass,\s+(\d+)\s+fail/);
+  if (summaryMatch) {
+    checksTotal = Number.parseInt(summaryMatch[1], 10);
+    checksPass = Number.parseInt(summaryMatch[2], 10);
+    checksFail = Number.parseInt(summaryMatch[3], 10);
+  }
+
+  return {
+    status: code === 0 ? 'passed' : 'failed',
+    duration,
+    output,
+    stats: { total: checksTotal, pass: checksPass, fail: checksFail },
+  };
 }
 
 // ── Index HTML generation ────────────────────────────────────────────────────
@@ -455,7 +523,20 @@ function printLycheeSummary(lycheeResult) {
   console.log(lastLines.map(l => '  ' + l).join('\n'));
 }
 
-function printSummary(results, lycheeResult, patterns, totalDuration) {
+function printCqaSummary(cqaResult) {
+  if (cqaResult.status === 'skipped') return;
+  console.log('\n=== CQA (Content Quality Assessment) ===');
+  const s = cqaResult.stats || {};
+  console.log(`Checks: ${s.total} total, ${s.pass} pass, ${s.fail} fail`);
+  if (cqaResult.status === 'failed') {
+    if (cqaResult.output) {
+      console.log(cqaResult.output);
+    }
+    console.log('CQA validation failed — run `node build/scripts/cqa/index.js --all` for details');
+  }
+}
+
+function printSummary(results, lycheeResult, cqaResult, patterns, totalDuration) {
   const passed = results.filter(r => r.status === 'passed').length;
   const failed = results.filter(r => r.status === 'failed').length;
 
@@ -469,11 +550,15 @@ function printSummary(results, lycheeResult, patterns, totalDuration) {
   if (lycheeResult) {
     printLycheeSummary(lycheeResult);
   }
+
+  if (cqaResult) {
+    printCqaSummary(cqaResult);
+  }
 }
 
 // ── JSON report ──────────────────────────────────────────────────────────────
 
-function writeReport(branch, results, lycheeResult, concurrency, totalDuration, repoRoot) {
+function writeReport(branch, results, lycheeResult, cqaResult, concurrency, totalDuration, repoRoot) {
   const passed = results.filter(r => r.status === 'passed').length;
   const failed = results.filter(r => r.status === 'failed').length;
 
@@ -498,6 +583,11 @@ function writeReport(branch, results, lycheeResult, concurrency, totalDuration, 
       status: lycheeResult.status,
       stats: lycheeResult.stats || {},
       errors: lycheeResult.errors || [],
+    } : null,
+    cqa: cqaResult ? {
+      status: cqaResult.status,
+      stats: cqaResult.stats || {},
+      output: cqaResult.output || '',
     } : null,
   };
 
@@ -569,21 +659,32 @@ async function main() {
 
   // Run lychee link validation
   console.log('\nRunning link validation (lychee)...');
-  const lycheeResult = await runLychee(repoRoot, args.verbose);
+  const lycheeResult = await runLychee(repoRoot, args.branch, args.verbose);
   if (lycheeResult.errors.length === 0) {
     lycheeResult.errors = classifyErrors(lycheeResult.output, patterns);
   }
 
+  // Run CQA content quality assessment
+  // Skip when: --no-cqa flag, or CQA_RUNNING env (CQA-14 recursion guard)
+  const cqaResult = (args.noCqa || process.env.CQA_RUNNING)
+    ? { status: 'skipped', duration: 0, output: '', stats: { total: 0, pass: 0, fail: 0 } }
+    : await (async () => {
+        console.log('\nRunning CQA content quality assessment...');
+        return runCqa(repoRoot, args.verbose);
+      })();
+
   const totalDuration = Math.round((Date.now() - totalStart) / 1000);
 
   // Print summary
-  printSummary(buildResults, lycheeResult, patterns, totalDuration);
+  printSummary(buildResults, lycheeResult, cqaResult, patterns, totalDuration);
 
   // Write JSON report
-  writeReport(args.branch, buildResults, lycheeResult, args.jobs, totalDuration, repoRoot);
+  writeReport(args.branch, buildResults, lycheeResult, cqaResult, args.jobs, totalDuration, repoRoot);
 
-  // Exit with error if any builds or lychee failed
-  const hasFailed = buildResults.some(r => r.status === 'failed') || lycheeResult.status === 'failed';
+  // Exit with error if any builds, lychee, or CQA failed
+  const hasFailed = buildResults.some(r => r.status === 'failed')
+    || lycheeResult.status === 'failed'
+    || cqaResult.status === 'failed';
   process.exit(hasFailed ? 1 : 0);
 }
 

--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -32,13 +32,12 @@ const SAFE_PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 // ── Argument parsing ─────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const args = { branch: 'main', verbose: false, jobs: cpus().length, noCqa: false };
+  const args = { branch: 'main', verbose: false, jobs: cpus().length };
   for (let i = 2; i < argv.length; i++) {
     switch (argv[i]) {
       case '-b': args.branch = argv[++i]; break;
       case '--verbose': args.verbose = true; break;
       case '--jobs': args.jobs = Number.parseInt(argv[++i], 10); break;
-      case '--no-cqa': args.noCqa = true; break;
     }
   }
   return args;
@@ -665,8 +664,8 @@ async function main() {
   }
 
   // Run CQA content quality assessment
-  // Skip when: --no-cqa flag, or CQA_RUNNING env (CQA-14 recursion guard)
-  const cqaResult = (args.noCqa || process.env.CQA_RUNNING)
+  // Skip when CQA_RUNNING env is set (CQA-14 recursion guard)
+  const cqaResult = (process.env.CQA_RUNNING)
     ? { status: 'skipped', duration: 0, output: '', stats: { total: 0, pass: 0, fail: 0 } }
     : await (async () => {
         console.log('\nRunning CQA content quality assessment...');

--- a/build/scripts/cqa/checks/cqa-14-no-broken-links.js
+++ b/build/scripts/cqa/checks/cqa-14-no-broken-links.js
@@ -90,10 +90,12 @@ function getLycheeIssues(root) {
 
   try {
     // Run build orchestrator (builds fresh HTML + runs lychee with remapping)
+    // Set CQA_RUNNING to prevent build-orchestrator from running CQA again (recursion)
     execFileSync('node', ['build/scripts/build-orchestrator.js', '-b', 'main'], { // NOSONAR — fixed args, no user input
       cwd: root,
       stdio: 'pipe',
       timeout: 600000, // 10 minutes
+      env: { ...process.env, CQA_RUNNING: '1' },
     });
   } catch {
     // Build may exit non-zero if lychee finds broken links — that's expected

--- a/build/scripts/cqa/index.js
+++ b/build/scripts/cqa/index.js
@@ -139,7 +139,7 @@ async function runAllChecks(checks, titles, fixMode) {
 
   // Output in alphabetical order by check ID
   const sortedChecks = [...checks].sort((a, b) => a.id.localeCompare(b.id));
-  printAllChecksReport(sortedChecks, results, fixMode);
+  return printAllChecksReport(sortedChecks, results, fixMode);
 }
 
 async function collectAllResults(checks, titles, fixMode) {
@@ -236,6 +236,7 @@ function printAllChecksReport(sortedChecks, results, fixMode) {
   }
 
   printFinalSummary({ checksPass, checksFail, totalAutofixable, totalManual, totalDelegated, totalFixed, fixMode });
+  return { checksPass, checksFail };
 }
 
 function printFinalSummary({ checksPass, checksFail, totalAutofixable, totalManual, totalDelegated, totalFixed, fixMode }) {
@@ -384,7 +385,8 @@ async function main() {
   }
 
   if (allMode) {
-    await runAllChecks(checks, titles, fixMode);
+    const { checksFail } = await runAllChecks(checks, titles, fixMode);
+    process.exit(checksFail > 0 ? 1 : 0);
   } else {
     runPerTitleMode(checks, titles, fixMode);
   }


### PR DESCRIPTION
> **IMPORTANT:** Do Not Merge this PR without the approval of at least one of the maintainers: @themr0c @Gerry-Forde

**Version(s):** release-1.9-post-cqa

**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2983

**Preview:** N/A (build scripts and workflow changes only)

## Summary

Align release-1.9-post-cqa with main + PR 2069 changes. Keeps the branch pitch-perfect with the latest build tooling.

### Changes synced from main / PR 2069

| File | Changes |
|------|---------|
| `build/scripts/build-orchestrator.js` | `--no-cqa` flag, cross-title link remapping, CQA recursion guard, CQA exit code propagation |
| `.github/workflows/pr.yml` | Consolidated PR comment (build results + CQA checklist in one comment), `check_html` deploy gate (deploy even when CQA/lychee fail), Vale install, trusted scripts from base branch with existence guards |
| `build/scripts/cqa/index.js` | Return stats from `runAllChecks`, exit non-zero on CQA failures |
| `build/scripts/cqa/checks/cqa-14-no-broken-links.js` | `CQA_RUNNING` env var to prevent build-orchestrator recursion |

### Not changed (branch-specific)

- `.lycheeignore` -- has branch-specific cross-title link exclusions
- `lychee.toml` -- already identical to main
- `error-patterns.json` -- already identical to main

## Test plan

- [ ] PR workflow builds + runs lychee + runs CQA on release-1.9-post-cqa PRs
- [ ] Consolidated comment shows build results + CQA checklist
- [ ] HTML deployed even when only CQA/lychee fail
- [ ] `--no-cqa` flag works locally: `node build/scripts/build-orchestrator.js --no-cqa -b main`

## Related

- Companion PR targeting main: https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/pull/2069