### PR TITLE
[RHIDP-2870]: Extract shared ObjectBucketClaim env vars into a reusable snippet

### DIFF
--- a/modules/configure_techdocs-for-rhdh/proc-make-object-storage-accessible-to-containers-by-using-the-helm-chart.adoc
+++ b/modules/configure_techdocs-for-rhdh/proc-make-object-storage-accessible-to-containers-by-using-the-helm-chart.adoc
@@ -8,15 +8,7 @@ Add `ObjectBucketClaim` access information to the Helm chart configuration to ma
 
 Creating an `ObjectBucketClaim` custom resource (CR) automatically generates both the {product-short} `ObjectBucketClaim` config map and secret. The config map and secret contain `ObjectBucket` access information. The Helm chart uses the following environment variables:
 
-* `BUCKET_NAME`
-* `BUCKET_HOST`
-* `BUCKET_PORT`
-* `BUCKET_REGION`
-* `BUCKET_SUBREGION`
-* `{aws-short}_ACCESS_KEY_ID`
-* `{aws-short}_SECRET_ACCESS_KEY`
-
-These variables are then used in the TechDocs plugin configuration.
+include::snip-objectbucketclaim-environment-variables.adoc[]
 
 .Prerequisites
 

--- a/modules/configure_techdocs-for-rhdh/proc-make-object-storage-accessible-to-containers-by-using-the-operator.adoc
+++ b/modules/configure_techdocs-for-rhdh/proc-make-object-storage-accessible-to-containers-by-using-the-operator.adoc
@@ -8,15 +8,7 @@ Add `ObjectBucketClaim` access information to the Operator configuration to make
 
 Creating an `ObjectBucketClaim` custom resource (CR) automatically generates both the {product-short} `ObjectBucketClaim` config map and secret. The config map and secret contain `ObjectBucket` access information. The Operator uses the following environment variables:
 
-* `BUCKET_NAME`
-* `BUCKET_HOST`
-* `BUCKET_PORT`
-* `BUCKET_REGION`
-* `BUCKET_SUBREGION`
-* `{aws-short}_ACCESS_KEY_ID`
-* `{aws-short}_SECRET_ACCESS_KEY`
-
-These variables are then used in the TechDocs plugin configuration.
+include::snip-objectbucketclaim-environment-variables.adoc[]
 
 .Prerequisites
 

--- a/modules/configure_techdocs-for-rhdh/snip-objectbucketclaim-environment-variables.adoc
+++ b/modules/configure_techdocs-for-rhdh/snip-objectbucketclaim-environment-variables.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: SNIPPET
+* `BUCKET_NAME`
+* `BUCKET_HOST`
+* `BUCKET_PORT`
+* `BUCKET_REGION`
+* `BUCKET_SUBREGION`
+* `{aws-short}_ACCESS_KEY_ID`
+* `{aws-short}_SECRET_ACCESS_KEY`
+
+These variables are then used in the TechDocs plugin configuration.


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHIDP-2870](https://redhat.atlassian.net/browse/RHIDP-2870)

**Preview:** N/A (pending CI build)

## Summary

The BUCKET_NAME/HOST/PORT/REGION/SUBREGION and AWS credential variable list was duplicated in both TechDocs object storage procedures (Operator and Helm chart). Extract into a shared snippet and replace with includes.

- **Create:** `snip-objectbucketclaim-environment-variables.adoc`
- **Modify:** Both `proc-make-object-storage-accessible-to-containers-by-using-the-*.adoc` files

## Test plan

- [ ] CQA checks pass on TechDocs title
- [ ] Variable list renders correctly in both procedures
- [ ] No content change visible to readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)