### PR TITLE
[RHDHBUGS-3034]: Add missing integrations config to GitHub/GitLab user import procedures

### DIFF
--- a/assemblies/shared/assembly-enable-authentication-in-rhdh-with-mandatory-steps-only.adoc
+++ b/assemblies/shared/assembly-enable-authentication-in-rhdh-with-mandatory-steps-only.adoc
@@ -24,7 +24,7 @@ include::../modules/shared/proc-import-users-and-groups-from-rhbk.adoc[leveloffs
 include::../modules/shared/proc-enable-authentication-with-rhbk.adoc[leveloffset=+1]
 
 
-include::../modules/shared/proc-share-a-secret-with-github.adoc[leveloffset=+1]
+include::../modules/shared/proc-share-secrets-with-github.adoc[leveloffset=+1]
 
 include::../modules/shared/proc-import-users-and-groups-from-github.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-share-a-secret-with-your-identity-provider.adoc
+++ b/assemblies/shared/assembly-share-a-secret-with-your-identity-provider.adoc
@@ -13,11 +13,11 @@ include::../modules/shared/proc-share-a-secret-with-rhbk.adoc[leveloffset=+1]
 
 include::../modules/shared/proc-share-a-secret-with-ldap.adoc[leveloffset=+1]
 
-include::../modules/shared/proc-share-a-secret-with-github.adoc[leveloffset=+1]
+include::../modules/shared/proc-share-secrets-with-github.adoc[leveloffset=+1]
 
 include::../modules/shared/proc-share-a-secret-with-microsoft-azure.adoc[leveloffset=+1]
 
-include::../modules/shared/proc-share-a-secret-with-gitlab.adoc[leveloffset=+1]
+include::../modules/shared/proc-share-secrets-with-gitlab.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/modules/shared/proc-enable-authentication-with-github.adoc
+++ b/modules/shared/proc-enable-authentication-with-github.adoc
@@ -21,8 +21,8 @@ auth:
   providers:
     github:
       production:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: ${GITHUB_CLIENT_SECRET}
+        clientId: ${GITHUB_APP_CLIENT_ID}
+        clientSecret: ${GITHUB_APP_CLIENT_SECRET}
 signInPage: github
 ----
 
@@ -30,10 +30,10 @@ signInPage: github
 Enter `production` to disable the Guest login option in the {product-short} login page.
 
 `clientId`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_ID}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_ID}`.
 
 `clientSecret`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_SECRET}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_SECRET}`.
 
 `signInPage`::
 Enter `github` to enable the GitHub provider as your {product-short} sign-in provider.
@@ -47,8 +47,8 @@ auth:
   providers:
     github:
       production:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: ${GITHUB_CLIENT_SECRET}
+        clientId: ${GITHUB_APP_CLIENT_ID}
+        clientSecret: ${GITHUB_APP_CLIENT_SECRET}
         callbackUrl: __<your_intermediate_service_url/handler>__
         sessionDuration: { hours: 24 }
         signIn:

--- a/modules/shared/proc-enable-authentication-with-github.adoc
+++ b/modules/shared/proc-enable-authentication-with-github.adoc
@@ -7,7 +7,7 @@
 Configure GitHub as your {product} sign-in provider.
 
 .Prerequisites
-* You have xref:share-a-secret-with-github_{secrets-context}[shared a secret with GitHub].
+* You have xref:share-secrets-with-github_{secrets-context}[shared secrets with GitHub].
 * You have {authentication-book-link}#import-users-and-groups-from-your-identity-provider_authentication-in-rhdh[provisioned users and groups to the software catalog].
 
 .Procedure

--- a/modules/shared/proc-enable-authentication-with-gitlab.adoc
+++ b/modules/shared/proc-enable-authentication-with-gitlab.adoc
@@ -7,7 +7,7 @@
 Configure GitLab as your {product} sign-in provider.
 
 .Prerequisites
