### PR TITLE
[RHDHBUGS-1978]: Remove broken tech-radar proxy example from learning paths

### DIFF
--- a/modules/shared/proc-customize-the-learning-paths-by-using-a-hosted-json-file.adoc
+++ b/modules/shared/proc-customize-the-learning-paths-by-using-a-hosted-json-file.adoc
@@ -41,7 +41,6 @@ proxy:
       target: https://raw.githubusercontent.com/
       pathRewrite:
         '^/api/proxy/developer-hub/learning-paths': '/redhat-developer/rhdh/main/packages/app/public/learning-paths/data.json'
-        '^/api/proxy/developer-hub/tech-radar': '/redhat-developer/rhdh/main/packages/app/public/tech-radar/data-default.json'
         '^/api/proxy/developer-hub': '/redhat-developer/rhdh/main/packages/app/public/homepage/data.json'
       changeOrigin: true
       secure: true


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge**
> This PR is not ready to merge until technical review is complete and all comments are addressed.

## Version(s)
1.9+

## Issue
https://redhat.atlassian.net/browse/RHDHBUGS-1978

## Preview
N/A

## Summary
- Removes broken tech-radar `pathRewrite` line from the proxy config example in the learning paths customization procedure
- The tech-radar data file moved from `redhat-developer/rhdh` to `backstage/community-plugins` and can no longer share the same proxy target
- The tech radar plugin now uses its own `techRadar.url` config, making the proxy example misleading

## Test plan
- [ ] Verify the remaining proxy example in the TIP block still shows correct learning-paths and homepage entries
- [ ] Confirm the tech-radar customization procedure already points to the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)