### PR TITLE
Revert "Do not require approval to run cherry-pick pull requests"

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,6 @@ jobs:
           organization: ${{ env.GH_ORGANIZATION }}
           gh_token: ${{ steps.app-token.outputs.token }}
           author: ${{ github.event.pull_request.user.login }}
-          whitelisted_authors: '[\"openshift-cherrypick-robot\"]'
 
   authorize:
     # The 'external' environment is configured with the rhdh-content team as required reviewers.


### PR DESCRIPTION
Reverts redhat-developer/red-hat-developers-documentation-rhdh#2189

It seems it caused this error:

```
Run redhat-developer/rhdh/.github/actions/check-author@main
Error: The template is not valid. Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: \. Path '', line 1, position 1.
   at Newtonsoft.Json.JsonTextReader.ParseValue()
   at Newtonsoft.Json.JsonTextReader.Read()
   at Newtonsoft.Json.Linq.JContainer.ReadTokenFrom(JsonReader reader, JsonLoadSettings options)
   at Newtonsoft.Json.Linq.JArray.Load(JsonReader reader, JsonLoadSettings settings)
   at Newtonsoft.Json.Linq.JToken.ReadFrom(JsonReader reader, JsonLoadSettings settings)
   at Newtonsoft.Json.Linq.JToken.ReadFrom(JsonReader reader)
   at GitHub.DistributedTask.Expressions2.Sdk.Functions.FromJson.EvaluateCore(EvaluationContext context, ResultMemory& resultMemory)
   at GitHub.DistributedTask.Expressions2.Sdk.ExpressionNode.Evaluate(EvaluationContext context)
   at GitHub.DistributedTask.Expressions2.Sdk.Functions.Contains.EvaluateCore(EvaluationContext context, ResultMemory& resultMemory)
   at GitHub.DistributedTask.Expressions2.Sdk.ExpressionNode.Evaluate(EvaluationContext context)
   at GitHub.DistributedTask.Expressions2.Sdk.Operators.And.EvaluateCore(EvaluationContext context, ResultMemory& resultMemory)
   at GitHub.DistributedTask.Expressions2.Sdk.ExpressionNode.Evaluate(EvaluationContext context)
   at GitHub.DistributedTask.Expressions2.Sdk.ExpressionNode.GitHub.DistributedTask.Expressions2.IExpressionNode.Evaluate(ITraceWriter trace, ISecretMasker secretMasker, Object state, EvaluationOptions options)
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateToken.EvaluateTemplateToken(TemplateContext context, String expression, Int32& bytes)
   at GitHub.DistributedTask.ObjectTemplating.Tokens.BasicExpressionToken.EvaluateTemplateToken(TemplateContext context, Int32& bytes)
   at GitHub.DistributedTask.ObjectTemplating.TemplateUnraveler.RootBasicExpression()
```