-* You have xref:share-a-secret-with-gitlab_{secrets-context}[shared a secret with GitLab].
+* You have xref:share-secrets-with-gitlab_{secrets-context}[shared secrets with GitLab].
 * You have {authentication-book-link}#import-users-and-groups-from-your-identity-provider_authentication-in-rhdh[provisioned users and groups to the software catalog].
 
 .Procedure

--- a/modules/shared/proc-enable-github-repository-discovery.adoc
+++ b/modules/shared/proc-enable-github-repository-discovery.adoc
@@ -101,18 +101,18 @@ Select `Only on this account`.
 . Add your GitHub credentials to {product-short} by adding the following key/value pairs to {configuring-dynamic-plugins-book-link}#provisioning-your-custom-configuration[your {product-short} secrets].
 You can use these secrets in the {product-short} configuration files by using the corresponding environment variable name for each secret.
 
-`GITHUB_INTEGRATION_APP_ID`::
+`GITHUB_APP_APP_ID`::
 Enter the saved **App ID**.
-`GITHUB_INTEGRATION_CLIENT_ID`::
+`GITHUB_APP_CLIENT_ID_INTEGRATION`::
 Enter the saved **Client ID**.
-`GITHUB_INTEGRATION_CLIENT_SECRET`::
+`GITHUB_APP_CLIENT_SECRET_INTEGRATION`::
 Enter the saved **Client Secret**.
-`GITHUB_INTEGRATION_HOST_DOMAIN`::
-Enter the GitHub host domain: `github.com`.
-`GITHUB_INTEGRATION_ORGANIZATION`::
-Enter your GitHub organization name, such as `__<your_github_organization_name>__'.
-`GITHUB_INTEGRATION_PRIVATE_KEY_FILE`::
+`GITHUB_APP_PRIVATE_KEY`::
 Enter the saved **Private key**.
+`GITHUB_URL`::
+Enter the GitHub host domain: `https://github.com`.
+`GITHUB_ORG`::
+Enter your GitHub organization name, such as `__<your_github_organization_name>__`.
 
 . Enable the `plugin-catalog-backend-module-github` plugin in your `dynamic-plugins.yaml` file.
 +
@@ -137,7 +137,7 @@ catalog:
   providers:
     github:
       providerId:
-        organization: "${GITHUB_INTEGRATION_ORGANIZATION}"
+        organization: "${GITHUB_ORG}"
         schedule:
           frequency:
             minutes: 30
@@ -147,12 +147,12 @@ catalog:
             minutes: 15
 integrations:
   github:
-    - host: ${GITHUB_INTEGRATION_HOST_DOMAIN}
+    - host: ${GITHUB_URL}
       apps:
-        - appId: ${GITHUB_INTEGRATION_APP_ID}
-          clientId: ${GITHUB_INTEGRATION_CLIENT_ID}
-          clientSecret: ${GITHUB_INTEGRATION_CLIENT_SECRET}
+        - appId: ${GITHUB_APP_APP_ID}
+          clientId: ${GITHUB_APP_CLIENT_ID_INTEGRATION}
+          clientSecret: ${GITHUB_APP_CLIENT_SECRET_INTEGRATION}
           privateKey: |
-            ${GITHUB_INTEGRATION_PRIVATE_KEY_FILE}
+            ${GITHUB_APP_PRIVATE_KEY}
 ----
 

--- a/modules/shared/proc-enable-user-authentication-with-github-as-an-auxiliary-authentication-provider.adoc
+++ b/modules/shared/proc-enable-user-authentication-with-github-as-an-auxiliary-authentication-provider.adoc
@@ -20,17 +20,17 @@ auth:
   providers:
     github:
       production:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: ${GITHUB_CLIENT_SECRET}
+        clientId: ${GITHUB_APP_CLIENT_ID}
+        clientSecret: ${GITHUB_APP_CLIENT_SECRET}
         disableIdentityResolution: true
 ----
 +
 where:
 `clientId`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_ID}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_ID}`.
 
 `clientSecret`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_SECRET}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_SECRET}`.
 
 `disableIdentityResolution`::
 Enter `true` to skip user identity resolution for this provider to enable sign-in from an auxiliary authentication provider.

