### PR TITLE
[RHDHBUGS-474]: Improve third-party plugin installation examples

### DIFF
--- a/modules/shared/proc-create-an-oci-image-with-dynamic-packages.adoc
+++ b/modules/shared/proc-create-an-oci-image-with-dynamic-packages.adoc
@@ -25,6 +25,13 @@ $ npx @red-hat-developer-hub/cli@latest plugin package --tag quay.io/example/ima
 
 In the earlier command, the `--tag` argument specifies the image name and tag.
 --
+. Ensure that your container runtime (`podman` or `docker`) is running and that you are logged in to the target image registry:
++
+[source,terminal]
+----
+$ podman login quay.io
+----
+
 . Run one of the following commands to push the image to a registry:
 +
 --

--- a/modules/shared/proc-load-a-plugin-packaged-as-an-oci-image.adoc
+++ b/modules/shared/proc-load-a-plugin-packaged-as-an-oci-image.adoc
@@ -12,7 +12,12 @@ Use this procedure to load a dynamic plugin from an OCI image into {product}.
 For more information about packaging a {plugin-type-name} plugin, see xref:package-and-publish-plugins-as-dynamic-plugins_plugins-in-rhdh[].
 
 .Procedure
-. To retrieve plugins from an authenticated registry, complete the following steps:
+. To retrieve plugins from an authenticated registry, such as a private repository, complete the following steps:
++
+[NOTE]
+====
+If your OCI image is stored in a public registry, you can skip this step.
+====
 .. Log in to the container image registry.
 +
 [source,yaml]
@@ -33,7 +38,7 @@ oc create secret generic _<secret_name>_ --from-file=auth.json=${XDG_RUNTIME_DIR
 ----
 +
 ** For an Operator-based deployment, replace _<secret_name>_ with `dynamic-plugins-registry-auth`.
-** For a Helm-based deployment, replace _<secret_name>_ with `<Helm_release_name>_-dynamic-plugins-registry-auth`.
+** For a Helm-based deployment, replace _<secret_name>_ with `<Helm_release_name>-dynamic-plugins-registry-auth`.
 
 . Define the plugin with the `oci://` prefix by using one of the following formats in your `dynamic-plugins.yaml` file:
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHDHBUGS-474](https://redhat.atlassian.net/browse/RHDHBUGS-474)

**Preview:** N/A (pending CI build)

## Summary

Three fixes to third-party plugin installation docs:

1. **Fix underscore typo** in Helm secret name: `<Helm_release_name>_-dynamic-plugins-registry-auth` → `<Helm_release_name>-dynamic-plugins-registry-auth` (proc-load-a-plugin-packaged-as-an-oci-image.adoc)
2. **Add registry login step** before pushing OCI image — ensures podman/docker is running and user is authenticated (proc-create-an-oci-image-with-dynamic-packages.adoc)
3. **Clarify private repo auth** — add NOTE that the authenticated registry step can be skipped for public registries (proc-load-a-plugin-packaged-as-an-oci-image.adoc)

## Test plan

- [ ] CQA checks pass
- [ ] Secret name renders without underscore typo
- [ ] Login step appears before push step in OCI image procedure
- [ ] NOTE about public registries renders in the load plugin procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)