### PR TITLE
[RHDHBUGS-3038]: Fix 3 broken docs.redhat.com cross-title links

### DIFF
--- a/modules/shared/proc-add-a-dynamic-plugin-to-rhdh.adoc
+++ b/modules/shared/proc-add-a-dynamic-plugin-to-rhdh.adoc
@@ -67,7 +67,7 @@ where
 +
 [NOTE]
 ====
-Ensure that your container images are publicly accessible, or that you have configured a pull secret in your environment. A pull secret provides {product} with credentials to authenticate pulling your plugin container images from a container registry. For more details, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html-single/installing_and_viewing_plugins_in_red_hat_developer_hub/index#proc-load-plugin-oci-image_assembly-install-third-party-plugins-rhdh[Loading a plugin packaged as an OCI image].
+Ensure that your container images are publicly accessible, or that you have configured a pull secret in your environment. A pull secret provides {product} with credentials to authenticate pulling your plugin container images from a container registry. For more details, see {installing-and-viewing-plugins-book-link}#load-a-plugin-packaged-as-an-oci-image_install-plugins-in-rhdh[Loading a plugin packaged as an OCI image].
 ====
 
 //For more information about using image pull secrets on {platform-generic}, see https://docs.okd.io/latest/openshift_images/managing_images/using-image-pull-secrets.html

--- a/modules/shared/proc-configure-front-end-plugin-wiring.adoc
+++ b/modules/shared/proc-configure-front-end-plugin-wiring.adoc
@@ -58,4 +58,4 @@ plugins:
 After restarting {product-very-short}, confirm that *Simple Example* appears in the sidebar menu. Click *Simple Example* and verify that the plugin page displays correctly. Navigate to a Component entity page and verify that the *ExampleCard* appears in the *Overview* tab.
 
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/installing_and_viewing_plugins_in_red_hat_developer_hub/assembly-front-end-plugin-wiring.adoc_rhdh-extensions-plugins[Frontend Plugin Wiring]
+* {installing-and-viewing-plugins-book-link}#front-end-plugin-wiring_installing-and-viewing-plugins-in-rhdh[Frontend Plugin Wiring]

--- a/modules/shared/proc-override-translations.adoc
+++ b/modules/shared/proc-override-translations.adoc
@@ -56,7 +56,7 @@ $ oc create configmap all-translations \
 As shown in the following examples, we recommend that you use the same mount path for your `allTranslations.json` file and any other override files that you create, for example `/opt/app-root/src/translations`.
 ====
 +
-.. For an Operator-installed {product-very-short} instance, update your `{product-custom-resource-type}` custom resource (CR). For more information about configuring a CR, see link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/configuring_red_hat_developer_hub/provisioning-and-using-your-custom-configuration#using-the-operator-to-run-rhdh-with-your-custom-configuration[Using the {product} Operator to run {product-short} with your custom configuration].
+.. For an Operator-installed {product-very-short} instance, update your `{product-custom-resource-type}` custom resource (CR). For more information about configuring a CR, see {configuring-book-link}#use-the-rhdh-operator-to-run-rhdh-with-your-custom-configuration_provision-and-use-your-custom-rhdh-configuration[Using the {product} Operator to run {product-short} with your custom configuration].
 ... In the `spec.application.extraFiles` section, add the translations custom app configuration as shown in the following example:
 +
 .{product-custom-resource-type} custom resource fragment


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge.** Merging is handled by the RHDH documentation team. If you want to contribute, please fork the upstream repo instead of this one.

## Version(s)

- 1.10

## Issue

https://redhat.atlassian.net/browse/RHDHBUGS-3038

## Summary

- Fix 3 broken external docs.redhat.com cross-title links using book link attributes (`{installing-and-viewing-plugins-book-link}`, `{configuring-book-link}`)
- `proc-configure-front-end-plugin-wiring.adoc`: fix incorrect assembly filename-based slug and wrong context (lychee 404)
- `proc-override-translations.adoc`: fix wrong page path and anchor ID (lychee 404)
- `proc-add-a-dynamic-plugin-to-rhdh.adoc`: fix dormant wrong anchor ID (`proc-load-plugin-oci-image_assembly-install-third-party-plugins-rhdh` -> `load-a-plugin-packaged-as-an-oci-image_install-plugins-in-rhdh`)

## Preview

N/A