### PR TITLE
RHDHBUGS-3207: NFS documentation is missing a banner indicating Dev/Tech Preview feature status

### DIFF
--- a/assemblies/configure_configuring-rhdh/assembly-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
+++ b/assemblies/configure_configuring-rhdh/assembly-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
@@ -10,6 +10,8 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 Migrate your {product} environment to the extension-based front-end system to use blueprint-based dynamic routing for improved extensibility and performance.
 
+include::{docdir}/artifacts/snip-developer-preview.adoc[]
+
 // Customize the interface theme
 include::../modules/shared/proc-customize-platform-appearance-to-reflect-your-brand-identity.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10, main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHDHBUGS-3207](https://redhat.atlassian.net/browse/RHDHBUGS-3207)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[3. Migrate to the front-end system to use blueprint-based dynamic routing](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2271/configure_configuring-rhdh/#migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing_configuring-rhdh)
