### PR TITLE
[RHDHBUGS-3055]: Fix unresolved attributes rendering as raw text

### DIFF
--- a/modules/shared/snip-provision-configuration-appconfig-intro.adoc
+++ b/modules/shared/snip-provision-configuration-appconfig-intro.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: SNIPPET
-
 . Author your custom `{my-app-config-file}` file.
 This is the main {product-short} configuration file.
 You need a custom `{my-app-config-file}` file to avoid the {product-short} installer to revert user edits during upgrades.

--- a/modules/shared/snip-provision-configuration-common-prerequisite.adoc
+++ b/modules/shared/snip-provision-configuration-common-prerequisite.adoc
@@ -1,3 +1,2 @@
 :_mod-docs-content-type: SNIPPET
-
 * By using the {platform-cli-link}, you have access, with developer permissions, to the {platform-generic} cluster aimed at containing your {product-short} instance.

--- a/modules/shared/snip-provision-configuration-final-steps.adoc
+++ b/modules/shared/snip-provision-configuration-final-steps.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: SNIPPET
-
 . Author your custom `dynamic-plugins.yaml` file to enable plugins.
 By default, {product-short} enables a minimal plugin set, and disables plugins that require configuration or secrets, such as the GitHub repository discovery plugin and the Role-based access control (RBAC) plugin.
 +

--- a/modules/shared/snip-provision-configuration-secrets-intro.adoc
+++ b/modules/shared/snip-provision-configuration-secrets-intro.adoc
@@ -1,4 +1,3 @@
 :_mod-docs-content-type: SNIPPET
-
 . For security, store your secrets as environment variables values in an {ocp-short} secret, rather than in plain text in your configuration files.
 Collect all your secrets in the `secrets.txt` file, with one secret per line in `KEY=value` form.

--- a/modules/shared/snip-provision-configuration-tip.adoc
+++ b/modules/shared/snip-provision-configuration-tip.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: SNIPPET
-
 [TIP]
 ====
 On {ocp-brand-name}, you can skip this step to run {product-short} with the default config map and secret.

--- a/titles/configure_configuring-rhdh/master.adoc
+++ b/titles/configure_configuring-rhdh/master.adoc
@@ -16,6 +16,7 @@ include::artifacts/attributes.adoc[]
 :platform-cli-name: {ocp-brand-name} CLI ('oc')
 :a-platform-generic: an OpenShift
 :platform-generic: OpenShift
+:namespace: project
 :optional-steps: enable
 
 [id="{context}"]

--- a/titles/get-started_setting-up-and-configuring-your-first-red-hat-developer-hub-instance/master.adoc
+++ b/titles/get-started_setting-up-and-configuring-your-first-red-hat-developer-hub-instance/master.adoc
@@ -8,6 +8,15 @@ include::artifacts/attributes.adoc[]
 :abstract: Prepare your IT infrastructure including {ocp-brand-name} and required external components, and run your first {product} ({product-very-short}) instance in production.
 :context: setting-up-and-configuring-your-first-red-hat-developer-hub-instance
 
+:platform-id: ocp
+:platform-long: {ocp-brand-name} ({ocp-very-short})
+:platform: {ocp-short}
+:platform-cli: oc
+:platform-cli-link: {ocp-docs-link}/html-single/cli_tools/index#cli-about-cli_cli-developer-commands[{openshift-cli}]
+:platform-cli-name: {ocp-brand-name} CLI ('oc')
+:a-platform-generic: an OpenShift
+:platform-generic: OpenShift
+:namespace: project
 :optional-steps: disable
 
 [id="{context}"]

--- a/titles/install_installing-rhdh-on-aks/master.adoc
+++ b/titles/install_installing-rhdh-on-aks/master.adoc
@@ -11,6 +11,7 @@ include::artifacts/attributes.adoc[]
 :platform: {aks-short}
 :a-platform-generic: a Kubernetes
 :platform-generic: Kubernetes
+:namespace: namespace
 :optional-steps: disable
 
 :title: {installing-on-aks-book-title}

--- a/titles/install_installing-rhdh-on-eks/master.adoc
+++ b/titles/install_installing-rhdh-on-eks/master.adoc
@@ -11,6 +11,7 @@ include::artifacts/attributes.adoc[]
 :platform-id: eks
 :a-platform-generic: a Kubernetes
 :platform-generic: Kubernetes
+:namespace: namespace
 :optional-steps: disable
 
 :title: {installing-on-eks-book-title}

--- a/titles/install_installing-rhdh-on-gke/master.adoc
+++ b/titles/install_installing-rhdh-on-gke/master.adoc
@@ -10,6 +10,7 @@ include::artifacts/attributes.adoc[]
 :platform: {gke-short}
 :a-platform-generic: a Kubernetes
 :platform-generic: Kubernetes
+:namespace: namespace
 :optional-steps: disable
 
 :title: {installing-on-gke-book-title}


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHDHBUGS-3055](https://redhat.atlassian.net/browse/RHDHBUGS-3055)

**Preview:** N/A (pending CI build)

## Summary

The Setting Up title's published page renders raw AsciiDoc syntax instead of formatted content. Three root causes:

1. **`:_mod-docs-content-type: SNIPPET` visible as text** — the blank line after this metadata in snippet files creates a separate paragraph context inside list continuations, causing AsciiDoc to render it as literal text instead of processing it as an attribute. Fixed by removing the blank line in all 5 provisioning snippets.

2. **Unresolved platform attributes** — the Setting Up title includes shared provisioning snippets that use `{platform-cli-link}`, `{platform-long}`, `{platform-generic}`, `{platform}` defined only in the Configuring title. Fixed by adding the platform attribute definitions to the Setting Up `master.adoc`.

3. **Unresolved `{namespace}` attribute** — used as a word but interpreted as an attribute reference. Fixed by defining `{namespace}` as a platform-conditional attribute: "project" on OCP, "namespace" on Kubernetes (EKS, AKS, GKE).

## Test plan

- [ ] CQA checks pass
- [ ] Setting Up title no longer shows raw `:_mod-docs-content-type: SNIPPET`
- [ ] Platform CLI link renders as a proper hyperlink
- [ ] `{namespace}` resolves to "project" in OCP context, "namespace" in K8s context

🤖 Generated with [Claude Code](https://claude.com/claude-code)