### PR TITLE
[RHDHBUGS-686]: Fix Support button prerequisite to require app.support.items

### DIFF
--- a/modules/shared/proc-customize-your-rhdh-global-header.adoc
+++ b/modules/shared/proc-customize-your-rhdh-global-header.adoc
@@ -116,7 +116,19 @@ The `red-hat-developer-hub.backstage-plugin-global-header` package (enabled by d
 Specifies the position of the header. Supported values are `above-main-content` and `above-sidebar`.
 
 .Prerequisites
-* You must configure the support URL in the `{my-app-config-file}` file to display the *Support* button in the header.
+* To display the *Support* button in the header, you must configure both the `app.support.url` and `app.support.items` fields in your `{my-app-config-file}` file. For example:
++
+[source,yaml]
+----
+app:
+  support:
+    url: https://support.example.com
+    items:
+      - title: Support
+        links:
+          - url: https://support.example.com
+            title: Open a support case
+----
 * You must install the notifications plugin to display the *Notifications* button in the header.
 
 .Procedure

--- a/modules/shared/proc-customize-your-rhdh-global-header.adoc
+++ b/modules/shared/proc-customize-your-rhdh-global-header.adoc
@@ -116,19 +116,6 @@ The `red-hat-developer-hub.backstage-plugin-global-header` package (enabled by d
 Specifies the position of the header. Supported values are `above-main-content` and `above-sidebar`.
 
 .Prerequisites
-* To display the *Support* button in the header, you must configure both the `app.support.url` and `app.support.items` fields in your `{my-app-config-file}` file. For example:
-+
-[source,yaml]
-----
-app:
-  support:
-    url: https://support.example.com
-    items:
-      - title: Support
-        links:
-          - url: https://support.example.com
-            title: Open a support case
-----
 * You must install the notifications plugin to display the *Notifications* button in the header.
 
 .Procedure
@@ -186,4 +173,18 @@ where:
 ----
 - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
   disabled: true
+----
+
+. Optional: To display the *Support* button in the header, configure the `app.support.url` and `app.support.items` fields in your `{my-app-config-file}` file. For example:
++
+[source,yaml]
+----
+app:
+  support:
+    url: https://support.example.com
+    items:
+      - title: Support
+        links:
+          - url: https://support.example.com
+            title: Open a support case
 ----


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** - PR for review only. Target: upstream `main`.

**Version(s):** 1.9, 1.10+

**Issue:** [RHDHBUGS-686](https://redhat.atlassian.net/browse/RHDHBUGS-686)

**Preview:** N/A (pending CI build)

## Summary

The global header procedure's prerequisite said to configure `app.support.url` to display the Support button, but `app.support.items` is also required. Without it, the UI crashes with: `Missing required config value at 'app.support.items' in 'app-config.yaml'`.

Updated the prerequisite to mention both fields and added a YAML example showing the complete `app.support` configuration.

## Test plan

- [ ] CQA checks pass
- [ ] YAML example is valid
- [ ] Prerequisite clearly states both fields are required

🤖 Generated with [Claude Code](https://claude.com/claude-code)