### PR TITLE
[RHDHBUGS-3000]: Fix concurrent PR build gh-pages push race condition

### DIFF
--- a/.github/workflows/build-asciidoc.yml
+++ b/.github/workflows/build-asciidoc.yml
@@ -70,7 +70,7 @@ jobs:
         touch .lycheecache
         build/scripts/build-ccutil.sh -b ${{ env.GIT_BRANCH }}
 
-    - name: Deploy to gh-pages
+    - name: Deploy to the gh-pages branch
       env:
         GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/build-asciidoc.yml
+++ b/.github/workflows/build-asciidoc.yml
@@ -70,15 +70,11 @@ jobs:
         touch .lycheecache
         build/scripts/build-ccutil.sh -b ${{ env.GIT_BRANCH }}
 
-    # repo must be public for this to work
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v4
-      # if: github.ref == 'refs/heads/main'
-      with:
-        github_token: ${{ secrets.RHDH_BOT_TOKEN }}
-        publish_branch: gh-pages
-        keep_files: true
-        publish_dir: ./titles-generated
+    - name: Deploy to gh-pages
+      env:
+        GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: bash build/scripts/deploy-gh-pages.sh ./titles-generated --message "Deploy ${{ env.GIT_BRANCH }}"
 
     - name: Cleanup merged PR branches
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,7 +194,7 @@ jobs:
             echo "html_built=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Deploy to gh-pages
+      - name: Deploy to the gh-pages branch
         if: steps.check_html.outputs.html_built == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,23 +194,12 @@ jobs:
             echo "html_built=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Avoid push conflicts: pull latest gh-pages before deploying new preview content
-      - name: Pull from origin before pushing (if possible)
+      - name: Deploy to gh-pages
         if: steps.check_html.outputs.html_built == 'true'
-        run: |
-          cd pr-content
-          /usr/bin/git pull origin gh-pages || true
-
-      # Always publish the preview when HTML has been built, even with broken links or CQA alerts
-      - name: Deploy
-        if: steps.check_html.outputs.html_built == 'true'
-        uses: peaceiris/actions-gh-pages@v4
-        # if: github.ref == 'refs/heads/main'
-        with:
-          github_token: ${{ secrets.RHDH_BOT_TOKEN }}
-          publish_branch: gh-pages
-          keep_files: true
-          publish_dir: ./pr-content/titles-generated
+        env:
+          GITHUB_TOKEN: ${{ secrets.RHDH_BOT_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash trusted-scripts/build/scripts/deploy-gh-pages.sh ./pr-content/titles-generated --message "Deploy PR ${{ github.event.number }} preview"
 
       # Post one consolidated PR comment with build results, preview link, and CQA checklist.
       # Preview link is always shown; marked stale when title build failed (HTML not generated).

--- a/README.adoc
+++ b/README.adoc
@@ -99,6 +99,11 @@ https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/
 
 PRs have a link to the generated HTML attached as a comment.
 
+The publication workflow has two stages:
+
+. The link:.github/workflows/pr.yml[PR workflow] and link:.github/workflows/build-asciidoc.yml[GitHub Pages workflow] build HTML from AsciiDoc sources and push the output to the `gh-pages` branch using `build/scripts/deploy-gh-pages.sh`, which handles concurrent pushes with automatic retry.
+. The link:https://github.com/redhat-developer/red-hat-developers-documentation-rhdh/actions/workflows/pages/pages-build-deployment[GitHub Pages build and deployment] workflow, managed by GitHub, detects pushes to the `gh-pages` branch and publishes the content to GitHub Pages.
+
 ## Reviews
 
 All PRs are reviewed for technical accuracy by an SME and writing quality by another tech writer.

--- a/build/scripts/deploy-gh-pages.sh
+++ b/build/scripts/deploy-gh-pages.sh
@@ -29,6 +29,9 @@ done
 
 PUBLISH_DIR="$(cd "$PUBLISH_DIR" && pwd)"
 
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required (set by GitHub Actions)}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required (set by GitHub Actions)}"
+
 MAX_RETRIES=3
 RETRY_DELAYS=(0 27 133)
 
@@ -46,12 +49,16 @@ git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHU
 for attempt in $(seq 1 "$MAX_RETRIES"); do
   echo "Deploy attempt $attempt/$MAX_RETRIES"
 
-  if git fetch origin gh-pages --depth=1 2>/dev/null; then
+  fetch_output=$(git fetch origin gh-pages --depth=1 2>&1) && fetch_ok=true || fetch_ok=false
+  if [[ "$fetch_ok" == "true" ]]; then
     git checkout -B gh-pages FETCH_HEAD
