### PR TITLE
[release-1.9] [RHDHBUGS-831]: Update prerequisites to include specific RBAC roles and permissions

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc
@@ -8,7 +8,7 @@ To manage storage capacity and comply with data retention policies, adjust the n
 
 .Prerequisites
 
-* You have administrative access to the {product-very-short} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
@@ -11,7 +11,7 @@ You can add the aggregated Scorecard widget to a customizable {product-very-shor
 * You established owner group relationships in the Software Catalog.
 * {scorecard-plugin-book-link}#assembly-configuring-scorecards-in-rhdh[You have installed the Scorecard plugin].
 * You have the `scorecard.metric.read` permission.
-* You have administrative access to the {product-very-short} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
@@ -11,7 +11,7 @@ You can add the aggregated Scorecard widget to a read-only {product-very-short} 
 * You established owner group relationships in the Software Catalog.
 * {scorecard-plugin-book-link}#assembly-configuring-scorecards-in-rhdh[You have installed the Scorecard plugin].
 * You have the `scorecard.metric.read` permission.
-* You have administrative access to the {product-very-short} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc
@@ -8,7 +8,7 @@ You can grant read access to Scorecard metrics by using the RBAC Web UI in {prod
 
 .Prerequisites
 
-* You have {authorization-book-link}#enabling-and-giving-access-to-rbac_title-authorization[enabled RBAC and assigned a policy administrator role].
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have added `scorecard` to the list of authorized plugins under your `permission.rbac.pluginsWithPermission` configuration.
 
 .Procedure

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
@@ -7,8 +7,7 @@
 To monitor component health and quality in {product-very-short}, you must enable the Scorecard plugin in your configuration.
 
 .Prerequisites
-* You have installed your {product-very-short} instance.
-* You have provisioned your custom {installing-and-viewing-plugins-book-link}[dynamic plugins config map].
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -18,7 +18,7 @@ For long-lived integrations or organizational access, you must use a GitHub App.
 * You have {install-category-link}[installed your {product-very-short} instance].
 * You have {scorecard-plugin-book-link}#proc-installing-scorecard-plugin-in-rhdh-instance[installed the Scorecard images].
 * Optional: If you choose the GitHub App option, you must have permissions in GitHub to create and manage a GitHub App.
-* You must have {configuring-book-link}[added a custom {product-very-short} application configuration] and have enough permissions to change it.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -13,7 +13,7 @@ The plugin supports Jira Cloud (API v3) and Jira Data Center (API v2).
 * You must have administrator privileges for Jira and {product-very-short}.
 * You have {install-category-link}[installed your {product-very-short} instance].
 * You have {scorecard-plugin-book-link}#proc-installing-scorecard-plugin-in-rhdh-instance[installed the Scorecard images].
-* You must have {configuring-book-link}[added a custom {product-very-short} application configuration] and have sufficient permissions to change it.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc
@@ -10,7 +10,7 @@ You can view metrics to evaluate the health and security of your software compon
 
 * You have installed your {product-very-short} instance.
 * You have configured the GitHub or Jira Scorecard (or both) plugin.
-* You must have permissions to read the Scorecard metrics.
+* If RBAC is enabled, you have a role with the following permission: `scorecard.metric.read`.
 
 .Procedure
 . In your {product-very-short} navigation menu, go to *Catalog*.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc
@@ -8,7 +8,7 @@ To balance data freshness with system performance and API rate limits, you can c
 
 .Prerequisites
 
-* You have administrative access to the {product-very-short} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have identified the `datasourceId` and `metricName` for the provider you want to configure.
 
 .Procedure

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-view-aggregated-metrics-for-owned-entities.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-view-aggregated-metrics-for-owned-entities.adoc
@@ -9,7 +9,7 @@ View aggregated metrics for your owned entities in {product-very-short} to monit
 .Prerequisites
 
 * (To view aggregated KPIs) You have established owner group relationships in the Software Catalog.
-* You have administrative access to the {product-very-short} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have the `catalog.entity.read` permission for the entities included in the aggregation.
 * You have the `scorecard.metric.read` permission to view aggregated metrics on the home page.
 

--- a/modules/shared/proc-add-new-components-to-your-rhdh-instance.adoc
+++ b/modules/shared/proc-add-new-components-to-your-rhdh-instance.adoc
@@ -9,7 +9,7 @@ You can add new components to expand your {product-short} Software Catalog by re
 .Prerequisites
 
 * You have installed and configured the {product} instance.
-* You have the required permissions. See {authorization-book-link}[{authorization-book-title}].
+* If RBAC is enabled, you have a role with the following permissions: `catalog.entity.create`, `catalog.location.create`, `bulk.import`.
 
 .Procedure
 

--- a/modules/shared/proc-configure-a-floating-action-button-as-a-dynamic-plugin.adoc
+++ b/modules/shared/proc-configure-a-floating-action-button-as-a-dynamic-plugin.adoc
@@ -7,7 +7,7 @@
 You can configure the floating action button as a dynamic plugin to perform actions or open an internal or external link.
 
 .Prerequisites
-* You must have sufficient permissions as a platform engineer.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc
+++ b/modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc
@@ -10,7 +10,7 @@ As a platform engineer, you must modify the Software Template YAML definition to
 
 .Prerequisites
 
-* You have administrator rights to {product}.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/shared/proc-configure-rbac-to-manage-extensions.adoc
+++ b/modules/shared/proc-configure-rbac-to-manage-extensions.adoc
@@ -7,7 +7,7 @@
 You can add Extensions permissions by creating or updating and existing RBAC role. For more information about using RBAC to manage role-based controls, see {authorization-book-link}#managing-authorizations-by-using-the-web-ui[Managing role-based access controls (RBAC) using the {product} Web UI].
 
 .Prerequisites
-* You have enabled RBAC, have a policy administrator role in {product-short}, and have added plugins with permission.
+* If RBAC is enabled, you have a role with the following permissions: `policy.entity.create`, `policy.entity.update`, `policy.entity.read`, `catalog.entity.read`.
 
 .Procedure
 . Go to *Administration* at the bottom of the sidebar in the {product-short}.

--- a/modules/shared/proc-create-a-basic-software-template.adoc
+++ b/modules/shared/proc-create-a-basic-software-template.adoc
@@ -8,7 +8,7 @@ To automate the setup of standardized environments for your developers, you must
 
 .Prerequisites
 
-* You have administrator access to a {product-very-short} instance.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have a Git repository to store Software Template files.
 
 .Procedure

--- a/modules/shared/proc-create-a-role-in-the-rhdh-web-ui.adoc
+++ b/modules/shared/proc-create-a-role-in-the-rhdh-web-ui.adoc
@@ -9,7 +9,7 @@ Create a role in {product-short} by using the Web UI to define permissions, user
 You can create a role in the {product} using the Web UI.
 
 .Prerequisites
-* You {authorization-book-link}#enabling-and-giving-access-to-rbac_title-authorization[have enabled RBAC, have a policy administrator role in {product-short}, and have added plugins with permission].
+* If RBAC is enabled, you have a role with the following permissions: `policy.entity.create`, `policy.entity.read`, `catalog.entity.read`.
 
 .Procedure
 

--- a/modules/shared/proc-create-a-software-component-using-software-templates.adoc
+++ b/modules/shared/proc-create-a-software-component-using-software-templates.adoc
@@ -8,6 +8,7 @@ To ensure project consistency and reduce manual configuration time, use Software
 
 .Prerequisites
 * You log in to the {product} instance.
+* If RBAC is enabled, you have a role with the following permissions: `scaffolder.template.parameter.read`, `scaffolder.template.step.read`, `scaffolder.task.create`.
 
 .Procedure
 

--- a/modules/shared/proc-create-new-components-in-your-rhdh-instance.adoc
+++ b/modules/shared/proc-create-new-components-in-your-rhdh-instance.adoc
@@ -9,7 +9,7 @@ You can create new components in the Software Catalog in your {product-very-shor
 .Prerequisites
 
 * You have installed and configured the {product} instance.
-* You have the required permissions. See {authorization-book-link}[{authorization-book-title}].
+* If RBAC is enabled, you have a role with the following permissions: `catalog.entity.create`, `scaffolder.template.parameter.read`, `scaffolder.template.step.read`, `scaffolder.task.create`.
 
 .Procedure
 

--- a/modules/shared/proc-customize-rhdh-backend-secret.adoc
+++ b/modules/shared/proc-customize-rhdh-backend-secret.adoc
@@ -9,7 +9,7 @@ The default {product} configuration defines the {product-short} backend secret f
 You can define your custom {product-short} backend secret.
 
 .Prerequisites
-* You {configuring-book-link}[added a custom {product-short} application configuration], and have sufficient permissions to modify it.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/shared/proc-customize-your-rhdh-quick-start.adoc
+++ b/modules/shared/proc-customize-your-rhdh-quick-start.adoc
@@ -7,7 +7,7 @@
 As an administrator, you can configure the {product} quick start plugin to create customized onboarding for your {product-short} users.
 
 .Prerequisites
-You must have administrator permissions.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 * Update your `{my-app-config-file}` with the following code:

--- a/modules/shared/proc-delete-a-role-in-the-rhdh-web-ui.adoc
+++ b/modules/shared/proc-delete-a-role-in-the-rhdh-web-ui.adoc
@@ -14,7 +14,7 @@ The policies generated from a `policy.csv` or ConfigMap file cannot be edited or
 ====
 
 .Prerequisites
-* You {authorization-book-link}#enabling-and-giving-access-to-rbac_title-authorization[have enabled RBAC and have a policy administrator role in {product-short}].
+* If RBAC is enabled, you have a role with the following permissions: `policy.entity.delete`, `policy.entity.read`, `catalog.entity.read`.
 * The role that you want to delete is created in the {product-short}.
 
 .Procedure

--- a/modules/shared/proc-download-active-users-list-in-rhdh.adoc
+++ b/modules/shared/proc-download-active-users-list-in-rhdh.adoc
@@ -11,7 +11,7 @@ You can download the list of users in CSV format by using the {product-short} we
 .Prerequisites
 
 * RBAC plugins (`@backstage-community/plugin-rbac` and `@backstage-community/plugin-rbac-backend`) must be enabled in {product}.
-* An administrator role must be assigned.
+* If RBAC is enabled, you have a role with the following permission: `policy.entity.read`.
 
 .Procedure
 

--- a/modules/shared/proc-edit-a-role-in-the-rhdh-web-ui.adoc
+++ b/modules/shared/proc-edit-a-role-in-the-rhdh-web-ui.adoc
@@ -14,7 +14,7 @@ The policies generated from a `policy.csv` or ConfigMap file cannot be edited or
 ====
 
 .Prerequisites
-* You {authorization-book-link}#enabling-and-giving-access-to-rbac_title-authorization[have enabled RBAC, have a policy administrator role in {product-short}, and have added plugins with permission].
+* If RBAC is enabled, you have a role with the following permissions: `policy.entity.update`, `policy.entity.read`, `catalog.entity.read`.
 
 * The role that you want to edit is created in the {product-short}.
 

--- a/modules/shared/proc-enable-and-disable-plugins-by-using-extensions.adoc
+++ b/modules/shared/proc-enable-and-disable-plugins-by-using-extensions.adoc
@@ -8,7 +8,7 @@ Use this procedure to enable or disable plugins through the Extensions interface
 
 .Prerequisites
 * You have configured {product-very-short} to allow plugins installation from *Extensions*.
-* You have configured RBAC to allow the current user to access to manage plugin configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 . Navigate to *Extensions*.

--- a/modules/shared/proc-enable-and-give-access-to-the-role-based-access-control-rbac-feature.adoc
+++ b/modules/shared/proc-enable-and-give-access-to-the-role-based-access-control-rbac-feature.adoc
@@ -13,7 +13,7 @@ The permission policies for users and groups in the {product-short} are managed 
 Only permission policy administrators can access the RBAC REST API.
 
 .Prerequisites
-* You have {configuring-book-link}[added a custom {product-short} application configuration], and have necessary permissions to change it.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have {authentication-book-link}[enabled an authentication provider].
 
 .Procedure

--- a/modules/shared/proc-enable-auto-logout-for-inactive-users.adoc
+++ b/modules/shared/proc-enable-auto-logout-for-inactive-users.adoc
@@ -9,7 +9,7 @@ This helps prevent unauthorized access to stale user sessions.
 
 .Prerequisites
 
-* You have administrative access to the {product} configuration files.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/shared/proc-enable-automated-template-updates.adoc
+++ b/modules/shared/proc-enable-automated-template-updates.adoc
@@ -10,7 +10,7 @@ To automate the synchronization of changes from Software Templates to your repos
 
 .Prerequisites
 
-* You have administrator access to the {product} configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * You have configured GitHub or GitLab integrations in your `{product-very-short} {my-app-config-file}` file.
 * Your scaffolded entities include the `spec.scaffoldedFrom` field referencing the source template.
 * Your entities include the `backstage.io/managed-by-location` annotation pointing to a valid GitHub or GitLab URL.

--- a/modules/shared/proc-enable-github-repository-discovery.adoc
+++ b/modules/shared/proc-enable-github-repository-discovery.adoc
@@ -7,7 +7,7 @@
 Configure automatic GitHub repository discovery to import repositories containing catalog-info.yaml files into the {product} catalog without manual registration.
 
 .Prerequisites
-* You {configuring-book-link}[added a custom {product-short} application configuration], and have sufficient permissions to modify it.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 * You have sufficient permissions in GitHub to create and manage a link:https://docs.github.com/en/apps/overview[GitHub App].
 

--- a/modules/shared/proc-enable-plugins-added-in-the-rhdh-container-image.adoc
+++ b/modules/shared/proc-enable-plugins-added-in-the-rhdh-container-image.adoc
@@ -56,7 +56,7 @@ Alternatively, you can use an `oci://` plugin reference, and the special `{{inhe
 +
 The location of the plugin configuration file varies based on the deployment method. For more details, see {installing-and-viewing-plugins-book-link}[{installing-and-viewing-plugins-book-title}].
 . Change the `disabled` field to `false` and add the package name as follows:
-
++
 --
 [source,yaml]
 ----

--- a/modules/shared/proc-install-plugins-by-using-extensions.adoc
+++ b/modules/shared/proc-install-plugins-by-using-extensions.adoc
@@ -8,7 +8,7 @@ You can install and configure plugins by using Extensions.
 
 .Prerequisites
 * You have configured {product-very-short} to allow plugins installation from *Extensions*.
-* You have configured RBAC to allow the current user to manage plugin configuration.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 . Navigate to *Extensions*.

--- a/modules/shared/proc-register-components-manually-in-your-rhdh-instance.adoc
+++ b/modules/shared/proc-register-components-manually-in-your-rhdh-instance.adoc
@@ -9,7 +9,7 @@ To manually register components in your {product-very-short} instance, create a 
 .Prerequisites
 
 * You have installed and configured the {product} instance.
-* You have the required permissions. See {authorization-book-link}[{authorization-book-title}].
+* If RBAC is enabled, you have a role with the following permissions: `catalog.entity.create`, `catalog.location.create`.
 
 .Procedure
 

--- a/modules/shared/proc-run-orchestrator-workflows-for-bulk-imports.adoc
+++ b/modules/shared/proc-run-orchestrator-workflows-for-bulk-imports.adoc
@@ -14,7 +14,7 @@ As a platform engineer, you can configure the Bulk Import plugin to run Orchestr
 
 * You have registered a generic custom workflow (for example, `universal-pr`) in the Orchestrator plugin.
 
-* You have role-based access control (RBAC) permissions to configure the Bulk Import plugin.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 
 .Procedure
 

--- a/modules/shared/proc-share-software-templates-with-your-organization.adoc
+++ b/modules/shared/proc-share-software-templates-with-your-organization.adoc
@@ -8,7 +8,7 @@ To allow developers to create new projects independently using your standards, y
 
 .Prerequisites
 
-* You have administrator access to a {product-very-short} instance.
+* If RBAC is enabled, you have a role with the following permissions: `catalog.entity.create`, `catalog.location.create`.
 * You have a Git repository to store Software Template files.
 
 .Procedure

--- a/modules/shared/proc-start-and-complete-lessons-in-learning-paths.adoc
+++ b/modules/shared/proc-start-and-complete-lessons-in-learning-paths.adoc
@@ -8,7 +8,7 @@ As a developer, you can start a course and complete the lessons at your own pace
 
 .Prerequisites
 * You can log in to developers.redhat.com
-* Your platform engineer has granted you access to the Learning Paths plugin.
+* If RBAC is enabled, you have a role with the following permission: `catalog.entity.read`.
 
 
 .Procedure

--- a/modules/shared/proc-update-existing-components-in-your-rhdh-catalog.adoc
+++ b/modules/shared/proc-update-existing-components-in-your-rhdh-catalog.adoc
@@ -9,7 +9,7 @@ You can update components in the Software Catalog in your {product} instance.
 .Prerequisites
 
 * You have installed and configured the {product} instance.
-* You have the required permissions. See {authorization-book-link}[{authorization-book-title}].
+* If RBAC is enabled, you have a role with the following permission: `catalog.entity.refresh`.
 
 .Procedure
 

--- a/modules/shared/proc-version-a-software-template-in-rhdh.adoc
+++ b/modules/shared/proc-version-a-software-template-in-rhdh.adoc
@@ -8,7 +8,7 @@ Version Software Templates by using the `catalog:scaffolded-from` and `catalog:t
 
 .Prerequisites
 
-* You have administrator rights to {product}.
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
 * The following dynamic plugins are enabled in your `{product-custom-resource-type}` or `{my-app-config-config-map}` file:
 ** `backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic`
 ** `backstage-plugin-notifications`


### PR DESCRIPTION
## IMPORTANT: Do Not Merge
> Merging is handled by the RHDH documentation team.

**Version(s):** 1.9
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-831
**Preview:** N/A (backport)

## Summary
- Backport of #2047 to release-1.9
- Adds specific RBAC permission prerequisites to procedures