### PR TITLE
[RHDHBUGS-758]: Add Operator procedure for air-gapped dynamic plugin install

### DIFF
--- a/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-install-dynamic-plugins-in-rhdh.adoc
+++ b/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-install-dynamic-plugins-in-rhdh.adoc
@@ -20,6 +20,8 @@ include::../modules/shared/ref-example-helm-chart-configurations-for-dynamic-plu
 
 include::../modules/shared/ref-installing-dynamic-plugins-in-an-air-gapped-environment.adoc[leveloffset=+1]
 
+include::../modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc[leveloffset=+1]
+
 include::assembly-mirror-rhdh-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-install-dynamic-plugins-in-rhdh.adoc
+++ b/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-install-dynamic-plugins-in-rhdh.adoc
@@ -18,7 +18,7 @@ include::../modules/shared/con-installing-dynamic-plugins-using-the-helm-chart.a
 
 include::../modules/shared/ref-example-helm-chart-configurations-for-dynamic-plugin-installations.adoc[leveloffset=+1]
 
-include::../modules/shared/ref-installing-dynamic-plugins-in-an-air-gapped-environment.adoc[leveloffset=+1]
+include::../modules/shared/ref-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-helm-chart.adoc[leveloffset=+1]
 
 include::../modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc[leveloffset=+1]
 

--- a/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
+++ b/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
@@ -1,0 +1,72 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator_{context}"]
+= Install dynamic plugins in an air-gapped environment by using the Operator
+
+[role="_abstract"]
+In an air-gapped environment, you can install external dynamic plugins by configuring a custom NPM registry for the {product-short} Operator. You create a Kubernetes Secret containing a `.npmrc` file and mount it into the `install-dynamic-plugins` init container.
+
+.Prerequisites
+
+* An {ocp-short} administrator has installed the {product} Operator.
+* You have set up a custom NPM registry that is accessible from within your cluster and contains the required dynamic plugin packages.
+
+.Procedure
+
+. Create a Secret containing your `.npmrc` configuration that points to your internal NPM registry:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dynamic-plugins-npmrc
+type: Opaque
+stringData:
+  .npmrc: |
+    registry=https://_<your_internal_registry>_
+    //_<your_internal_registry>_:_authToken=_<your_auth_token>_
+----
+
+. Apply the Secret to your namespace:
++
+[source,terminal,subs="+attributes"]
+----
+$ oc apply -f dynamic-plugins-npmrc.yaml -n {my-product-namespace}
+----
+
+. Add the Secret to the `spec.application.extraFiles.secrets` field in your `{product-custom-resource-type}` CR, targeting the `install-dynamic-plugins` init container:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: rhdh.redhat.com/v1alpha5
+kind: {product-custom-resource-type}
+metadata:
+  name: my-rhdh
+spec:
+  application:
+    extraFiles:
+      secrets:
+        - name: dynamic-plugins-npmrc
+          mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
+          containers:
+            - install-dynamic-plugins
+----
++
+The `install-dynamic-plugins` init container reads the `.npmrc` file from `/opt/app-root/src/.npmrc.dynamic-plugins/.npmrc` to resolve plugin packages from your internal registry.
+
+. Apply the updated CR:
++
+[source,terminal,subs="+attributes"]
+----
+$ oc apply -f my-rhdh.yaml -n {my-product-namespace}
+----
+
+.Verification
+
+* Verify that the init container used your custom registry by checking the init container logs:
++
+[source,terminal]
+----
+$ oc logs -c install-dynamic-plugins deploy/backstage-my-rhdh
+----

--- a/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
+++ b/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
@@ -4,7 +4,7 @@
 = Install dynamic plugins in an air-gapped environment by using the Operator
 
 [role="_abstract"]
-In an air-gapped environment, you can install external dynamic plugins by configuring a custom NPM registry for the {product-short} Operator. You create a Kubernetes secret containing a `.npmrc` file and mount it into the `install-dynamic-plugins` init container.
+To install external dynamic plugins in an air-gapped environment, configure a custom NPM registry by mounting a secret into the {product-short} Operator.
 
 .Prerequisites
 

--- a/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
+++ b/modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc
@@ -4,7 +4,7 @@
 = Install dynamic plugins in an air-gapped environment by using the Operator
 
 [role="_abstract"]