-  else
+  elif echo "$fetch_output" | grep -qi "not found\|couldn't find\|no such remote ref"; then
     echo "gh-pages branch does not exist, creating orphan"
     git checkout --orphan gh-pages
     git rm -rf . 2>/dev/null || true
+  else
+    echo "ERROR: Failed to fetch gh-pages: $fetch_output" >&2
+    exit 1
   fi
 
   cp -a "$PUBLISH_DIR"/. .

--- a/build/scripts/deploy-gh-pages.sh
+++ b/build/scripts/deploy-gh-pages.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Deploy files to the gh-pages branch with retry on push rejection.
+# Replaces peaceiris/actions-gh-pages to handle concurrent builds.
+#
+# Usage: deploy-gh-pages.sh <publish_dir> [--message <msg>]
+#
+# Environment: GITHUB_TOKEN, GITHUB_REPOSITORY (set by GitHub Actions)
+
+set -euo pipefail
+
+PUBLISH_DIR="${1:?Usage: deploy-gh-pages.sh <publish_dir> [--message <msg>]}"
+shift
+
+COMMIT_MSG="Deploy to GitHub Pages"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --message) COMMIT_MSG="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+PUBLISH_DIR="$(cd "$PUBLISH_DIR" && pwd)"
+
+MAX_RETRIES=3
+RETRY_DELAYS=(0 27 133)
+
+DEPLOY_DIR="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked via trap
+cleanup() { rm -rf "$DEPLOY_DIR"; }
+trap cleanup EXIT
+
+cd "$DEPLOY_DIR"
+git init -q
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+for attempt in $(seq 1 "$MAX_RETRIES"); do
+  echo "Deploy attempt $attempt/$MAX_RETRIES"
+
+  if git fetch origin gh-pages --depth=1 2>/dev/null; then
+    git checkout -B gh-pages FETCH_HEAD
+  else
+    echo "gh-pages branch does not exist, creating orphan"
+    git checkout --orphan gh-pages
+    git rm -rf . 2>/dev/null || true
+  fi
+
+  cp -a "$PUBLISH_DIR"/. .
+  git add -A
+
+  if git diff --cached --quiet; then
+    echo "No changes to deploy"
+    exit 0
+  fi
+
+  git commit -q -m "$COMMIT_MSG"
+
+  if git push origin gh-pages; then
+    echo "Deployed successfully (attempt $attempt)"
+    exit 0
+  fi
+
+  echo "Push rejected (attempt $attempt/$MAX_RETRIES)"
+
+  if [[ $attempt -lt $MAX_RETRIES ]]; then
+    jitter=$((RANDOM % 10))
+    wait=$(( RETRY_DELAYS[attempt] + jitter ))
+    echo "Retrying in ${wait}s..."
+    sleep "$wait"
+  fi
+done
+
+echo "ERROR: Deploy failed after $MAX_RETRIES attempts"
+exit 1

--- a/build/scripts/deploy-gh-pages.sh
+++ b/build/scripts/deploy-gh-pages.sh
@@ -36,9 +36,7 @@ MAX_RETRIES=3
 RETRY_DELAYS=(0 27 133)
 
 DEPLOY_DIR="$(mktemp -d)"
-# shellcheck disable=SC2329 # invoked via trap
-cleanup() { rm -rf "$DEPLOY_DIR"; }
-trap cleanup EXIT
+trap 'rm -rf "$DEPLOY_DIR"' EXIT
 
 cd "$DEPLOY_DIR"
 git init -q


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** All
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-3000
**Preview:** N/A

## Summary

- Replace `peaceiris/actions-gh-pages` with a custom deploy script (`build/scripts/deploy-gh-pages.sh`) that retries on push rejection with irregular backoff (27s, 133s + jitter)
- Fix concurrent PR build failures where `git push origin gh-pages` is rejected because another build pushed first
- Remove the no-op "pull before push" step in `pr.yml` (pulled gh-pages into the PR branch checkout, always failed silently)
- Apply the fix to both `pr.yml` and `build-asciidoc.yml`
- Document the two-stage publication workflow in README.adoc

## Merge order

**Merge PR 2090 (release-1.8) and PR 2089 (release-1.9) BEFORE this PR.** The `pr.yml` workflow runs from `main` via `pull_request_target`, but checks out `trusted-scripts` from the PR's base branch. This PR updates `pr.yml` to reference `deploy-gh-pages.sh` via `trusted-scripts/`, so the script must already exist on release branches.

1. Merge PR 2090 (release-1.8) and PR 2089 (release-1.9)
2. Then merge this PR (main)

## Test plan

- [ ] Open 2+ PRs simultaneously and verify both deploy successfully
- [ ] Verify single PR build still deploys correctly
- [ ] Verify main branch push still deploys correctly