### PR TITLE
fix(cqa-14b): Suppress git stderr for new files not in merge base

### DIFF
--- a/build/scripts/cqa/checks/cqa-14b-inbound-link-stability.js
+++ b/build/scripts/cqa/checks/cqa-14b-inbound-link-stability.js
@@ -82,7 +82,7 @@ function getFileAtBase(root, repoRelPath) {
 
   try {
     return execFileSync(GIT, ['show', `${base}:${repoRelPath}`], {
-      cwd: root, encoding: 'utf8',
+      cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
     });
   } catch {
     // File didn't exist at the merge-base commit


### PR DESCRIPTION
## Summary

CQA-14b uses `git show` to retrieve file content from the merge-base commit. For new files that don't exist in the base branch, git prints `fatal: path ... exists on disk, but not in ...` to stderr before the error is caught and handled. This clutters the build output with harmless but alarming-looking messages.

## Fix

Add `stdio: ['pipe', 'pipe', 'pipe']` to the `execFileSync` options so stderr is captured instead of printed to the console.

## Testing

- Full build: 36/36 titles pass
- CQA-14b: passes, zero `fatal:` messages in output
- No behavioral change: new files still skip correctly, ID changes still detected

## Jira

- https://redhat.atlassian.net/browse/RHDHBUGS-3362