--- a/modules/shared/proc-import-users-and-groups-from-github.adoc
+++ b/modules/shared/proc-import-users-and-groups-from-github.adoc
@@ -7,7 +7,7 @@
 Import GitHub users and groups to the {product} software catalog.
 
 .Prerequisites
-* You have xref:share-a-secret-with-github_{secrets-context}[shared a secret with GitHub].
+* You have xref:share-secrets-with-github_{secrets-context}[shared secrets with GitHub].
 
 .Procedure
 
@@ -20,7 +20,7 @@ plugins:
     disabled: false
 ----
 
-. Add a GitHub catalog provider section to your `{my-app-config-file}` file:
+. Add a GitHub catalog provider and integration section to your `{my-app-config-file}` file:
 +
 [id=githubProviderId]
 [source,yaml]
@@ -38,6 +38,15 @@ catalog:
           seconds: 15
         timeout:
           minutes: 15
+integrations:
+  github:
+    - host: "${GITHUB_URL}"
+      apps:
+        - appId: ${GITHUB_APP_ID}
+          clientId: ${GITHUB_CLIENT_ID}
+          clientSecret: ${GITHUB_CLIENT_SECRET}
+          privateKey: |
+            ${GITHUB_PRIVATE_KEY}
 ----
 
 `id`::
@@ -63,6 +72,21 @@ Enter your schedule timeout, in the ISO duration or "human duration" format.
 
 `schedule.initialDelay`::
 Enter your schedule initial delay, in the ISO duration or "human duration" format.
+
+`integrations.github.host`::
+Enter the configured secret variable name: `$\{GITHUB_URL}`.
+
+`integrations.github.apps.appId`::
+Enter the configured secret variable name: `$\{GITHUB_APP_ID}`.
+
+`integrations.github.apps.clientId`::
+Enter the configured secret variable name: `$\{GITHUB_CLIENT_ID}`.
+
+`integrations.github.apps.clientSecret`::
+Enter the configured secret variable name: `$\{GITHUB_CLIENT_SECRET}`.
+
+`integrations.github.apps.privateKey`::
+Enter the configured secret variable name: `$\{GITHUB_PRIVATE_KEY}`.
 
 .Verification
 * Check user and group provisioning in the console logs.

--- a/modules/shared/proc-import-users-and-groups-from-github.adoc
+++ b/modules/shared/proc-import-users-and-groups-from-github.adoc
@@ -42,11 +42,11 @@ integrations:
   github:
     - host: "${GITHUB_URL}"
       apps:
-        - appId: ${GITHUB_APP_ID}
-          clientId: ${GITHUB_CLIENT_ID}
-          clientSecret: ${GITHUB_CLIENT_SECRET}
+        - appId: ${GITHUB_APP_APP_ID}
+          clientId: ${GITHUB_APP_CLIENT_ID_INTEGRATION}
+          clientSecret: ${GITHUB_APP_CLIENT_SECRET_INTEGRATION}
           privateKey: |
-            ${GITHUB_PRIVATE_KEY}
+            ${GITHUB_APP_PRIVATE_KEY}
 ----
 
 `id`::
@@ -77,16 +77,16 @@ Enter your schedule initial delay, in the ISO duration or "human duration" forma
 Enter the configured secret variable name: `$\{GITHUB_URL}`.
 
 `integrations.github.apps.appId`::
