### PR TITLE
RHDHBUGS-3306: Removed Developer Preview snippet for Adoption Insights

### DIFF
--- a/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
@@ -4,6 +4,7 @@
 
 [role="_abstract"]
 Adoption Insights is enabled by default on {product-short} instances.
+// cqa-17: suppress
 If you are migrating from a Developer Preview or you have installed Adoption Insights manually before, update your configuration.
 
 .Procedure

--- a/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
@@ -4,7 +4,7 @@
 
 [role="_abstract"]
 Adoption Insights is enabled by default on {product-short} instances.
-If you are migrating from a {developer-preview} or you have installed Adoption Insights manually before, update your configuration.
+If you are migrating from a Developer Preview or you have installed Adoption Insights manually before, update your configuration.
 
 .Procedure
 

--- a/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
@@ -6,8 +6,6 @@
 Adoption Insights is enabled by default on {product-short} instances.
 If you are migrating from a {developer-preview} or you have installed Adoption Insights manually before, update your configuration.
 
-include::{docdir}/artifacts/snip-developer-preview.adoc[]
-
 .Procedure
 
 . Remove legacy plugins, because Adoption Insights is now built-in. Delete the following references from your dynamic-plugins.yaml file:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
main, release-1.10, release-1.9
**Issue:**
[RHDHBUGS-3306](https://redhat.atlassian.net/browse/RHDHBUGS-3306)
**Preview:**
https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2320/observability_adoption-insights-in-rhdh/#enable-the-adoption-insights-plugin_adoption-insights-in-rhdh
