### PR TITLE
RHDHBUGS-3352-release-1.10 : Fix anchor ID format for section headings

### DIFF
--- a/modules/shared/ref-servicenow-configuration-parameters.adoc
+++ b/modules/shared/ref-servicenow-configuration-parameters.adoc
@@ -5,6 +5,7 @@
 [role="_abstract"]
 The ServiceNow integration requires specific parameters in your configuration files to establish a connection between {product} and your ServiceNow instances. Use these parameters to define authentication methods, instance URLs, and UI layouts.
 
+[id="servicenow-backend-and-frontend-configuration_{context}"]
 == ServiceNow backend and frontend configuration
 Define the following parameters in the `app-config.yaml` file or the `dynamic-plugins.yaml` section of the `{product}` ConfigMap to enable the backend and frontend plugins.
 
@@ -19,6 +20,7 @@ Define the following parameters in the `app-config.yaml` file or the `dynamic-pl
 | `oauth.clientSecret` | The client secret for OAuth authentication. | Optional
 |===
 
+[id="servicenow-scaffolder-configuration_{context}"]
 == ServiceNow scaffolder configuration
 The ServiceNow Scaffolder module requires a separate configuration block. Note that this module uses `baseUrl` instead of `instanceUrl`.
 
@@ -30,9 +32,11 @@ The ServiceNow Scaffolder module requires a separate configuration block. Note t
 | `password` | The service account password. | Required for Basic authentication
 |===
 
+[id="servicenow-authentication-examples_{context}"]
 == Authentication examples
 The following examples demonstrate how to structure different authentication methods in your configuration.
 
+[id="servicenow-basic-authentication-example_{context}"]
 == Basic authentication example
 [source,yaml]
 ----
@@ -42,6 +46,7 @@ servicenow:
   password: ${SERVICENOW_PASS}
 ----
 
+[id="servicenow-oauth-client-credentials_{context}"]
 == OAuth with Client Credentials
 [source,yaml]
 ----
@@ -53,6 +58,7 @@ servicenow:
     clientSecret: ${SERVICENOW_CLIENT_SECRET}
 ----
 
+[id="servicenow-oauth-password-grant_{context}"]
 == OAuth with Password Grant
 [source,yaml]
 ----
@@ -66,6 +72,7 @@ servicenow:
     password: ${SERVICENOW_PASS}
 ----
 
+[id="servicenow-frontend-ui-configuration_{context}"]
 == Frontend UI configuration
 The frontend plugin configuration defines how ServiceNow data appears on component entity pages.
 


### PR DESCRIPTION
Added anchor IDs with [id="..."] format to all section headings to comply with repository standards and enable cross-referencing.

Updated all == section headings in ref-servicenow-configuration-parameters.adoc:
- ServiceNow backend and frontend configuration
- ServiceNow scaffolder configuration
- Authentication examples
- Basic authentication example
- OAuth with Client Credentials
- OAuth with Password Grant
- Frontend UI configuration

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:**
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
