### PR TITLE
RHDHBUGS-3359: Add missing Common icons reference section

### DIFF
--- a/assemblies/configure_customizing-rhdh/assembly-configure-the-global-header-in-rhdh.adoc
+++ b/assemblies/configure_customizing-rhdh/assembly-configure-the-global-header-in-rhdh.adoc
@@ -33,6 +33,8 @@ include::../modules/shared/con-quicklinks-and-starred-items-in-the-global-header
 
 include::../modules/shared/proc-enable-quicklinks-and-starred-items-after-an-upgrade.adoc[leveloffset=+1]
 
+include::../modules/shared/ref-common-icons-for-customization.adoc[leveloffset=+1]
+
 :context: {previouscontext}
 :!previouscontext:
 

--- a/modules/shared/proc-customize-quickaccesscard-card-icons-on-the-rhdh-homepage.adoc
+++ b/modules/shared/proc-customize-quickaccesscard-card-icons-on-the-rhdh-homepage.adoc
@@ -27,30 +27,7 @@ proxy:
     secure: true
 ----
 +
-The following table lists the supported icon types:
-+
-[cols="25%,25%,50%", frame="all", options="header"]
-|===
-|Icon type
-|Example
-|Rendered as
-
-|*{product-custom-resource-type} system icon*
-|`"catalog"`
-|Uses {product-custom-resource-type} system [icons](https://github.com/backstage/backstage/blob/master/packages/app-defaults/src/defaults/icons.tsx)
-
-|*SVG String*
-|`"<svg>...</svg>"`
-|Renders inline SVG
-
-|*Image URL*
-|`"https://example.com/icon.png"`
-|Renders external image. External images might be restricted to Content Security Policy (CSP) which can be configured in your {product-very-short} `{my-app-config-file}` file.
-
-|*Relative Path*
-|`"/homepage/icons/icon.png"`
-|Loads the icon from the app public folder (if present)
-|===
+For a list of supported icon types and identifiers, see xref:common-icons-for-customization_{context}[Common icons for customization].
 +
 [NOTE]
 ====

--- a/modules/shared/proc-customize-quickaccesscard-card-icons-on-the-rhdh-homepage.adoc
+++ b/modules/shared/proc-customize-quickaccesscard-card-icons-on-the-rhdh-homepage.adoc
@@ -27,7 +27,7 @@ proxy:
     secure: true
 ----
 +
-For a list of supported icon types and identifiers, see xref:common-icons-for-customization_{context}[Common icons for customization].
+For a list of supported icon types and identifiers, see xref:common-icons-for-customization_configure-the-global-header-in-rhdh[Common icons for customization].
 +
 [NOTE]
 ====

--- a/modules/shared/ref-common-icons-for-customization.adoc
+++ b/modules/shared/ref-common-icons-for-customization.adoc
@@ -61,7 +61,7 @@ In addition to these predefined icon identifiers, you can use:
 * *SVG paths*: Valid inline SVG markup
 * *Relative paths*: Paths to images in your {product-short} public folder
 
-For information about extending the internal icon catalog with custom icons, see xref:extend-internal-icon-catalog_{context}[].
+For information about extending the internal icon catalog with custom icons, see xref:extend-internal-icon-catalog_front-end-plugin-wiring[].
 ====
 
 .Additional resources

--- a/modules/shared/ref-common-icons-for-customization.adoc
+++ b/modules/shared/ref-common-icons-for-customization.adoc
@@ -63,7 +63,3 @@ In addition to these predefined icon identifiers, you can use:
 
 For information about extending the internal icon catalog with custom icons, see xref:extend-internal-icon-catalog_front-end-plugin-wiring[].
 ====
-
-.Additional resources
-
-* link:https://github.com/backstage/backstage/blob/master/packages/app-defaults/src/defaults/icons.tsx[{backstage} default icons^]

--- a/modules/shared/ref-common-icons-for-customization.adoc
+++ b/modules/shared/ref-common-icons-for-customization.adoc
@@ -1,0 +1,69 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="common-icons-for-customization_{context}"]
+= Common icons for customization
+
+[role="_abstract"]
+When customizing {product-short}, you can use predefined system icon identifiers in various configuration contexts, including global header buttons, quick access cards, quick starts, and navigation menu items.
+
+The following table lists commonly used icon identifiers available in {product-short}:
+
+[cols="30%,70%", options="header"]
+|===
+|Icon identifier
+|Description
+
+|`add`
+|Plus sign icon, typically used for "Create" or "Add new" actions
+
+|`bookmarks`
+|Bookmark icon for saved items
+
+|`catalog`
+|Catalog or list icon
+
+|`category`
+|Category or organization icon
+
+|`developerHub`
+|{product-short} logo icon
+
+|`extension`
+|Extension or plugin icon
+
+|`favorite`
+|Star icon for favorites or starred items
+
+|`github`
+|GitHub logo icon
+
+|`group`
+|Group or team icon
+
+|`home`
+|Home icon
+
+|`manageAccounts`
+|User account management icon
+
+|`school`
+|Education or learning icon
+
+|`search`
+|Search or magnifying glass icon
+|===
+
+[NOTE]
+====
+In addition to these predefined icon identifiers, you can use:
+
+* *Full image URLs*: External image URLs (for example, `https://example.com/icon.png`)
+* *SVG paths*: Valid inline SVG markup
+* *Relative paths*: Paths to images in your {product-short} public folder
+
+For information about extending the internal icon catalog with custom icons, see xref:extend-internal-icon-catalog_{context}[].
+====
+
+.Additional resources
+
+* link:https://github.com/backstage/backstage/blob/master/packages/app-defaults/src/defaults/icons.tsx[{backstage} default icons^]

