### PR TITLE
[RHDHBUGS-3022]: Fix broken links found by lychee validation

### DIFF
--- a/modules/developer-lightspeed/con-about-lightspeed-stack-and-llama-stack.adoc
+++ b/modules/developer-lightspeed/con-about-lightspeed-stack-and-llama-stack.adoc
@@ -28,7 +28,7 @@ The {lcs-name} serves as the Llama Stack service intermediary. It manages the op
 
 * Conversation history
 
-Llama Stack provides the inference functionality that {lcs-short} uses to process requests. For more information, see https://llamastack.github.io/docs#what-is-llama-stack[What is Llama Stack].
+Llama Stack provides the inference functionality that {lcs-short} uses to process requests. For more information, see https://ogx-ai.github.io/docs/concepts[OGX (formerly Llama Stack) concepts].
 
 The {ls-brand-name} plugin in {product-very-short} sends prompts and receives LLM responses through the {lcs-short} sidecar. {lcs-short} then uses the Llama Stack sidecar service to perform inference and MCP or RAG tool calling.
 

--- a/modules/release-notes/ref-release-notes-developer-preview.adoc
+++ b/modules/release-notes/ref-release-notes-developer-preview.adoc
@@ -107,7 +107,7 @@ The {ls-short} plugin has completed its migration from the Road-Core Service to 
 
 .Additional resources
 * {developer-lightspeed-link}[{ls-brand-name}]
-* link:https://llamastack.github.io/docs#what-is-llama-stack[What is Llama Stack]
+* link:https://ogx-ai.github.io/docs/concepts[OGX (formerly Llama Stack) concepts]
 * link:https://github.com/lightspeed-core[Lightspeed Core]
 
 // Link in comment to facilitate reviews: https://issues.redhat.com/browse/RHIDP-10225

--- a/modules/techdocs/proc-techdocs-addon-install-third-party.adoc
+++ b/modules/techdocs/proc-techdocs-addon-install-third-party.adoc
@@ -7,7 +7,7 @@ You can install compatible third-party TechDocs add-on on your {product} instanc
 
 .Prerequisites
 * The third-party TechDocs add-on has a valid `package.json` file in its root directory, containing all required metadata and dependencies.
-* The third-party plugin is packaged as a dynamic plugin in an OCI image. For alternative package types, see link:https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/release-1.5/plugins-rhdh-install/#assembly-install-third-party-plugins-rhdh[Installing third-party plugins in {product}].
+* The third-party plugin is packaged as a dynamic plugin in an OCI image. For alternative package types, see link:{installing-and-viewing-plugins-book-link}#assembly-install-third-party-plugins-rhdh[Installing third-party plugins in {product}].
 * You have installed the `yarn` package manager.
 * The third-party plugin is packaged as a dynamic plugin in an OCI image.* You have installed and configured Node.js and NPM.
 


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.8
**Issue:** https://issues.redhat.com/browse/RHDHBUGS-3022
**Preview:** N/A

## Summary

Backport of #2110 to release-1.8.

- Update Llama Stack docs URL: project rebranded to OGX, old `llamastack.github.io` domain returns 404. Updated to `ogx-ai.github.io/docs/concepts`.
- Replace stale `release-1.5` GitHub Pages preview URL with `{installing-and-viewing-plugins-book-link}` attribute.

Note: on release-1.8 the llama stack file is at `modules/developer-lightspeed/` (moved to `modules/shared/` on main) and uses an inline link rather than an `.Additional resources` section.