-Enter the configured secret variable name: `$\{GITHUB_APP_ID}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_APP_ID}`.
 
 `integrations.github.apps.clientId`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_ID}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_ID_INTEGRATION}`.
 
 `integrations.github.apps.clientSecret`::
-Enter the configured secret variable name: `$\{GITHUB_CLIENT_SECRET}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_CLIENT_SECRET_INTEGRATION}`.
 
 `integrations.github.apps.privateKey`::
-Enter the configured secret variable name: `$\{GITHUB_PRIVATE_KEY}`.
+Enter the configured secret variable name: `$\{GITHUB_APP_PRIVATE_KEY}`.
 
 .Verification
 * Check user and group provisioning in the console logs.

--- a/modules/shared/proc-import-users-and-groups-from-gitlab.adoc
+++ b/modules/shared/proc-import-users-and-groups-from-gitlab.adoc
@@ -7,11 +7,11 @@
 Import GitLab users and groups to the {product} software catalog.
 
 .Prerequisites
-* You have xref:share-a-secret-with-gitlab_{secrets-context}[shared a secret with GitLab].
+* You have xref:share-secrets-with-gitlab_{secrets-context}[shared secrets with GitLab].
 
 .Procedure
 
-* Add a GitLab provider section to your {product-very-short} `{my-app-config-file}` file:
+* Add a GitLab catalog provider and integration section to your {product-very-short} `{my-app-config-file}` file:
 +
 [source,yaml,subs="+quotes,+attributes"]
 ----
@@ -36,6 +36,10 @@ catalog:
             minutes: 50
           timeout:
             minutes: 50
+integrations:
+  gitlab:
+    - host: $\{GITLAB_HOST}
+      token: $\{GITLAB_TOKEN}
 ----
 
 `host`::
@@ -75,6 +79,12 @@ Enter your schedule frequency, in the cron, ISO duration, or `HumanDuration` for
 
 `schedule.timeout`::
 Enter your schedule timeout, in the ISO duration or `HumanDuration` format.
+
+`integrations.gitlab.host`::
+Enter your GitLab instance address: pass:c,a,q[`${GITLAB_HOST}`].
+
+`integrations.gitlab.token`::
+Enter the configured secret variable name: `$\{GITLAB_TOKEN}`.
 
 .Verification
 * Open {product-very-short} and wait for first ingestion.

--- a/modules/shared/proc-share-secrets-with-github.adoc
+++ b/modules/shared/proc-share-secrets-with-github.adoc
@@ -1,10 +1,17 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="share-a-secret-with-github_{context}"]
-= Share a secret with GitHub
+[id="share-secrets-with-github_{context}"]
+= Share secrets with GitHub
 
 [role="_abstract"]
 Register a GitHub App and store the credentials in {product} to enable secure communication.
+These credentials serve two purposes:
+
+Integration ({product-short} to GitHub)::
+`GITHUB_APP_ID`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `GITHUB_PRIVATE_KEY` authenticate {product-short} to GitHub for catalog operations such as importing users, groups, and repositories.
+
+Authentication (user to {product-short})::
+`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` authenticate users signing in to {product-short} with their GitHub credentials.
 
 .Prerequisites
 include::snip-enabling-user-authentication-with-github-common-prerequisites.adoc[]
@@ -40,21 +47,31 @@ Select `Only on this account`.
 
 .. In the *General* -> *Clients secrets* section, click *Generate a new client secret*.
 
+.. In the *General* -> *Private keys* section, click *Generate a private key*.
+
 .. In the *Install App* tab, choose an account to install your GitHub App on.
 
 .. Save the following values for the next step:
 
+. **App ID**
 . **Client ID**
 . **Client secret**
+. **Private key**
 
 . Add the following key/value pairs to {configuring-book-link}#provisioning-your-custom-configuration[your {product-short} secrets].
 You can use these secrets in the {product-short} configuration files by using their environment variable name.
+
+`GITHUB_APP_ID`::
+Enter the saved **App ID**.
 
 `GITHUB_CLIENT_ID`::
 Enter the saved **Client ID**.
 
 `GITHUB_CLIENT_SECRET`::
 Enter the saved **Client Secret**.
+
+`GITHUB_PRIVATE_KEY`::
+Enter the saved **Private key**.
 
 `GITHUB_URL`::
 Enter the GitHub host domain: `https://github.com`.

--- a/modules/shared/proc-share-secrets-with-github.adoc
+++ b/modules/shared/proc-share-secrets-with-github.adoc
@@ -4,26 +4,90 @@
 = Share secrets with GitHub
 
 [role="_abstract"]
-Register a GitHub App and store the credentials in {product} to enable secure communication.
-These credentials serve two purposes:
+Register GitHub Apps and store the credentials in {product} to enable secure communication.
+For security, create two separate GitHub Apps following the principle of least privilege:
 
