### PR TITLE
[RHIDP#RHDHBUGS-2796]: Add procedure for HTTP server timeout configuration

### DIFF
--- a/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
+++ b/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
@@ -45,5 +45,5 @@ Where:
 
 .Additional resources
 
-* xref:time-syntax-in-rhdh_{context}[Time syntax in {product}]
+* xref:time-syntax-in-rhdh_rhdh-default-configuration[Time syntax in {product}]
 * {configuring-dynamic-plugins-book-link}#override-core-backend-service-configuration_configuring-dynamic-plugins[Override Core Backend Service Configuration]

--- a/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
+++ b/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
@@ -38,6 +38,10 @@ Where:
 `timeout`:: Socket inactivity timeout. Maximum time a socket can remain idle before being closed.
 `maxHeadersCount`:: Maximum number of incoming HTTP headers allowed per request.
 `maxRequestsPerSocket`:: Maximum number of requests a socket can handle before the connection is closed.
++
+When these settings are not configured, the Node.js defaults apply.
+Timeout values support multiple formats, including human-readable strings, duration objects, and ISO 8601 duration strings.
+For more information, see xref:time-syntax-in-rhdh_rhdh-default-configuration[Time syntax in {product}].
 
 .Verification
 

--- a/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
+++ b/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
@@ -1,0 +1,49 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-http-server-timeouts_{context}"]
+= Configure HTTP server timeouts
+
+[role="_abstract"]
+Adjust HTTP server timeouts to prevent connection drops behind load balancers or when handling long-running API requests.
+
+If your {product} ({product-very-short}) instance is deployed behind a load balancer or reverse proxy, you might need to adjust the backend HTTP server timeouts.
+For example, if the load balancer closes idle connections before the {product-very-short} backend does, clients might experience unexpected disconnects.
+Similarly, long-running operations such as large catalog imports or slow upstream API calls might require longer request timeouts.
+
+.Procedure
+
+* In your `{my-app-config-file}` configuration file, add or update the `backend.server` section:
++
+[source,yaml]
+----
+backend:
+  server:
+    keepAliveTimeout:
+      minutes: 1
+    headersTimeout:
+      minutes: 2
+    requestTimeout:
+      minutes: 1
+    timeout:
+      minutes: 5
+    maxHeadersCount: 2000
+    maxRequestsPerSocket: 100
+----
++
+Where:
++
+`keepAliveTimeout`:: Maximum time an idle keep-alive connection stays open before the server closes it. Set this higher than your load balancer's idle timeout to avoid premature disconnects.
+`headersTimeout`:: Maximum time allowed to receive the complete HTTP request headers. Must be greater than `keepAliveTimeout`.
+`requestTimeout`:: Maximum time allowed for the entire HTTP request, including headers and body.
+`timeout`:: Socket inactivity timeout. Maximum time a socket can remain idle before being closed.
+`maxHeadersCount`:: Maximum number of incoming HTTP headers allowed per request.
+`maxRequestsPerSocket`:: Maximum number of requests a socket can handle before the connection is closed.
+
+.Verification
+
+* Verify that long-running requests or idle connections behave as expected with the new timeout values.
+
+.Additional resources
+
+* xref:time-syntax-in-rhdh_{context}[Time syntax in {product}]
+* {configuring-dynamic-plugins-book-link}override-core-backend-service-configuration_configuring-dynamic-plugins[Override Core Backend Service Configuration]

--- a/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
+++ b/modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc
@@ -46,4 +46,4 @@ Where:
 .Additional resources
 
 * xref:time-syntax-in-rhdh_{context}[Time syntax in {product}]
-* {configuring-dynamic-plugins-book-link}override-core-backend-service-configuration_configuring-dynamic-plugins[Override Core Backend Service Configuration]
+* {configuring-dynamic-plugins-book-link}#override-core-backend-service-configuration_configuring-dynamic-plugins[Override Core Backend Service Configuration]

--- a/titles/configure_configuring-rhdh/master.adoc
+++ b/titles/configure_configuring-rhdh/master.adoc
@@ -38,6 +38,8 @@ include::assemblies/configure_configuring-rhdh/assembly-configure-high-availabil
 
 include::assemblies/configure_configuring-rhdh/assembly-run-rhdh-behind-a-corporate-proxy.adoc[leveloffset=+1]
 
+include::modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc[leveloffset=+1]
+
 include::assemblies/configure_configuring-rhdh/assembly-use-the-dynamic-plugins-cache.adoc[leveloffset=+1]
 
 include::modules/configure_configuring-rhdh/proc-enable-the-rhdh-plugin-assets-cache.adoc[leveloffset=+1]
@@ -51,7 +53,5 @@ include::modules/configure_configuring-rhdh/proc-mount-secrets-and-pvcs-to-speci
 include::modules/configure_configuring-rhdh/ref-configure-rhdh-deployment-when-using-the-operator.adoc[leveloffset=+1]
 
 include::modules/configure_configuring-rhdh/proc-configure-an-rhdh-instance-with-a-tls-connection-in-kubernetes.adoc[leveloffset=+1]
-
-include::modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc[leveloffset=+1]
 
 include::assemblies/configure_configuring-rhdh/assembly-troubleshoot-rhdh-configuration-issues.adoc[leveloffset=+1]

--- a/titles/configure_configuring-rhdh/master.adoc
+++ b/titles/configure_configuring-rhdh/master.adoc
@@ -52,4 +52,6 @@ include::modules/configure_configuring-rhdh/ref-configure-rhdh-deployment-when-u
 
 include::modules/configure_configuring-rhdh/proc-configure-an-rhdh-instance-with-a-tls-connection-in-kubernetes.adoc[leveloffset=+1]
 
+include::modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc[leveloffset=+1]
+
 include::assemblies/configure_configuring-rhdh/assembly-troubleshoot-rhdh-configuration-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.9+
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-2796
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2247/configure_configuring-rhdh/#configure-http-server-timeouts_configuring-rhdh

## Summary
- Add new procedure documenting how to configure HTTP server timeouts via `backend.server` in `app-config.yaml`
- Include the procedure in the Configuring title after the TLS procedure