### PR TITLE
[RHDHBUGS-2787]: Replace deprecated RoadieHQ ArgoCD backend with Red Hat backend

### DIFF
--- a/modules/extend_orchestrator-in-rhdh/proc-install-the-orchestrator-software-templates-infra-chart.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-the-orchestrator-software-templates-infra-chart.adoc
@@ -18,7 +18,7 @@ The `orchestrator-software-templates-infra` chart installs the Custom Resource D
 ** `backstage-plugin-kubernetes`
 ** `backstage-community-plugin-tekton`
 ** `backstage-community-plugin-redhat-argocd`
-** `roadiehq-backstage-plugin-argo-cd-backend-dynamic`
+** `backstage-community-plugin-argocd-backend`
 ** `roadiehq-scaffolder-backend-argocd-dynamic`
 +
 Edit the `values.yaml` and upgrade the chart.

--- a/modules/shared/proc-enable-the-argo-cd-plugin.adoc
+++ b/modules/shared/proc-enable-the-argo-cd-plugin.adoc
@@ -71,7 +71,7 @@ global:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:__<tag>__
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd-backend:__<tag>__
         disabled: false
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:__<tag>__
         disabled: false


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge**
> This PR is not ready to merge until technical review is complete and all comments are addressed.

## Version(s)
1.9+

## Issue
https://redhat.atlassian.net/browse/RHDHBUGS-2787

## Preview
N/A

## Summary
- Replaces deprecated `roadiehq-backstage-plugin-argo-cd-backend` with `backstage-community-plugin-argocd-backend` (Red Hat backend) in the Argo CD enable procedure
- Updates the orchestrator infra chart prerequisites to use the same Red Hat backend plugin name
- The scaffolder backend module (`roadiehq-scaffolder-backend-argocd`) has no Red Hat replacement yet and is left unchanged

## Test plan
- [ ] Verify `backstage-community-plugin-argocd-backend` matches the migration table in `ref-community-plugins-migration-to-the-github-container-registry.adoc`
- [ ] Confirm the OCI package exists at `ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd-backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)