-Integration ({product-short} to GitHub)::
-`GITHUB_APP_ID`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `GITHUB_PRIVATE_KEY` authenticate {product-short} to GitHub for catalog operations such as importing users, groups, and repositories.
+Integration App ({product-short} to GitHub)::
+Authenticates {product-short} to GitHub for catalog operations such as importing users, groups, and repositories.
+Requires: `GITHUB_APP_APP_ID`, `GITHUB_APP_CLIENT_ID_INTEGRATION`, `GITHUB_APP_CLIENT_SECRET_INTEGRATION`, and `GITHUB_APP_PRIVATE_KEY`.
 
-Authentication (user to {product-short})::
-`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` authenticate users signing in to {product-short} with their GitHub credentials.
+Authentication App (user to {product-short})::
+Authenticates users signing in to {product-short} with their GitHub credentials.
+Requires only OAuth credentials: `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET`.
 
 .Prerequisites
 include::snip-enabling-user-authentication-with-github-common-prerequisites.adoc[]
 
 .Procedure
 
-. Create a GitHub App.
+. Create a GitHub App for integration.
 +
 [NOTE]
 ====
 Use a GitHub App instead of an OAuth app to use fine-grained permissions and short-lived tokens, scale with the number of installations by avoiding rate limits, and have a more transparent integration by avoiding to request user input.
 ====
+
+.. link:https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app[Register a GitHub App] with the following configuration:
+
+GitHub App name::
+Enter a unique name identifying your GitHub App, such as `integrating-with-rhdh-__<GUID>__`.
+
+Homepage URL::
+Enter your {product-short} URL: `pass:c,a,q[{my-product-url}]`.
+
+Webhook::
+Clear "Active".
+
+Repository permissions::
+
+Contents:::
+`Read-only`
+
+Commit statuses:::
+`Read-only`
+
+Organization permissions::
+
+Members:::
+`Read-only`
+
+Where can this GitHub App be installed?::
+Select `Only on this account`.
+
+.. In the *General* -> *Clients secrets* section, click *Generate a new client secret*.
+
+.. In the *General* -> *Private keys* section, click *Generate a private key*.
+
+.. In the *Install App* tab, choose an account to install your GitHub App on.
+
+.. Save the following values for the next step:
+
+. **App ID**
+. **Client ID**
+. **Client secret**
+. **Private key**
+
+. Store the integration app credentials: Add the following key/value pairs to {configuring-book-link}#provisioning-your-custom-configuration[your {product-short} secrets].
+
+`GITHUB_APP_APP_ID`::
+Enter the saved **App ID**.
+
+`GITHUB_APP_CLIENT_ID_INTEGRATION`::
+Enter the saved **Client ID**.
+
+`GITHUB_APP_CLIENT_SECRET_INTEGRATION`::
+Enter the saved **Client Secret**.
+
+`GITHUB_APP_PRIVATE_KEY`::
+Enter the saved **Private key**.
+
+`GITHUB_URL`::
+Enter the GitHub host domain: `https://github.com`.
+
+`GITHUB_ORG`::
+Enter your GitHub organization name, such as `__<your_github_organization_name>__`.
+
+. Create a separate GitHub App for authentication.
 
 .. link:https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app[Register a GitHub App] with the following configuration:
 
@@ -47,37 +111,18 @@ Select `Only on this account`.
 
 .. In the *General* -> *Clients secrets* section, click *Generate a new client secret*.
 
-.. In the *General* -> *Private keys* section, click *Generate a private key*.
-
-.. In the *Install App* tab, choose an account to install your GitHub App on.
-
 .. Save the following values for the next step:
 
-. **App ID**
 . **Client ID**
 . **Client secret**
-. **Private key**
 
-. Add the following key/value pairs to {configuring-book-link}#provisioning-your-custom-configuration[your {product-short} secrets].
-You can use these secrets in the {product-short} configuration files by using their environment variable name.
+. Store the authentication app credentials: Add the following key/value pairs to {configuring-book-link}#provisioning-your-custom-configuration[your {product-short} secrets].
 
