### PR TITLE
docs(bulk-import): fix prerequisites to reference integration instead of user auth

### DIFF
--- a/modules/shared/proc-enable-and-authorize-bulk-import-capabilities-in-rhdh.adoc
+++ b/modules/shared/proc-enable-and-authorize-bulk-import-capabilities-in-rhdh.adoc
@@ -7,13 +7,8 @@
 Enable Bulk Import plugins and configure RBAC permissions to allow users to import multiple GitHub repositories and GitLab projects into the catalog.
 
 .Prerequisites
-* You have configured user authentication with {authentication-book-link}#enabling-user-authentication-with-github[GitHub] or {authentication-book-link}#enabling-user-authentication-with-gitlab[GitLab] as your authentication provider. This is a mandatory requirement for Bulk Import, as repository listings use user OAuth tokens.
+* You have configured the {integrating-with-your-git-provider-book-link}[GitHub or GitLab integration].
 * For GitHub only: You have {integrating-with-github-book-link}#enabling-github-repository-discovery[enabled GitHub repository discovery].
-
-[IMPORTANT]
-====
-Bulk Import requires user OAuth tokens for all repository and organization listing operations. Deployments without user authentication configured will receive HTTP 401 Unauthorized errors when accessing the Bulk Import feature.
-====
 
 .Procedure
 . The Bulk Import plugins are installed but disabled by default.


### PR DESCRIPTION


The Bulk Import prerequisites incorrectly stated that user OAuth authentication was required. The actual requirement is having the GitHub or GitLab integration configured.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
RHDH 1.9.x
**Issue:**
N/A
**Preview:**
N/A
