### PR TITLE
[RHIDP-7115]: Fix tenantId typo in Azure user provisioning docs

### DIFF
--- a/modules/shared/proc-import-users-and-groups-from-microsoft-azure.adoc
+++ b/modules/shared/proc-import-users-and-groups-from-microsoft-azure.adoc
@@ -47,7 +47,7 @@ catalog:
 Enter `\https://graph.microsoft.com/v1.0` to define the MSGraph API endpoint the provider is connecting to.
 You might change this parameter to use a different version, such as the link:https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-beta#call-the-beta-endpoint[beta endpoint].
 
-`tenandId`::
+`tenantId`::
 Enter the configured secret variable name: `$\{MICROSOFT_TENANT_ID}`.
 
 `clientId`::


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.9+
**Issue:** https://redhat.atlassian.net/browse/RHIDP-7115
**Preview:** N/A

## Summary

- Fix typo `tenandId` → `tenantId` in the Azure user provisioning procedure

The two original rendering issues reported in RHIDP-7115 (broken line rendering and "?TITLE?" on definition lists) were already fixed in prior commits during the auth title restructuring.