### PR TITLE
[RHDHBUGS-829]: Add Quick Access card xref to home page layout procedure

### DIFF
--- a/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
+++ b/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
@@ -127,4 +127,4 @@ dynamicPlugins:
 
 [role="_additional-resources"]
 .Additional resources
-* xref:customize-the-quick-access-card_{context}[Customize the Quick access card]
+* xref:customize-the-quick-access-card_customize-the-quick-access-card[Customize the Quick access card]

--- a/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
+++ b/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
@@ -127,4 +127,4 @@ dynamicPlugins:
 
 [role="_additional-resources"]
 .Additional resources
-* xref:customize-the-quick-access-card_customize-the-quick-access-card[Customize the Quick access card]
+* xref:customize-the-quick-access-card_customizing-rhdh[Customize the Quick access card]

--- a/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
+++ b/modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc
@@ -124,3 +124,7 @@ dynamicPlugins:
               showBorder: true
               debugContent: right
 ----
+
+[role="_additional-resources"]
+.Additional resources
+* xref:customize-the-quick-access-card_{context}[Customize the Quick access card]


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHDHBUGS-829](https://redhat.atlassian.net/browse/RHDHBUGS-829)

**Preview:** N/A (pending CI build)

## Summary

The home page layout procedure (`proc-define-the-layout-of-the-rhdh-home-page.adoc`) had no cross-reference to the Quick Access card customization section. Users looking to customize the Quick Access card content (including hosted JSON files) had no link from the home page docs.

Adds an Additional resources section with an xref to `customize-the-quick-access-card`.

## Test plan

- [ ] CQA checks pass
- [ ] xref resolves correctly in the Customizing title
- [ ] Link appears at the end of the home page layout procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)