### PR TITLE
[RHDHBUGS-3010]: Fix shellcheck workflow on deleted .sh files

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -89,9 +89,16 @@ jobs:
       - name: Get changed shell scripts
         id: changed-files
         run: |
-          # Get list of changed .sh files
+          # Get list of changed .sh files that still exist (exclude deletions)
           git fetch origin ${{ github.base_ref }}
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.sh$' || echo "")
+          ALL_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.sh$' || echo "")
+          CHANGED_FILES=""
+          while IFS= read -r file; do
+            if [ -n "$file" ] && [ -f "$file" ]; then
+              CHANGED_FILES="${CHANGED_FILES:+$CHANGED_FILES
+          }$file"
+            fi
+          done <<< "$ALL_CHANGED"
           echo "changed_files<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** All
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-3010
**Preview:** N/A

## Summary

- Filter out deleted `.sh` files before running shellcheck, preventing `reviewdog: parse error: EOF` when a PR only deletes shell scripts

Merge this before redhat-developer/red-hat-developers-documentation-rhdh/pull/2100 and redhat-developer/red-hat-developers-documentation-rhdh/pull/2101 so the shellcheck workflow runs correctly on those PRs.

Cherry-pick to `release-1.9` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>