### PR TITLE
RHDHBUGS-3348: Orchestrator pluginConfig docs buried in air-gapped section and YAML indentation error

### DIFF
--- a/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
@@ -116,7 +116,7 @@ Where:
 +
 [IMPORTANT]
 ====
-Ensure correct indentation: `if` must be at the same level as `layout` under `config`, and conditions under `anyOf` must be indented two more levels. Incorrect indentation can cause the *Workflows* tab to appear on all entity types, including User and Group entities.
+Make sure the indentation is correct: `if` must be at the same level as `layout` under `config`, and conditions under `anyOf` must be indented two more levels. Incorrect indentation can cause the *Workflows* tab to appear on all entity types, including User and Group entities.
 
 To restrict the *Workflows* tab to only `Component` entities, modify the `if` condition:
 +

--- a/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
@@ -117,7 +117,7 @@ Where:
 [IMPORTANT]
 ====
 Make sure the indentation is correct: `if` must be at the same level as `layout` under `config`, and conditions under `anyOf` must be indented two more levels. Incorrect indentation can cause the *Workflows* tab to appear on all entity types, including User and Group entities.
-
++
 To restrict the *Workflows* tab to only `Component` entities, modify the `if` condition:
 +
 [source,yaml]

--- a/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
@@ -117,9 +117,9 @@ Where:
 [IMPORTANT]
 ====
 Make sure the indentation is correct: `if` must be at the same level as `layout` under `config`, and conditions under `anyOf` must be indented two more levels. Incorrect indentation can cause the *Workflows* tab to appear on all entity types, including User and Group entities.
-+
+
 To restrict the *Workflows* tab to only `Component` entities, modify the `if` condition:
-+
+
 [source,yaml]
 ----
                   if:

--- a/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
@@ -37,7 +37,7 @@ Provides callable actions from Scaffolder templates, such as `orchestrator:workf
 * (Optional) To use Tekton tasks and the build pipeline, you have an instance of Tekton or Red Hat OpenShift Pipelines in the cluster. These features are disabled by default.
 
 .Procedure
-* Locate your {product-short} configuration and enable the Orchestrator plugins and the supporting notification plugins.
+. Locate your {product-short} configuration and enable the Orchestrator plugins and the supporting notification plugins.
 +
 The `{{inherit}}` attribute in the package field automatically resolves to the default plugin version and configuration for your version of {product-very-short}.
 +
@@ -65,4 +65,66 @@ plugins:
 [NOTE]
 ====
 If you need a specific plugin version, replace `{{inherit}}` with the version tag, for example: `oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:1.3.0`.
+====
+
+. Optional: Restrict where the *Workflows* tab appears.
++
+By default, the *Workflows* tab appears on all entity types. To display it only on specific entities, add the `pluginConfig` section with filtering conditions.
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+plugins:
+  - package: "oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{inherit}}"
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          red-hat-developer-hub.backstage-plugin-orchestrator:
+            appIcons:
+              - importName: OrchestratorIcon
+                name: orchestratorIcon
+            dynamicRoutes:
+              - importName: OrchestratorPage
+                menuItem:
+                  icon: orchestratorIcon
+                  text: Orchestrator
+                  textKey: menuItem.orchestrator
+                path: /orchestrator
+            entityTabs:
+              - path: /workflows
+                title: Workflows
+                titleKey: catalog.entityPage.workflows.title
+                mountPoint: entity.page.workflows
+            mountPoints:
+              - mountPoint: entity.page.workflows/cards
+                importName: OrchestratorCatalogTab
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                      - IsOrchestratorCatalogTabAvailable
+----
++
+Where:
++
+`IsOrchestratorCatalogTabAvailable`::: A condition function exported by the Orchestrator plugin that checks whether the entity has workflow-related data or annotations.
++
+`layout.gridColumn`::: Controls the grid layout positioning. The value `1 / -1` spans the full width of the grid.
++
+`if.anyOf`::: Specifies that the tab appears if any of the listed conditions are met. Add conditions like `isKind: component` to further restrict where the tab appears.
++
+[IMPORTANT]
+====
+Ensure correct indentation: `if` must be at the same level as `layout` under `config`, and conditions under `anyOf` must be indented two more levels. Incorrect indentation can cause the *Workflows* tab to appear on all entity types, including User and Group entities.
+
+To restrict the *Workflows* tab to only `Component` entities, modify the `if` condition:
++
+[source,yaml]
+----
+                  if:
+                    allOf:
+                      - IsOrchestratorCatalogTabAvailable
+                      - isKind: component
+----
 ====

--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-helm-chart.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-fully-disconnected-ocp-environment-using-the-helm-chart.adoc
@@ -176,10 +176,10 @@ orchestrator:
                 importName: OrchestratorCatalogTab
                 config:
                   layout:
-                  gridColumn: 1 / -1
+                    gridColumn: 1 / -1
                   if:
                     anyOf:
-                    - IsOrchestratorCatalogTabAvailable
+                      - IsOrchestratorCatalogTabAvailable
     - package: oci://<custom_registry_url>/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@_<digest>_
       disabled: true
       pluginConfig:

--- a/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-helm-chart.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-install-rhdh-with-orchestrator-in-a-partially-disconnected-ocp-environment-using-the-helm-chart.adoc
@@ -135,10 +135,10 @@ orchestrator:
                 importName: OrchestratorCatalogTab
                 config:
                   layout:
-                  gridColumn: 1 / -1
+                    gridColumn: 1 / -1
                   if:
                     anyOf:
-                    - IsOrchestratorCatalogTabAvailable
+                      - IsOrchestratorCatalogTabAvailable
     - - package: oci://<custom_registry_url>/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator@_<digest>_
       disabled: true
       pluginConfig:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.9, 1.10, main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHDHBUGS-3348](https://redhat.atlassian.net/browse/RHDHBUGS-3348)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[2.1. Configure Orchestrator plugins](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2361/extend_orchestrator-in-rhdh/#configure-orchestrator-plugins_enable-orchestrator-plugins-components)