-`GITHUB_APP_ID`::
-Enter the saved **App ID**.
-
-`GITHUB_CLIENT_ID`::
+`GITHUB_APP_CLIENT_ID`::
 Enter the saved **Client ID**.
 
-`GITHUB_CLIENT_SECRET`::
+`GITHUB_APP_CLIENT_SECRET`::
 Enter the saved **Client Secret**.
 
-`GITHUB_PRIVATE_KEY`::
-Enter the saved **Private key**.
-
-`GITHUB_URL`::
-Enter the GitHub host domain: `https://github.com`.
-
-`GITHUB_ORG`::
-Enter your GitHub organization name, such as `__<your_github_organization_name>__`.
-
 .Verification
-* Verify that the secret key-value pairs are stored in your {product-short} secrets.
+* Verify that the secret key-value pairs for both apps are stored in your {product-short} secrets.

--- a/modules/shared/proc-share-secrets-with-gitlab.adoc
+++ b/modules/shared/proc-share-secrets-with-gitlab.adoc
@@ -1,10 +1,17 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="share-a-secret-with-gitlab_{context}"]
-= Share a secret with GitLab
+[id="share-secrets-with-gitlab_{context}"]
+= Share secrets with GitLab
 
 [role="_abstract"]
 Register a GitLab OAuth 2 application and store the credentials in {product} to enable secure communication.
+These credentials serve two purposes:
+
+Integration ({product-short} to GitLab)::
+`GITLAB_HOST` and `GITLAB_TOKEN` authenticate {product-short} to GitLab for catalog operations such as importing users, groups, and repositories.
+
+Authentication (user to {product-short})::
+`GITLAB_CLIENT_ID` and `GITLAB_CLIENT_SECRET` authenticate users signing in to {product-short} with their GitLab credentials.
 
 .Prerequisites
 include::snip-enable-user-authentication-with-gitlab-common-prerequisites.adoc[]
@@ -38,6 +45,9 @@ Enable `email`, `profile`, `openid`, and `read_user`.
 . **OAuth 2 Client ID**, available in the *Application ID* field
 . **OAuth 2 Client secret**, accessible by selecting *Copy* in the *Secret* field
 
+. Set up a link:https://docs.gitlab.com/user/profile/personal_access_tokens/[GitLab personal access token (PAT)] with `read_api` scope.
+Save the token value for the next step.
+
 . Add your GitLab credentials to {configuring-book-link}#provisioning-your-custom-configuration[your {product-very-short} secrets] using the following key/value pairs.
 Use these environment variables in your {product-very-short} configuration files.
 
@@ -49,6 +59,9 @@ Enter the saved *OAuth 2 Client ID*.
 
 `GITLAB_CLIENT_SECRET`::
 Enter the saved *OAuth 2 Client Secret*.
+
+`GITLAB_TOKEN`::
+Enter the saved *Personal access token*.
 
 `GITLAB_URL`::
 Enter the GitLab host domain: _`<gitlab_host_domain>`_.

--- a/modules/shared/ref-troubleshoot-catalog-provider-errors.adoc
+++ b/modules/shared/ref-troubleshoot-catalog-provider-errors.adoc
@@ -45,7 +45,7 @@ Authenticated requests using a GitHub App get up to 5,000 requests per hour.
 To resolve this issue:
 
 * Verify that the `integrations.github` section is configured in your `{my-app-config-file}` file with valid GitHub App credentials.
-For more information, see xref:import-users-and-groups-from-github_{context}[Import users and groups from GitHub].
+For more information, see xref:import-users-and-groups-from-github_import-users-and-groups-from-your-identity-provider[Import users and groups from GitHub].
 
 == GitLab: API rate limit exceeded
 
@@ -54,4 +54,4 @@ This error occurs when {product-short} makes unauthenticated API calls to GitLab
 To resolve this issue:
 
 * Verify that the `integrations.gitlab` section is configured in your `{my-app-config-file}` file with a valid GitLab personal access token.
