### PR TITLE
RHDHBUGS-2140: Air-gapped install fails because `oc-mirror` command is missing `--v2` flag

### DIFF
--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-helm-chart.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-helm-chart.adoc
@@ -14,7 +14,7 @@ include::snip-installing-the-orchestrator-common-prerequisites.adoc[]
 
 .Procedure
 
-. Create an `ImageSetConfiguration.yaml` file for `oc-mirror`. You must use an `ImageSetConfiguration` file to include all mirrored images required, as shown in the following example:
+. Create an `ImageSetConfiguration.yaml` file for `oc mirror`. You must use an `ImageSetConfiguration` file to include all mirrored images required, as shown in the following example:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -76,16 +76,17 @@ unpack "registry.access.redhat.com/rhdh/plugin-catalog-index:{product-version}"
 # you can then find the `dynamic-plugins.default.yaml` under /tmp/registry.access.redhat.com/rhdh/plugin-catalog-index_{product-version}/dynamic-plugins.default.yaml
 ----
 
-. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc-mirror` command. For example:
+. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc mirror` command. For example:
 +
 [source,terminal,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --config=ImageSetConfiguration.yaml file:///path/to/mirror-archive --authfile /path/to/authfile  --v2
+$ oc mirror --config=ImageSetConfiguration.yaml file:///path/to/mirror-archive --authfile /path/to/authfile --v2
 ----
 +
 [NOTE]
 ====
-The `oc-mirror` command pulls the charts listed in the `ImageSetConfiguration` file and makes them available as `tgz` archives under the `/path/to/mirror-archive` directory.
+. The `--v2` flag is required for {ocp-short} 4.21 and later.
+. The `oc mirror` command pulls the charts listed in the `ImageSetConfiguration` file and makes them available as `tgz` archives under the `/path/to/mirror-archive` directory.
 ====
 +
 . Apply the cluster-wide resources generated during the push step to redirect all image pulls to your local registry, as shown in the following example:
@@ -102,7 +103,7 @@ $ oc apply -f .
 +
 [source,terminal,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --v2 --from <mirror-archive-file> docker://<target-registry-url:port> --workspace file://<workspace folder> --authfile /path/to/authfile
+$ oc mirror --v2 --from <mirror-archive-file> docker://<target-registry-url:port> --workspace file://<workspace folder> --authfile /path/to/authfile
 ----
 +
 where:

--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-operator.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-operator.adoc
@@ -18,7 +18,7 @@ include::snip-installing-the-orchestrator-common-prerequisites.adoc[]
 
 .Procedure
 
-. Create an `ImageSetConfiguration` file for `oc-mirror`. You must include the images and operators required by the Serverless Logic Operator in the `ImageSetConfiguration` file, as shown in the following example:
+. Create an `ImageSetConfiguration` file for `oc mirror`. You must include the images and operators required by the Serverless Logic Operator in the `ImageSetConfiguration` file, as shown in the following example:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -71,16 +71,17 @@ unpack "registry.access.redhat.com/rhdh/plugin-catalog-index:{product-version)"
 # you can then find the `dynamic-plugins.default.yaml` under /tmp/registry.access.redhat.com/rhdh/plugin-catalog-index_{product-version)/dynamic-plugins.default.yaml
 ----
 
-. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc-mirror` command. For example:
+. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc mirror` command. For example:
 +
 [source,terminal,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --config=ImageSetConfiguration.yaml file:///path/to/mirror-archive --authfile /path/to/authfile  --v2
+$ oc mirror --config=ImageSetConfiguration.yaml file:///path/to/mirror-archive --authfile /path/to/authfile --v2
 ----
 +
 [NOTE]
 ====
-The `oc-mirror` command generates a local workspace containing the mirror archive files and the required cluster manifests.
+. The `--v2` flag is required for {ocp-short} 4.21 and later.
+. The `oc mirror` command generates a local workspace containing the mirror archive files and the required cluster manifests.
 ====
 +
 . Transfer the directory specified by `/path/to/mirror-archive` to a bastion host within your disconnected environment.
@@ -89,7 +90,7 @@ The `oc-mirror` command generates a local workspace containing the mirror archiv
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --v2 --from <mirror-archive-file> docker://<target-registry-url:port> --workspace file://<workspace folder> --authfile /path/to/authfile
+$ oc mirror --v2 --from <mirror-archive-file> docker://<target-registry-url:port> --workspace file://<workspace folder> --authfile /path/to/authfile
 ----
 +
 where:

--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-helm-chart.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-helm-chart.adoc
@@ -8,7 +8,7 @@ You can install {product} ({product-very-short}) with the Orchestrator plugin in
 
 A disconnected installation prevents unauthorized access, data transfer, or communication with external sources.
 
-You can use the `oc-mirror` command to mirror resources directly to your accessible local registry and apply the generated cluster resources.
+You can use the `oc mirror` command to mirror resources directly to your accessible local registry and apply the generated cluster resources.
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ include::snip-installing-the-orchestrator-common-prerequisites.adoc[]
 
 .Procedure
 
-. Create an `ImageSetConfiguration.yaml` file for `oc-mirror`. You must use an `ImageSetConfiguration` file to include all mirrored images required, as shown in the following example:
+. Create an `ImageSetConfiguration.yaml` file for `oc mirror`. You must use an `ImageSetConfiguration` file to include all mirrored images required, as shown in the following example:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -54,16 +54,17 @@ mirror:
           maxVersion: {rhoserverless-version}
 ----
 
-. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc-mirror` command to pull images and charts, and push the images directly to the target registry. For example:
+. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc mirror` command to pull images and charts, and push the images directly to the target registry. For example:
 +
 [source,terminal,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --config=imagesetconfiguration.yaml docker://<registry URL:port> --workspace file://<workspace folder> --authfile /path/to/authfile  --v2
+$ oc mirror --config=imagesetconfiguration.yaml docker://<registry URL:port> --workspace file://<workspace folder> --authfile /path/to/authfile --v2
 ----
 +
 [NOTE]
 ====
-The `oc-mirror` command pulls the charts listed in the `ImageSetConfiguration` file and makes them available as `tgz` archives under the `<workspace folder>` directory.
+. The `--v2` flag is required for {ocp-short} 4.21 and later.
+. The `oc mirror` command pulls the charts listed in the `ImageSetConfiguration` file and makes them available as `tgz` archives under the `<workspace folder>` directory.
 ====
 
 . Apply the generated cluster resources to the disconnected cluster. For example:

--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-operator.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-operator.adoc
@@ -8,7 +8,7 @@ You can install {product} with Orchestrator plugin in a partial air-gapped envir
 
 A disconnected installation prevents unauthorized access, data transfer, or communication with external sources.
 
-You can use the `oc-mirror` command to mirror resources directly to your accessible local mirror registry and apply the generated cluster resources.
+You can use the `oc mirror` command to mirror resources directly to your accessible local mirror registry and apply the generated cluster resources.
 
 .Prerequisites
 
@@ -18,7 +18,7 @@ include::snip-installing-the-orchestrator-common-prerequisites.adoc[]
 
 .Procedure
 
-. Create an `ImageSetConfiguration` file for `oc-mirror`. You must include the images and operators required by the Serverless Logic Operator in the `ImageSetConfiguration` file, as shown in the following example:
+. Create an `ImageSetConfiguration` file for `oc mirror`. You must include the images and operators required by the Serverless Logic Operator in the `ImageSetConfiguration` file, as shown in the following example:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -71,14 +71,19 @@ unpack "registry.access.redhat.com/rhdh/plugin-catalog-index:{product-version)"
 # you can then find the `dynamic-plugins.default.yaml` under /tmp/registry.access.redhat.com/rhdh/plugin-catalog-index_{product-version)/dynamic-plugins.default.yaml
 ----
 
-. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc-mirror` command. For example:
+. Mirror the images in the `ImageSetConfiguration.yaml` file by running the `oc mirror` command. For example:
 +
 [source,terminal,subs="+attributes,+quotes"]
 ----
-$ oc-mirror --config=imagesetconfiguration.yaml docker://<registry URL:port> --workspace file://<workspace folder> --authfile /path/to/authfile  --v2
+$ oc mirror --config=imagesetconfiguration.yaml docker://<registry URL:port> --workspace file://<workspace folder> --authfile /path/to/authfile --v2
 $ cd <workspace folder>/working-dir/cluster-resources/
 $ oc apply -f .
 ----
++
+[NOTE]
+====
+The `--v2` flag is required for {ocp-short} 4.21 and later.
+====
 +
 . Install the OpenShift Serverless Operator and OpenShift Serverless Logic Operators using `OperatorHub`.
 

--- a/modules/extend_orchestrator-in-rhdh/snip-installing-the-orchestrator-common-prerequisites.adoc
+++ b/modules/extend_orchestrator-in-rhdh/snip-installing-the-orchestrator-common-prerequisites.adoc
@@ -4,4 +4,4 @@
 
 * You have permissions to push OCI images to your internal container registry.
 
-* You have installed the {ocp-docs-link}/html-single/disconnected_environments/index#installation-oc-mirror-installing-plugin_about-installing-oc-mirror-v2[`oc-mirror`] tool, with a version corresponding to the version of your {ocp-short} cluster.
+* You have installed the {ocp-docs-link}/html-single/disconnected_environments/index#installation-oc-mirror-installing-plugin_about-installing-oc-mirror-v2[`oc mirror`] tool, with a version corresponding to the version of your {ocp-short} cluster.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc
@@ -62,11 +62,11 @@ where:
 `_<my_pulled_image_location>_/install.sh`:: Enter the downloaded installation script and the absolute path to the directory where you stored it on your system.
 `--from-dir _<my_pulled_image_location>_`:: Enter the directory where you want to pull all of the necessary images.
 `--to-registry`:: (Optional) Enter the URL for the target mirror registry where you want to mirror the images.
-`--use-oc-mirror true`:: Recommended on {ocp-short}: Use the `oc-mirror` {ocp-short} CLI plugin to mirror images.
+`--use-oc-mirror true`:: Recommended on {ocp-short}: Use the `oc mirror` {ocp-short} CLI plugin to mirror images.
 +
 [IMPORTANT]
 ====
-If you used `oc-mirror` to mirror the images to disk, you must also use `oc-mirror` to mirror the images from disk due to the folder layout that `oc-mirror` uses.
+If you used `oc mirror` to mirror the images to disk, you must also use `oc mirror` to mirror the images from disk due to the folder layout that `oc mirror` uses.
 ====
 +
 [NOTE]

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc
@@ -34,7 +34,7 @@ For more information, see link:https://access.redhat.com/articles/RegistryAuthen
 * You have installed the `opm` CLI tool.
 For more information, see {ocp-docs-link}/html/cli_tools/opm-cli#olm-about-opm_cli-opm-install[Installing the opm CLI].
 * If you are using an {ocp-short} cluster, you have the following prerequisites:
-** Recommended: You have installed the `oc-mirror` tool, with a version corresponding to the version of your {ocp-short} cluster.
+** Recommended: You have installed the `oc mirror` tool, with a version corresponding to the version of your {ocp-short} cluster.
 * If you are using a supported Kubernetes cluster, you have the following prerequisites:
 ** You have installed the Operator Lifecycle Manager (OLM) on the disconnected cluster.
 ** You have a mirror registry that is reachable from the disconnected cluster.
@@ -61,7 +61,7 @@ $ bash prepare-restricted-environment.sh \
 ----
 where:
 `--to-registry _<my.registry.example.com>`:: Enter the URL for the target mirror registry where you want to mirror the images.
-`--use-oc-mirror true`:: Optional: Use the `oc-mirror` {ocp-short} CLI plugin to mirror images.
+`--use-oc-mirror true`:: Optional: Use the `oc mirror` {ocp-short} CLI plugin to mirror images.
 +
 [NOTE]
 ====

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
@@ -42,7 +42,7 @@ mirror:
 where:
 `version: "{product-version}"`:: Enter the {product} version to mirror.
 
-. Mirror the resources specified in the `ImageSetConfiguration.yaml` file by running the `oc-mirror` command. For example:
+. Mirror the resources specified in the `ImageSetConfiguration.yaml` file by running the `oc mirror` command. For example:
 +
 [source,terminal,subs="+quotes"]
 ----
@@ -76,7 +76,7 @@ Creating archive /path/to/mirror-archive/mirror_seq1_000000.tar
 . The local target registry
 . The target {ocp-short} cluster
 +
-. From your air-gapped environment, mirror the resources from the archive to the target registry by running the `oc-mirror` command. For example:
+. From your air-gapped environment, mirror the resources from the archive to the target registry by running the `oc mirror` command. For example:
 +
 [source,terminal,subs="+quotes"]
 ----

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
@@ -59,7 +59,8 @@ where:
 +
 [NOTE]
 ====
-Running the `oc-mirror` command generates a local workspace containing the mirror archive file, the Helm chart, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) manifests. The IDMS and ITMS manifests contain files that you must apply against the cluster in a later step.
+. The `--v2` flag is required for {ocp-short} 4.21 and later.
+. Running the `oc mirror` command generates a local workspace containing the mirror archive file, the Helm chart, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) manifests. The IDMS and ITMS manifests contain files that you must apply against the cluster in a later step.
 ====
 +
 Example output:

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
@@ -63,7 +63,8 @@ where:
 +
 [NOTE]
 ====
-Running the `oc mirror` command generates a local workspace containing the Helm chart, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) manifests. The IDMS and ITMS manifests contain files that you must apply against the cluster in a later step.
+. The `--v2` flag is required for {ocp-short} 4.21 and later.
+. Running the `oc mirror` command generates a local workspace containing the Helm chart, `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) manifests. The IDMS and ITMS manifests contain files that you must apply against the cluster in a later step.
 ====
 +
 . In your workspace, locate the `ImageDigestMirrorSet` (IDMS) and `ImageTagMirrorSet` (ITMS) files by running the `ls` command. For example:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.8, 1.9, 1.10, main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHDHBUGS-2140](https://redhat.atlassian.net/browse/RHDHBUGS-2140)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
