### PR TITLE
fix: exclude VPN-only release notes URL from lychee checks

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,6 @@ file://.*titles-generated/index\.html$
 
 # External sites that block automated requests
 ^https://fonts\.google\.com/icons
+
+# Release notes site is behind Red Hat VPN, unreachable from GitHub Actions
+^https://red-hat-developers-documentation\.pages\.redhat\.com/red-hat-developer-hub-release-notes


### PR DESCRIPTION
## IMPORTANT: Do Not Merge

<!-- Remove this section when the PR is ready to be merged -->

## Summary

- Adds the release notes site URL to `.lycheeignore` since it is behind the Red Hat VPN and unreachable from GitHub Actions runners
- This eliminates persistent lychee failures in CI for the branch index release notes link

## Version(s)

main

## Issue

N/A — CI fix

## Preview

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>