-For more information, see xref:import-users-and-groups-from-gitlab_{context}[Import users and groups from GitLab].
+For more information, see xref:import-users-and-groups-from-gitlab_import-users-and-groups-from-your-identity-provider[Import users and groups from GitLab].

--- a/modules/shared/ref-troubleshoot-catalog-provider-errors.adoc
+++ b/modules/shared/ref-troubleshoot-catalog-provider-errors.adoc
@@ -32,3 +32,26 @@ catalog:
 ----
 +
 For more information about LDAP user filters, see xref:enable-user-provisioning-with-ldap_import-users-and-groups-from-your-identity-provider[Enable user provisioning with LDAP].
+
+== GitHub: API rate limit exceeded
+
+----
+GithubMultiOrgEntityProvider:default refresh failed, HttpError: API rate limit exceeded
+----
+
+This error occurs when {product-short} makes unauthenticated API calls to GitHub, which are limited to 60 requests per hour.
+Authenticated requests using a GitHub App get up to 5,000 requests per hour.
+
+To resolve this issue:
+
+* Verify that the `integrations.github` section is configured in your `{my-app-config-file}` file with valid GitHub App credentials.
+For more information, see xref:import-users-and-groups-from-github_{context}[Import users and groups from GitHub].
+
+== GitLab: API rate limit exceeded
+
+This error occurs when {product-short} makes unauthenticated API calls to GitLab, which are subject to rate limits.
+
+To resolve this issue:
+
+* Verify that the `integrations.gitlab` section is configured in your `{my-app-config-file}` file with a valid GitLab personal access token.
+For more information, see xref:import-users-and-groups-from-gitlab_{context}[Import users and groups from GitLab].


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge:** this PR must be reviewed first.

**Version(s):** 1.9, 1.10

**Issue:** [RHDHBUGS-3034](https://redhat.atlassian.net/browse/RHDHBUGS-3034)

**Preview:** N/A

## Summary

- Recommend two separate GitHub Apps following the principle of least privilege (per @JessicaJHee review): one for user authentication (OAuth), one for catalog integration (GitHub App with private key)
- Align all GitHub env var names to the `GITHUB_APP_*` convention used in the [RHDH codebase](https://github.com/redhat-developer/rhdh/blob/main/scripts/rhdh-openshift-setup/resources/rhdh-configmap.yaml)
- Merge `integrations.github` config into the GitHub user import procedure YAML block
- Merge `integrations.gitlab` (PAT) into the GitLab user import procedure YAML block
- Rename `proc-share-a-secret-with-{github,gitlab}.adoc` to `proc-share-secrets-with-{github,gitlab}.adoc`
- Add GitHub and GitLab API rate limit troubleshooting sections to `ref-troubleshoot-catalog-provider-errors.adoc`
- Update all cross-references to the renamed procedures

## Variable naming

Variable names follow the `GITHUB_APP_*` convention from the RHDH default configmap. The `_INTEGRATION` suffix disambiguates the integration app's client credentials from the authentication app's:

| Variable | App | Purpose |
|---|---|---|
| `GITHUB_APP_CLIENT_ID` | Auth | OAuth client ID for user sign-in |
| `GITHUB_APP_CLIENT_SECRET` | Auth | OAuth client secret for user sign-in |
| `GITHUB_APP_APP_ID` | Integration | GitHub App ID for API access |
| `GITHUB_APP_CLIENT_ID_INTEGRATION` | Integration | Client ID (separate app, different value from auth) |
| `GITHUB_APP_CLIENT_SECRET_INTEGRATION` | Integration | Client secret (separate app, different value from auth) |
| `GITHUB_APP_PRIVATE_KEY` | Integration | Private key for server-to-server auth |
| `GITHUB_URL` | Integration | GitHub host domain |
| `GITHUB_ORG` | Integration | GitHub organization name |

## Test plan

- [ ] Verify `./build/scripts/build-ccutil.sh` builds all titles without "Unknown ID" xref errors
- [ ] Verify CQA checks pass on affected titles
- [ ] Review YAML code blocks match Backstage integration schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)