-In an air-gapped environment, you can install external dynamic plugins by configuring a custom NPM registry for the {product-short} Operator. You create a Kubernetes Secret containing a `.npmrc` file and mount it into the `install-dynamic-plugins` init container.
+In an air-gapped environment, you can install external dynamic plugins by configuring a custom NPM registry for the {product-short} Operator. You create a Kubernetes secret containing a `.npmrc` file and mount it into the `install-dynamic-plugins` init container.
 
 .Prerequisites
 
@@ -13,7 +13,7 @@ In an air-gapped environment, you can install external dynamic plugins by config
 
 .Procedure
 
-. Create a Secret containing your `.npmrc` configuration that points to your internal NPM registry:
+. Create a secret containing your `.npmrc` configuration that points to your internal NPM registry:
 +
 [source,yaml,subs="+quotes"]
 ----
@@ -28,14 +28,14 @@ stringData:
     //_<your_internal_registry>_:_authToken=_<your_auth_token>_
 ----
 
-. Apply the Secret to your namespace:
+. Apply the secret to your namespace:
 +
 [source,terminal,subs="+attributes"]
 ----
 $ oc apply -f dynamic-plugins-npmrc.yaml -n {my-product-namespace}
 ----
 
-. Add the Secret to the `spec.application.extraFiles.secrets` field in your `{product-custom-resource-type}` CR, targeting the `install-dynamic-plugins` init container:
+. Add the secret to the `spec.application.extraFiles.secrets` field in your `{product-custom-resource-type}` custom resource, targeting the `install-dynamic-plugins` init container:
 +
 [source,yaml,subs="+attributes"]
 ----
@@ -55,7 +55,7 @@ spec:
 +
 The `install-dynamic-plugins` init container reads the `.npmrc` file from `/opt/app-root/src/.npmrc.dynamic-plugins/.npmrc` to resolve plugin packages from your internal registry.
 
-. Apply the updated CR:
+. Apply the updated custom resource:
 +
 [source,terminal,subs="+attributes"]
 ----

--- a/modules/shared/ref-example-helm-chart-configurations-for-dynamic-plugin-installations.adoc
+++ b/modules/shared/ref-example-helm-chart-configurations-for-dynamic-plugin-installations.adoc
@@ -41,7 +41,7 @@ global:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-      - package: <some imported plugins listed in dynamic-plugins.custom.yaml>
+      - package: <some imported plugin listed in dynamic-plugins.default.yaml>
         disabled: false
 ----
 
@@ -54,6 +54,6 @@ global:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-      - package: <some imported plugins listed in dynamic-plugins.custom.yaml>
-        disabled: false
+      - package: <some disabled plugin listed in dynamic-plugins.default.yaml>
+        disabled: false # overrides disabled: true from the included file
 ----

--- a/modules/shared/ref-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-helm-chart.adoc
+++ b/modules/shared/ref-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="installing-dynamic-plugins-in-an-air-gapped-environment_{context}"]
-= Installing dynamic plugins in an air-gapped environment
+[id="install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-helm-chart_{context}"]
+= Install dynamic plugins in an air-gapped environment by using the Helm chart
 
 [role="_abstract"]
 You can install external plugins in an air-gapped environment by setting up a custom NPM registry.


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHDHBUGS-758](https://redhat.atlassian.net/browse/RHDHBUGS-758)

**Preview:**  https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2260/extend_installing-and-viewing-plugins-in-rhdh/#install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator_install-dynamic-plugins-in-rhdh

## Summary

The existing air-gapped plugin install docs only cover the Helm chart method. This PR adds an Operator-specific procedure.

The procedure covers:
1. Creating a Secret with `.npmrc` content pointing to an internal NPM registry
2. Mounting the Secret into the `install-dynamic-plugins` init container via `spec.application.extraFiles.secrets` at `/opt/app-root/src/.npmrc.dynamic-plugins`
3. The init container reads the `.npmrc` automatically via the pre-configured `NPM_CONFIG_USERCONFIG` env var

Technical details sourced from the [upstream Operator docs](https://github.com/redhat-developer/rhdh-operator/blob/main/docs/dynamic-plugins.md).

## Test plan

- [ ] CQA checks pass
- [ ] Procedure renders correctly in HTML preview
- [ ] Placed after the existing Helm-based air-gapped reference in the plugins title
- [ ] YAML examples are valid and use correct attribute substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)