--- a/modules/shared/ref-common-icons-for-customization.adoc
+++ b/modules/shared/ref-common-icons-for-customization.adoc
@@ -53,11 +53,73 @@ The following table lists commonly used icon identifiers available in {product-s
 |Search or magnifying glass icon
 |===
 
+.{backstage} system icons
+[cols="30%,70%", options="header"]
+|===
+|Icon identifier
+|Description
+
+|`kind:api`
+|API entity icon
+
+|`kind:component`
+|Component entity icon
+
+|`kind:domain`
+|Domain entity icon
+
+|`kind:group`
+|Group entity icon
+
+|`kind:location`
+|Location entity icon
+
+|`kind:resource`
+|Resource entity icon
+
+|`kind:system`
+|System entity icon
+
+|`kind:template`
+|Template entity icon
+
+|`kind:user`
+|User entity icon
+
+|`brokenImage`
+|Placeholder for missing or broken images
+
+|`chat`
+|Chat or messaging icon
+
+|`dashboard`
+|Dashboard icon
+
+|`docs`
+|Documentation icon
+
+|`email`
+|Email icon
+
+|`scaffolder`
+|Software Templates icon
+
+|`techdocs`
+|TechDocs icon
+
+|`user`
+|Single user icon
+
+|`warning`
+|Warning indicator icon
+|===
+
 [NOTE]
 ====
 In addition to these predefined icon identifiers, you can use:
 
 * *Full image URLs*: External image URLs (for example, `https://example.com/icon.png`)
+* *Data-encoded URIs*: Base64-encoded image data (for example, `data:image/svg+xml;base64,PHN2Zy...`)
 * *SVG paths*: Valid inline SVG markup
 * *Relative paths*: Paths to images in your {product-short} public folder
 

--- a/modules/shared/ref-common-icons-for-customization.adoc
+++ b/modules/shared/ref-common-icons-for-customization.adoc
@@ -123,5 +123,5 @@ In addition to these predefined icon identifiers, you can use:
 * *SVG paths*: Valid inline SVG markup
 * *Relative paths*: Paths to images in your {product-short} public folder
 
-For information about extending the internal icon catalog with custom icons, see xref:extend-internal-icon-catalog_front-end-plugin-wiring[].
+For information about extending the internal icon catalog with custom icons, see {product-docs-link}/html-single/installing_and_viewing_plugins_in_red_hat_developer_hub/index#extend-internal-icon-catalog_front-end-plugin-wiring[Extend internal icon catalog].
 ====


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
release 1.9

**Issue:**
https://redhat.atlassian.net/browse/RHDHBUGS-3359

**Summary:**
This PR fixes broken cross-references to a missing "Common icons for customization" reference section by creating the missing content.

**Changes:**
- Created `modules/shared/ref-common-icons-for-customization.adoc` with a table of commonly used icon identifiers
- Added the new reference module to the global header assembly
- Documented alternative icon types (URLs, SVG paths, relative paths)
- Linked to the upstream Backstage icon set for complete documentation

**Fixes broken links in:**
- `proc-configure-the-logo-in-the-global-header.adoc`
- `proc-customize-your-rhdh-quick-start.adoc`  
- `proc-use-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc`

**Preview:**
Will be available after build completes