### PR TITLE
RHDHBUGS-3361: Add jtbd-map skill and TOC mapping reference

### DIFF
--- a/.claude/skills/jtbd-map/SKILL.md
+++ b/.claude/skills/jtbd-map/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: jtbd-map
+description: Populate JTBD navigation map files with actual include directives from Jira tickets or category/job/topic names. Use when mapping content for a JTBD job, populating nav files, or connecting existing modules to the JTBD structure.
+argument-hint: "[RHIDP-XXXX or category/job/topic]"
+allowed-tools: Bash(git *) Bash(node *) Read Grep Glob Edit Write
+---
+
+# JTBD Map: Populate navigation map files
+
+## Purpose
+
+This skill populates the JTBD (Jobs To Be Done) navigation map files under `titles/product_product/category-maps/` with actual `include::` directives pointing to existing modules. It bridges the migration from modular docs (assemblies) to JTBD docs (MAP files).
+
+## Arguments
+
+The skill accepts one of:
+- A **Jira ticket** ID (e.g., `RHIDP-14636`) -- fetches ticket content to identify the category, job, or topic
+- A **category name** (e.g., `Secure`, `Install`) -- maps the entire category
+- A **job or topic name** (e.g., `Configure authentication providers`) -- maps a specific job
+
+## Workflow
+
+### Step 1: Identify scope and check file state
+
+If the argument is a Jira ticket:
+1. Use the `jira-reader` skill to fetch the ticket summary and description
+2. Match the ticket to a category, job, or topic in the TOC mapping reference
+
+If the argument is a category/job/topic name:
+1. Search the TOC mapping reference file at `.claude/skills/jtbd-map/jtbd-toc-mapping.tsv`
+2. Find the matching entry in the hierarchy
+
+Then, for each entry in scope:
+3. Check whether the corresponding `nav-*.adoc` and `con-*.adoc` files exist in `titles/product_product/category-maps/<category>/`
+4. If any nav or con file is missing, create it using the standard templates (see "MAP file structure" and "Concept file structure" below)
+5. For existing nav files, check whether they contain `// TODO:` comments (need population) or actual `include::` directives (already populated). Skip entries that are already fully populated.
+
+### Step 2: Confirm scope with user
+
+Before proceeding, show the user:
+- The identified category, job, and topic hierarchy from the TSV
+- The nav files that will be populated, indicating which have TODOs vs. which are already done
+
+Ask the user to confirm before making changes.
+
+### Step 3: Find existing assemblies and modules
+
+For each topic in the scope, find the corresponding assembly file first, then derive modules from it:
+
+1. Search `assemblies/<category>_*/` for matching assembly files by title (using `Glob` and `Grep`)
+2. If no match, search `assemblies/shared/`
+3. If still no match, search all `assemblies/*/` subdirectories (catches content that moved categories, such as reference and troubleshooting content originating in other directories)
+4. Read the found assembly's `include::` directives -- these give the module file paths to use in the nav file
+5. Read the assembly's body content (abstract, paragraphs, admonitions, snippet includes, additional resources) -- this content goes into the concept file
+
+If no assembly is found for a topic, fall back to searching modules directly:
+1. Search `modules/<category>_*/`
+2. If no match, search `modules/shared/`
+3. If still no match, search all `modules/*/` subdirectories
+
+### Step 4: Populate nav files
+
+For each nav file in scope:
+1. Replace `// TODO:` comments with actual `include::` directives
+2. Use the format without navtitle (default):
+   ```
+   include::modules/<subdirectory>/<module>.adoc[leveloffset=+1]
+   ```
+   Where `<subdirectory>` is the actual directory the module lives in (e.g., `shared`, `configure_configuring-rhdh`, `extend_orchestrator-in-rhdh`), accessed through the `modules` symlink in the category directory.
+3. Add `navtitle` only when the TSV's Navtitle column (column 9) has an explicit value, or when the module's internal `= Title` heading does not match the desired navigation title:
+   ```
+   include::modules/<subdirectory>/<module>.adoc[leveloffset=+1,navtitle="<nav title>"]
+   ```
+4. Keep any existing includes that are already populated
+
+### Step 5: Populate concept files
+
+The concept file (`con-*.adoc`) in the MAP structure contains the assembly's non-include content. For each `con-*.adoc` concept file paired with a nav file:
+
+1. Read the corresponding assembly file to extract all non-include content
+2. Replace the TODO placeholder with the following content, in this order:
+   a. The `[role="_abstract"]` paragraph -- always exactly one paragraph (the short description)
+   b. Body content after the abstract -- additional paragraphs, admonitions, notes, lists, maintaining the original order from the assembly
+   c. Snippet includes -- `include::` directives to `snip-*` files (such as Technology Preview admonitions), placed where they appeared in the assembly body
+   d. `[role="_additional-resources"]` section -- always last, if present in the assembly
+3. Do NOT include in the concept file:
+   - Module includes (`proc-*`, `ref-*`, `con-*`, `assembly-*`) -- these go in the nav file
+   - Context save/restore (`ifdef::context[:parent-context:]`, `ifdef::parent-context[:context:]`)
+   - `[id="..."]` attributes -- the nav file owns the ID
+   - `:context:` declarations -- the nav file owns the context
+
+### Step 6: Resolve xref dependencies
+
+When the content you are migrating (modules or concept body text) contains `xref:` cross-references pointing to IDs that do not yet exist in the MAP structure, you must also migrate the referenced content as a dependency:
+
+1. For each `xref:<target-id>` found in migrated content, check whether `<target-id>` resolves to an existing `[id="..."]` in the `product_product` include tree
+2. If the target ID is missing, trace it back to the old assembly or module that defines it
+3. Use the TOC mapping reference (`.claude/skills/jtbd-map/jtbd-toc-mapping.tsv`) to determine the correct JTBD category and job for the missing content
+4. Create or populate the corresponding nav file and concept file in the correct category directory, adding the module includes that provide the missing ID
+5. Use hardcoded IDs (e.g., `[id="permission-policies-reference_authorization-in-rhdh"]`) when the xrefs use hardcoded context values instead of `_{context}`
+6. Repeat until all xref targets in the migrated scope are resolvable within the `product_product` build
+
+This ensures the ccutil build passes with 0 "Unknown ID" errors.
+
+### Step 7: Ensure required attributes
+
+For each modified nav file, verify:
+
+1. **Mandatory attributes** are present:
+   - `:_mod-docs-content-type: MAP` before the ID
+   - `[id="<context-value>_{context}"]` before the title
+   - `:context: <context-value>` after the title
+2. **Cross-reference attributes** are defined where needed:
+   - `:secrets-context:` for authentication-related nav files (needed by 9 modules using `{secrets-context}` in xrefs)
+   - `:import-context:` for authentication nav files (needed by PingFederate module)
+3. **Platform attributes** for non-OCP install nav files. Each hyperscaler section must set all 8 platform attributes before its includes and restore OCP defaults after:
+
+   **EKS override:**
+   ```asciidoc
+   :platform-id: eks
+   :platform-long: {eks-brand-name} ({eks-short})
+   :platform: {eks-short}
+   :platform-cli: kubectl
+   :platform-cli-link: link:https://kubernetes.io/docs/reference/kubectl/[Kubernetes CLI ('kubectl')]
+   :platform-cli-name: Kubernetes CLI ('kubectl')
+   :a-platform-generic: a Kubernetes
+   :namespace: namespace
+   ```
+
+   **GKE override:** Same as EKS but with `:platform-id: gke`, `:platform-long: {gke-brand-name} ({gke-short})`, `:platform: {gke-short}`.
+
+   **AKS override:** Same as EKS but with `:platform-id: aks`, `:platform-long: {aks-brand-name} ({aks-short})`, `:platform: {aks-short}`.
+
+   **OCP restore** (required after each hyperscaler section):
+   ```asciidoc
+   // Restore platform attributes to OCP defaults
+   :platform-id: ocp
+   :platform-long: {ocp-brand-name} ({ocp-very-short})
+   :platform: {ocp-short}
+   :platform-cli: oc
+   :platform-cli-link: {ocp-docs-link}/html-single/cli_tools/index#cli-about-cli_cli-developer-commands[{openshift-cli}]
+   :platform-cli-name: {ocp-brand-name} CLI ('oc')
+   :a-platform-generic: an OpenShift
+   :namespace: project
+   ```
+
+### Step 8: Validate
+
+1. Run CQA checks: `node build/scripts/cqa/index.js titles/product_product/master.adoc`
+2. Run full build: `build/scripts/build-ccutil.sh`
+3. Report any errors and suggest fixes
+
+## Architecture reference
+
+### Old structure (modular docs with assemblies)
+```
+titles/<category>_<title>/
+  master.adoc                              # Title entry point with :context:
+  assemblies/<category>_<title>/
+    assembly-<topic>.adoc                  # Assembly: includes modules
+  modules/<category>_<title>/
+    proc-<step>.adoc                       # Procedure module
+    con-<concept>.adoc                     # Concept module
+    ref-<reference>.adoc                   # Reference module
+```
+
+### New structure (JTBD with MAP files)
+```
+titles/product_product/
+  master.adoc                              # Product entry point
+  category-maps/
+    <category>.adoc                        # Category MAP (includes concept + job navs)
+    <category>/
+      modules -> ../../../../modules       # Symlink to shared modules
+      con-<category>.adoc                  # Category intro concept
+      nav-<job>.adoc                       # Job MAP (includes concept + topic modules)
+      con-<job>.adoc                       # Job overview concept
+```
+
+### MAP file structure
+```asciidoc
+:_mod-docs-content-type: MAP
+
+[id="<context-value>_{context}"]
+= <Title>
+:context: <context-value>
+
+include::con-<matching-concept>.adoc[leveloffset=+1]
+include::modules/<subdirectory>/<module>.adoc[leveloffset=+1]
+include::nav-<sub-job>.adoc[leveloffset=+1]
+```
+
+**Mandatory attributes:**
+- `:_mod-docs-content-type: MAP`
+- `[id="<context-value>_{context}"]`
+- `:context: <context-value>`
+
+**Optional attributes:**
+- `:secrets-context:`, `:import-context:` (for authentication-related nav files)
+- Platform attribute blocks (for non-OCP install nav files)
+
+**Also allowed:**
+- Comments (`// ...`) and blank lines
+- `// TODO: include <Topic title>` for topics not yet populated
+
+### Concept file structure
+```asciidoc
+:_mod-docs-content-type: CONCEPT
+
+= <Title>
+
+[role="_abstract"]
+<Short description paragraph.>
+```
+
+**Rules:**
+- No `[id="..."]` anchor -- the ID is inherited from the parent MAP
+- No `:context:` declaration -- the MAP file owns the context
+- Title matches the corresponding nav file section title
+
+### Key rules
+- First include in a MAP must be a `con-` concept file
+- MAP files contain only the mandatory attributes listed above, optional attributes, `include::` directives, comments, and blank lines
+- `navtitle` is only added when the module's internal title does not match the desired navigation title
+- Context values must be unique across all MAP files (IDs derive from context)
+- Some nav files share a context value with their parent for xref compatibility
+
+## TOC mapping reference
+
+The complete TOC mapping is available at `.claude/skills/jtbd-map/jtbd-toc-mapping.tsv`. This file maps:
+- Categories (L1) to their Jira tickets and assignees
+- Jobs (L2) and sub-jobs (L3/L4) to their topics
+- Topics to their H2/H3 headings and `.adoc` file paths
+
+Each level in the TSV hierarchy can correspond to either a MAP file (nav + con pair) or a leaf module include. The skill determines which from the actual file structure on disk.
+
+## Categories (16)
+
+Discover, Get started, Plan, Install, Upgrade, Migrate, Administer, Develop, Configure, Secure, Observe, Integrate, Optimize, Extend, Troubleshoot, Reference

--- a/.claude/skills/jtbd-map/jtbd-toc-mapping.tsv
+++ b/.claude/skills/jtbd-map/jtbd-toc-mapping.tsv
@@ -1,0 +1,728 @@
+Category (L1)	Level 2 (Jobs)	Level 3 (Jobs or Topics)	Level 4 (Jobs or Topics)	Topic (H2)	H3	Full .adoc file path	Is a job?	Navtitle	Jira	Assignee
+Discover									https://redhat.atlassian.net/browse/RHIDP-14495	Kalyani
+	Evaluate RHDH capabilities								FALSE	
+		Why Internal developer platforms?							TRUE	
+				Core platform features for your development toolchain			FALSE	
+				RHDH value proposition for enterprises			FALSE	
+		System architecture for deployment strategy planning							TRUE	
+				Frontend client layer for user access and routing			FALSE	
+				Backend service layer for system integration and scaling			FALSE	
+				External data dependencies for databases and caches			FALSE	
+		Developer Lightspeed AI virtual assistant capabilities							FALSE	
+			System architecture for the AI virtual assistant						FALSE	
+		Platform integrations for toolchain connectivity							FALSE	
+			OpenShift integration for native Kubernetes capabilities						FALSE	
+			Advanced Developer Suite integration for software supply chain security						FALSE	
+Get Started									https://redhat.atlassian.net/browse/RHIDP-14503	
+	Set up the first RHDH instance								FALSE	Kalyani
+		Checklist for initial configuration planning							FALSE	
+		Install the RHDH Operator							FALSE	
+		Prepare external databases and identity providers for production workloads							FALSE	
+		Provision custom ConfigMaps and secrets to connect external services							FALSE	
+		Enable initial authentication to verify user access							FALSE	
+			Authentication methods and identity provider selection						TRUE	
+				User provisioning			FALSE	
+				Authentication			FALSE	
+			Configure guest access to safely test early deployments						TRUE	
+				Enable the Guest login			FALSE	
+				Disable the Guest login			FALSE	
+			Integrate your chosen identity provider						TRUE	
+				Red Hat Build of Keycloak			FALSE	
+					Share a secret		FALSE	
+					Import users and groups		FALSE	
+					Enable authentication		FALSE	
+		Start your RHDH instance to verify deployments							FALSE	
+		Customize the default theme mode to match organizational preferences							FALSE	
+		Define initial RBAC policies to regulate user access							FALSE	
+	Navigate RHDH on your first day								FALSE	
+		Red Hat Developer Hub capabilities and architecture							FALSE	
+			Onboarding process for platform initialization						TRUE	
+				Log in and verify your profile			FALSE	
+				Organize your workspace			FALSE	
+				Explore production resources			FALSE	
+			Developer productivity benefits						FALSE	
+		Log in to Red Hat Developer Hub							FALSE	
+			Authentication methods to enable self-service capabilities						TRUE	
+				Common authentication methods			FALSE	
+			Explore the RHDH interface						FALSE	
+		Find software components to discover assets							TRUE	
+				Filter and analyze dependencies			FALSE	
+		Import and use an existing software template for faster development							TRUE	
+				Create a software component using Software Templates			FALSE	
+		Search for relevant content in technical documentation (TechDocs)							FALSE	
+		Verify API contracts before integrating with backend services							FALSE	
+		Find resources and documentation using search							FALSE	
+		Get AI-assisted help for your development tasks							TRUE	
+				Prerequisites			FALSE	
+				Configure safety guards			FALSE	
+				Best results for assistant queries			FALSE	
+				AI response monitoring and context management			FALSE	
+				Manage chats			FALSE	
+		Integrate and customize your daily tools using Extensions							TRUE	
+				Access platform-wide tools			FALSE	
+				Review RHDH resource data			FALSE	
+				Identify integrations in the RHDH extensions marketplace			FALSE	
+		Customize your RHDH interface settings							FALSE	
+		Manage starred items for quick access							FALSE	
+Plan									https://redhat.atlassian.net/browse/RHIDP-14507	Gaurav
+	Plan your deployment architecture and scale								FALSE	
+		Sizing requirements for cluster resource provisioning							FALSE	
+			Compute resource guidelines for the core platform						FALSE	
+			Storage guidelines for external PostgreSQL deployments						FALSE	
+		Compare the Helm chart and Operator deployment methods							TRUE	
+				Pros and cons of each deployment method			FALSE	
+		Scale your deployment using enterprise performance benchmarks							FALSE	
+			Baseline metrics for large-scale enterprise environments						FALSE	
+			Tune system resources to improve performance and stability						FALSE	
+Install									https://redhat.atlassian.net/browse/RHIDP-14526	Fabrice
+	Install on OpenShift Container Platform to leverage existing Red Hat infrastructure								FALSE	
+		Compare the Helm chart and Operator deployment methods							FALSE	
+		Install on OpenShift Container Platform using the Operator							TRUE	
+				Install the Operator			FALSE	
+				Deploy the instance			FALSE	
+		Install on OpenShift Container Platform using the Helm chart							TRUE	
+				Deploy from the web console			FALSE	
+				Deploy with the Helm CLI			FALSE	
+	Install on managed hyperscaler environments to integrate with cloud resources								FALSE	
+		Install on Amazon Elastic Kubernetes Service (EKS) using the Operator							TRUE	
+				Install the Operator using OLM to automate deployments			FALSE	
+				Provision custom configuration files and secrets to your cluster			FALSE	
+				Provision a pull secret to access the container registry			FALSE	
+				Apply the custom resource to initialize the platform			FALSE	
+				Expose your Operator instance using an Ingress resource			FALSE	
+		Deploy on Amazon EKS using the Helm chart							FALSE	
+		Install on Google Kubernetes Engine (GKE) using the Operator							TRUE	
+				Install the Operator using OLM to automate deployments			FALSE	
+				Provision custom configuration files and secrets to your cluster			FALSE	
+				Provision a pull secret to access the container registry			FALSE	
+				Apply the custom resource to initialize the platform			FALSE	
+				Expose your Operator instance using an Ingress resource			FALSE	
+		Deploy on GKE using the Helm chart							FALSE	
+		Install on Microsoft Azure Kubernetes Service (AKS) using the Operator							TRUE	
+				Install the Operator using OLM to automate deployments			FALSE	
+				Provision custom configuration files and secrets to your cluster			FALSE	
+				Provision a pull secret to access the container registry			FALSE	
+				Apply the custom resource to initialize the platform			FALSE	
+				Expose your Operator instance using an Ingress resource			FALSE	
+		Deploy on AKS using the Helm chart							FALSE	
+		Install on OpenShift Dedicated using the Operator							FALSE	
+		Deploy on OpenShift Dedicated using the Helm chart							FALSE	
+	Install in an air-gapped environment								FALSE	
+		Isolated network deployments for air-gapped environments							FALSE	
+		Install in an air-gapped environment using the Operator							TRUE	
+				Mirror Operator images to deploy in fully disconnected networks			FALSE	
+				Mirror Operator images to local registries for partially disconnected networks			FALSE	
+		Deploy on OpenShift using Helm in an air-gapped environment							TRUE	
+				Mirror Helm images to deploy in fully disconnected OpenShift networks			FALSE	
+				Mirror Helm images to local registries for partially disconnected networks			FALSE	
+		Deploy on Kubernetes platforms using Helm in air-gapped environments							TRUE	
+				Mirror Helm images to deploy in fully disconnected Kubernetes networks			FALSE	
+				Mirror Helm images to local registries for partially disconnected Kubernetes networks			FALSE	
+Upgrade									https://redhat.atlassian.net/browse/RHIDP-14538	Tim
+	Upgrade RHDH to apply the latest features and security patches								FALSE	
+		Upgrade the RHDH Operator							TRUE	
+				Approve the Operator InstallPlan			FALSE	
+		Upgrade the RHDH Helm chart							TRUE	
+				Apply the new Helm chart version			FALSE	
+				Update custom Helm configurations			FALSE	
+		Merge new mandatory default configurations							FALSE	
+Migrate									https://redhat.atlassian.net/browse/RHIDP-14540	Tim
+	Migrate from a local database to an external PostgreSQL server								FALSE	
+		Configure an external PostgreSQL database							FALSE	
+		Migrate local databases to an external PostgreSQL server							TRUE	
+				Execute the database copy script			FALSE	
+				Create destination databases on the external server			FALSE	
+Administer									https://redhat.atlassian.net/browse/RHIDP-14680	Gaurav
+	Evaluate component compliance using Scorecards								FALSE	
+		Supported Scorecard metrics providers							FALSE	
+		Set up Scorecards							FALSE	
+			Enable Scorecards						FALSE	
+			Configure RBAC using the CSV file						FALSE	
+			Configure RBAC using the Web UI						FALSE	
+		Install and configure Scorecards							FALSE	
+			Integrate GitHub health metrics						FALSE	
+			Integrate Jira health metrics						FALSE	
+		Manage metric thresholds							FALSE	
+			Metric categorization criteria						FALSE	
+			Threshold expression syntax						FALSE	
+			Resolve configuration conflicts using threshold precedence						FALSE	
+			Standardize metric thresholds across components						FALSE	
+			Component-specific threshold rules						TRUE	
+				Annotation structure			FALSE	
+				Example			FALSE	
+			Logical flow verification						FALSE	
+		Monitor component health							FALSE	
+	Monitor portfolio health using aggregated Scorecard KPIs								FALSE	
+		Monitor collective health							FALSE	
+			Monitor portfolio health with aggregated KPIs						FALSE	
+		Configure aggregated Scorecard KPIs							FALSE	
+			Configure portfolio health						TRUE	
+				Configure on a customizable home page			FALSE	
+				Configure on a read-only home page			FALSE	
+			Schedule metrics						FALSE	
+			Adjust metric retention						FALSE	
+			Establish ownership in the software catalog						FALSE	
+			View aggregated metrics for owned entities						FALSE	
+		Identify services impacting team compliance KPIs							FALSE	
+			Retrieve metric data using the API						TRUE	
+				Required permissions			FALSE	
+				API endpoints			FALSE	
+				API parameter details			FALSE	
+				Troubleshooting API errors			FALSE	
+	Analyze platform adoption trends to measure engagement and tool popularity								FALSE	
+		Adoption Insights							FALSE	
+			Enable the Adoption Insights plugin						FALSE	
+			Disable the Adoption Insights plugin						FALSE	
+			Customize the Adoption Insights plugin						FALSE	
+		Use Adoption Insights							TRUE	
+				Set the duration of data metrics			FALSE	
+		View the Adoption Insights cards							TRUE	
+				View active users			FALSE	
+				View total users			FALSE	
+				View top catalog entities			FALSE	
+				View top templates			FALSE	
+				View top TechDocs			FALSE	
+				View top plugins			FALSE	
+		Display human-readable entity titles							FALSE	
+		Change the number of displayed records							FALSE	
+		Filter records							FALSE	
+		View platform searches							FALSE	
+Develop									https://redhat.atlassian.net/browse/RHIDP-14672	Priyanka
+	Register and update software components to maintain a unified service inventory								FALSE	
+		Manage your software components							TRUE	
+			Register new software components						FALSE	
+				Generate new components			FALSE	
+				Register existing repositories manually			FALSE	
+			Update component YAML metadata						FALSE	
+			Filter the catalog by entity kind						FALSE	
+			Search the catalog using text filters						FALSE	
+			Review the raw YAML configuration						FALSE	
+			Star frequently used components						FALSE	
+	Project standardization with software templates								FALSE	
+		Create new Software Templates							FALSE	
+		Use sample templates							FALSE	
+		Publish template definitions to the catalog							FALSE	
+		Extend templates using conditional logic and external fetch capabilities							FALSE	
+		Version Software Templates to track template updates and dependencies							TRUE	
+				Version Software Templates			FALSE	
+				Enable update notifications			FALSE	
+		Track component provenance to map dependencies back to source templates							FALSE	
+			Configure provenance annotations						FALSE	
+			View template dependencies in the catalog						FALSE	
+		Automate template lifecycle management							FALSE	
+			Enable the scaffolder-relation-processor						FALSE	
+			Template sync limitations						FALSE	
+		Standardized project generation with software templates							FALSE	
+			Run Software Templates from the UI						FALSE	
+			Browse available templates						FALSE	
+			Import an existing template file using the Catalog Processor						FALSE	
+	Automate repository onboarding to the catalog								FALSE	
+		Import source code repositories in bulk							FALSE	
+			Enable and authorize bulk import plugins						FALSE	
+			Select and import GitHub repositories						FALSE	
+			Manage imported repositories						FALSE	
+			Monitor bulk import operations in audit logs						FALSE	
+		Configure bulk import capabilities							FALSE	
+			Select and import Git projects						FALSE	
+			Review input parameters						FALSE	
+			Create custom Scaffolder workflows						FALSE	
+			Register repository lists with the orchestrator						TRUE	
+				Data handoff and custom workflow design			FALSE	
+	Orchestrate infrastructure tasks using workflows								FALSE	
+		Orchestrator process automation architecture							TRUE	
+				Orchestrator version compatibility matrix			FALSE	
+				Operator and orchestrator plugin compatibility matrix			FALSE	
+		Build serverless workflows							FALSE	
+			Pre-built workflow container image capabilities						TRUE	
+				Project structure			FALSE	
+				Develop and test serverless workflows locally			FALSE	
+			Build workflow container images locally using the build.sh script						TRUE	
+				build.sh script configuration and flags			FALSE	
+				Supported build environment variables			FALSE	
+				Prerequisites			FALSE	
+				Build a basic serverless workflow			FALSE	
+			Review generated Kubernetes manifests						FALSE	
+			Deploy workflow images to an OpenShift cluster						FALSE	
+			Workflow design best practices						TRUE	
+				Unique workflow ID requirements			FALSE	
+		Automate workflow deployments							TRUE	
+				Workflow deployment components			FALSE	
+			Install Orchestrator Helm charts						TRUE	
+				Install the Infra chart			FALSE	
+				Enable workflow software templates			FALSE	
+			Install Orchestrator in an air-gapped environment						TRUE	
+				Install Orchestrator with the Operator			FALSE	
+				Install Orchestrator with the Helm chart			FALSE	
+			Launch workflow templates						FALSE	
+			Apply generated GitOps resources						FALSE	
+			Verify your workflow deployment in the UI						FALSE	
+			Trigger workflows from event-driven systems						FALSE	
+	Write and publish documentation as code to keep knowledge synchronized								FALSE	
+		Docs-like-code practices for TechDocs strategies							FALSE	
+		Import Markdown documentation							FALSE	
+		Filter the TechDocs catalog							FALSE	
+		Navigate within TechDocs books							FALSE	
+		Edit TechDocs files directly							FALSE	
+		Embed video iframes							FALSE	
+		Configure TechDocs storage and CI/CD pipelines							FALSE	
+			Configure Amazon S3 or OpenShift Data Foundation buckets						TRUE	
+				Configure Amazon S3			FALSE	
+				Configure OpenShift Data Foundation			FALSE	
+					Configure object storage access with Operator		FALSE	
+					Configure object storage access with Helm Chart		FALSE	
+			Use the techdocs-cli in your CI/CD pipelines						FALSE	
+		Automate documentation builds with GitHub Actions							FALSE	
+		Install TechDocs add-ons							FALSE	
+			Install external or third-party add-ons						TRUE	
+				Install with Operator			FALSE	
+				Install with Helm Chart			FALSE	
+			Disable or remove TechDocs add-ons						TRUE	
+				Remove from your Operator			FALSE	
+				Remove from your Helm Chart			FALSE	
+			Use enabled add-ons						TRUE	
+				Configure documentation issue reporting			FALSE	
+				Configure documentation text scaling			FALSE	
+				Configure image overlay features			FALSE	
+		Develop custom TechDocs add-ons as React components							FALSE	
+Configure									https://redhat.atlassian.net/browse/RHIDP-14545	Fabrice
+	Configure core parameters to meet infrastructure requirements								FALSE	
+		Default configurations to establish a deployment foundation							TRUE	
+				Default configurations			FALSE	
+				Automated Operator features			FALSE	
+					Metadata generation		FALSE	
+					Many resources		FALSE	
+					Default base URLs		FALSE	
+				Time syntax			FALSE	
+		Provision custom config maps and secrets to define platform behavior							FALSE	
+			Provision your custom configuration						FALSE	
+			Deploy a custom configuration using an Operator						FALSE	
+			Deploy a custom configuration using Helm Chart						FALSE	
+		Configure the base URL to route frontend and backend traffic							FALSE	
+		Configure backend secrets to secure service-to-service communication							FALSE	
+		Inject extra files and variables to secure external service connections							FALSE	
+		Configure mount paths to safely attach default secrets and storage							FALSE	
+		Mount secrets to specific containers to isolate sensitive data							FALSE	
+		Patch deployment resources to customize Operator pod specifications							FALSE	
+		Configure TLS connections to encrypt external platform traffic							FALSE	
+		Configure corporate proxy settings to enable external network access							TRUE	
+				The NO_PROXY exclusion rules			FALSE	
+				Configure proxy settings in Operator deployment			FALSE	
+				Configure proxy settings in Helm deployment			FALSE	
+	Customize the user interface to reflect organizational branding								FALSE	
+		Customize the display title							FALSE	
+		Customize Learning Paths to integrate tailored e-learning content							TRUE	
+				Structured learning paths for developers onboarding			FALSE	
+				Customize by using a hosted JSON file			FALSE	
+				Customize by using a customization service			FALSE	
+				Start and complete lessons			FALSE	
+		Configure the global header for consistent top-level navigation							FALSE	
+			Add custom branding logos						TRUE	
+				Enable logo in the sidebar			FALSE	
+			Configure display names						FALSE	
+			Define Quicklinks						TRUE	
+				Enable Quicklinks and starred items after an upgrade			FALSE	
+		Configure floating action buttons for quick access to workflows							TRUE	
+				Interface translation options			FALSE	
+				Internal translation implementation			FALSE	
+		Customize the Quick Start to guide user onboarding							FALSE	
+			Configure role-based access control for quick starts						FALSE	
+			Customize your quick start						TRUE	
+				Disable the quick start			FALSE	
+			Explore quick start onboarding steps						FALSE	
+			Localize quick start						FALSE	
+		Customize the Tech Radar page to visualize technology adoption							TRUE	
+				Customize by using a JSON file			FALSE	
+				Customize by using a customization service			FALSE	
+		Customize themes and branding to align with corporate standards							TRUE	
+				Configure the default theme mode			FALSE	
+				Configure the branding logo			FALSE	
+				Define custom color palettes			FALSE	
+				Configure the page theme header			FALSE	
+				Customize typography			FALSE	
+			Load a custom React theme for advanced UI overrides						FALSE	
+			Custom component options						FALSE	
+		Customize sidebar navigation and tabs to organize essential tools							FALSE	
+			Customize the sidebar menu items						TRUE	
+				Localize sidebar menu items			FALSE	
+				Configure custom menu items			FALSE	
+				Modify or add a custom menu items			FALSE	
+			Customize entity tab titles						FALSE	
+			Change entity detail tab layouts						FALSE	
+		Customize the Home page layout to optimize developer workflows							TRUE	
+				Customize Home page dashboard cards			FALSE	
+				Set up dynamic homepage layouts			FALSE	
+				Configure interface shortcut links			FALSE	
+		Configure Quick access cards to surface frequently used links							TRUE	
+				Use hosted JSON files to provide data			FALSE	
+				Use a dedicated service to provide data			FALSE	
+		Customize the Metadata card to display internal build information							FALSE	
+	Configure language localization to improve accessibility for global users								FALSE	
+		Enable the localization framework							TRUE	
+				Override default translations using JSON maps			FALSE	
+				Implement localization in custom plugins			FALSE	
+				Select a language			FALSE	
+		Localization best practices							FALSE	
+Secure									https://redhat.atlassian.net/browse/RHIDP-14635	Fabrice
+	Configure authentication providers to verify user identities								FALSE	
+		Authentication methods and identity provider selection							TRUE	
+				User provisioning			FALSE	
+				Authentication			FALSE	
+		Configure guest access to securely test non-production environments							FALSE	
+				Enable the Guest login			FALSE	
+				Disable the Guest login			FALSE	
+		Share credentials with your identity provider to secure communications							TRUE	
+				Share credentials with RHBK			FALSE	
+				Share credentials with LDAP			FALSE	
+				Share credentials with GitHub			FALSE	
+				Share credentials with Microsoft Azure			FALSE	
+				Share credentials with GitLab			FALSE	
+		Import users and groups to synchronize enterprise directory data							TRUE	
+				Import users and groups from RHBK			FALSE	
+					Create custom transformers		FALSE	
+				Provision users with LDAP			FALSE	
+					Create custom transformers		FALSE	
+				Import users and groups from GitHub			FALSE	
+					Create custom transformers		FALSE	
+				Import users and groups from Microsoft Azure			FALSE	
+					Create custom transformers		FALSE	
+				Import users and groups from GitLab			FALSE	
+					Create custom transformers		FALSE	
+		Enable authentication to verify identities against enterprise directories							TRUE	
+				Enable authentication with RHBK			FALSE	
+				Match users by LDAP UUID with RHBK			FALSE	
+				Enable authentication with GitHub			FALSE	
+				Enable authentication with Microsoft Azure			FALSE	
+				Enable authentication with GitLab			FALSE	
+		Connect your platform to external identity providers and APIs							FALSE	
+			Configure service-to-service authentication to secure API calls						TRUE	
+				Use a static token			FALSE	
+				Use JSON web key sets (JWKS) tokens			FALSE	
+				Set access restrictions to external service tokens			FALSE	
+		Configure session expiration and auto-logout policies							TRUE	
+				Session management			FALSE	
+					What happens when a session expires		FALSE	
+					AutoLogout (frontend inactivity)		FALSE	
+					Session duration (provider-level)		FALSE	
+					Identity Provider session settings		FALSE	
+					How the mechanisms interact		FALSE	
+				Configure session management			FALSE	
+				Enable auto-logout for inactive users			FALSE	
+	Define authorization policies to restrict access based on user roles								FALSE	
+		Enable the RBAC plugin							FALSE	
+		Determine your policy source							FALSE	
+		Design policy rules							FALSE	
+		Manage roles using the Web UI							TRUE	
+				Create a role			FALSE	
+				Edit a role			FALSE	
+				Delete a role			FALSE	
+		Manage policies using the REST API							TRUE	
+				Send requests by using the curl utility			FALSE	
+				Send requests by using a REST client			FALSE	
+				Send requests by using an external service			FALSE	
+				Supported REST API endpoints			FALSE	
+					Roles		FALSE	
+					Permission policies		FALSE	
+					Conditional policies		FALSE	
+					User statistics		FALSE	
+		Define policies in external files to provision permissions during cluster deployment							TRUE	
+				Define authorizations by using the Operator			FALSE	
+				Define authorizations by using the Helm Chart			FALSE	
+				Configure RBAC for Extensions			FALSE	
+		Configure guest access							TRUE	
+				Configure the RBAC backend plugin			FALSE	
+				Set up the guest authentication provider			FALSE	
+		Permission policy parameters and definitions							FALSE	
+		Define conditional policies							FALSE	
+		Download user statistics							FALSE	
+		Delegate RBAC management to decentralize administration							FALSE	
+			Configure RBAC delegation						TRUE	
+				Delegate access using the Web UI			FALSE	
+				Delegate access using the API			FALSE	
+Observe									https://redhat.atlassian.net/browse/RHIDP-14684	Kalyani
+	Monitor system logs and application metrics to ensure platform availability								FALSE	
+		Configure log levels							TRUE	
+				Set the log level in the Operator			FALSE	
+				Set the log level in the Helm chart			FALSE	
+		Enable metrics monitoring on OpenShift Container Platform							TRUE	
+				Create a ServiceMonitor using the Operator			FALSE	
+				Enable the ServiceMonitor using the Helm chart			FALSE	
+		Configure AWS monitoring							TRUE	
+				Configure annotations for Amazon Prometheus			FALSE	
+					Configure annotations with Operator		FALSE	
+					Configure annotations with Helm Chart		FALSE	
+				Retrieve logs from Amazon CloudWatch			FALSE	
+		Configure Azure monitoring							TRUE	
+				Enable Azure Monitor metrics			FALSE	
+				Configure annotations for AKS monitoring			FALSE	
+					Configure annotations with Operator		FALSE	
+					Configure annotations with Helm Chart		FALSE	
+				View live logs			FALSE	
+				View real-time log data in AKS			FALSE	
+	Manage telemetry collection to balance data insights with privacy requirements								FALSE	
+		Telemetry collection							FALSE	
+		Disable telemetry collection							TRUE	
+				Disable telemetry using the Operator			FALSE	
+				Disable telemetry using the Helm chart			FALSE	
+		Enable telemetry collection							TRUE	
+				Enable telemetry using the Operator			FALSE	
+				Enable telemetry using the Helm chart			FALSE	
+		Customize the Segment source							TRUE	
+				Override the Segment write key using the Operator			FALSE	
+				Override the Segment write key using the Helm chart			FALSE	
+	Capture and review audit logs to trace user activities and maintain accountability								FALSE	
+		Tracked events in audit logs							FALSE	
+		Configure audit logs on OpenShift							FALSE	
+		Forward audit logs to Splunk							FALSE	
+		View audit logs using the OpenShift console							FALSE	
+		Review RBAC audit log events							TRUE	
+				Track policy updates using RBAC event types			FALSE	
+				RBAC metadata field definitions			FALSE	
+				Example			FALSE	
+	Centralize workflow observability								FALSE	
+		Deploy observability manifests to configure the Jaeger and Loki stacks							FALSE	
+			Apply deployment manifests						TRUE	
+				Jaeger distributed tracing deployment manifests			FALSE	
+				Loki log aggregation deployment manifests			FALSE	
+				OpenTelemetry Collector deployment manifest			FALSE	
+		Diagnose workflow failures using centralized logging							TRUE	
+				Enable JSON logging			FALSE	
+				Configure log rotation			FALSE	
+				Link logs to traces			FALSE	
+				Centralize logs			FALSE	
+				Set up automated alerts			FALSE	
+				Route alerts to external tools			FALSE	
+				Troubleshoot missing logs			FALSE	
+				OpenTelemetry configuration properties reference			FALSE	
+		Optimize workflow performance							TRUE	
+				Collect distributed traces			FALSE	
+				Route workflow traces to existing observability tools			FALSE	
+				Troubleshoot trace connectivity			FALSE	
+		Trace attribute definitions and filtering keys							FALSE	
+			Trace parameters for monitoring queries						FALSE	
+	Collect diagnostic data to troubleshoot platform issues								FALSE	
+		Diagnostic data collection							FALSE	
+		Run must-gather on OpenShift to collect diagnostic data							TRUE	
+				Run must-gather on Kubernetes			FALSE	
+				Collect diagnostic data from air-gapped clusters			FALSE	
+		Collect heap dumps to diagnose memory issues							FALSE	
+		Diagnostic data types and collection scope							FALSE	
+		Configuration options							FALSE	
+		Diagnostic data output structure and organization							FALSE	
+Integrate									https://redhat.atlassian.net/browse/RHIDP-14642	Priyanka
+	Enable AI assistance for developers								FALSE	
+		Developer Lightspeed for RHDH architecture							TRUE	
+				Lightspeed Core Service and Llama Stack			FALSE	
+			Retrieval augmented generation (RAG) embeddings						FALSE	
+			Configure the virtual assistant components						FALSE	
+			Customize the system prompt and UI options						TRUE	
+				Enable user feedback			FALSE	
+				Update the system prompt			FALSE	
+				Customize the chat history storage			FALSE	
+			Mirror Lightspeed images for air-gapped environments						FALSE	
+		Build a private knowledge base with Lightspeed Notebooks							FALSE	
+			Solve project-specific challenges						FALSE	
+		LLM requirements							FALSE	
+		Manage user data security							FALSE	
+		Configure Model Context Protocol tools to enhance AI interactions with portal data							FALSE	
+			Install MCP server and tool plugins						FALSE	
+			Configure MCP tokens and endpoints						TRUE	
+				Configure MCP clients to access the RHDH server			FALSE	
+			Enable Software Catalog MCP tools						TRUE	
+				Fetch entities			FALSE	
+				Register entities			FALSE	
+				Unregister entities			FALSE	
+				Retrieve Software Template metadata			FALSE	
+			Enable TechDocs MCP tools						TRUE	
+				Retrieve TechDocs URLs and metadata			FALSE	
+				Measure documentation gaps			FALSE	
+				Find a specific TechDoc			FALSE	
+			Enable Scaffolder MCP tools						TRUE	
+				Automate software resource creation			FALSE	
+				Automate Software Templates			FALSE	
+		Accelerate AI model discovery by integrating the OpenShift AI Connector							FALSE	
+			Configure AI asset mapping						TRUE	
+				Model-to-Entity mapping			FALSE	
+				Data mapping specifications			FALSE	
+			Set up the OpenShift AI Connector						FALSE	
+			Populate AI model catalog metadata						TRUE	
+				Populate the API Definition tab			FALSE	
+	Integrate CI/CD and infrastructure tools to visualize pipelines and workloads								FALSE	
+		Track deployment history and rollouts with Argo CD							TRUE	
+				Enable the plugin			FALSE	
+				Enable Argo CD Rollouts			FALSE	
+		Track build artifacts using the JFrog plugin							TRUE	
+				Enable the plugin			FALSE	
+				Configure the plugin			FALSE	
+		Manage identity data by integrating Keycloak							TRUE	
+				Enable the plugin			FALSE	
+				Configure the plugin			FALSE	
+				Keycloak plugin metrics			FALSE	
+					Counters		FALSE	
+					Labels		FALSE	
+					Export metrics		FALSE	
+		View build artifacts using Nexus Repository Manager							TRUE	
+				Enable the plugin			FALSE	
+				Configure the plugin			FALSE	
+		Monitor continuous integration pipelines with Tekton							FALSE	
+		Visualize Kubernetes workloads and pod health with Topology							TRUE	
+				Enable the plugin			FALSE	
+				Configure the plugin			FALSE	
+					View OpenShift routes		FALSE	
+					View pod logs		FALSE	
+					View Tekton PipelineRuns		FALSE	
+					View virtual machines		FALSE	
+					Enable the source code editor		FALSE	
+				Manage labels and annotations			FALSE	
+					Link to the source code editor		FALSE	
+					Add entity annotations and labels		FALSE	
+					Namespace annotation		FALSE	
+					Add a label selector query annotation		FALSE	
+					Display a runtime icon in the topology node		FALSE	
+					Group applications		FALSE	
+					Node connector		FALSE	
+Optimize									https://redhat.atlassian.net/browse/RHIDP-14691	Tim
+	Scale system performance for growing traffic								FALSE	
+		Plan production scaling using high availability architecture							TRUE	
+				Deploy multiple stateless instances			FALSE	
+				Implement database HA			FALSE	
+				Implement cache HA			FALSE	
+		Configure high availability to maintain performance							TRUE	
+				Configure with the Operator			FALSE	
+				Configure with the Helm chart			FALSE	
+		Configure the dynamic plugins cache							FALSE	
+			Create a persistent volume claim						TRUE	
+				Create PVC with Operator			FALSE	
+				Create PVC with Helm Chart			FALSE	
+				Resolve plugin configuration errors			FALSE	
+		Enable the plugin assets cache							FALSE	
+Extend									https://redhat.atlassian.net/browse/RHIDP-14638	Gaurav
+	Manage the plugin ecosystem to add functionality without downtime								FALSE	
+		Install dynamic plugins							FALSE	
+			Install with Operator						TRUE	
+				Dynamic plugin dependency requirements and resource specifications			FALSE	
+					Cluster level plugin dependencies configuration		FALSE	
+					Plugin dependencies infrastructure		FALSE	
+					Plugin configuration		FALSE	
+			Install with Helm Chart						TRUE	
+				Example configurations			FALSE	
+			Install in an air-gapped environment						FALSE	
+			Mirror dynamic plugins in disconnected environments						TRUE	
+				Mirror to a partially disconnected environment			FALSE	
+				Mirror to a fully disconnected environment			FALSE	
+				Mirror specific plugins			FALSE	
+				Mirror plugins from a file			FALSE	
+				Combine plugin sources			FALSE	
+		Install plugins using custom certificates to secure private registry connections							TRUE	
+				Install from secure container registries			FALSE	
+				Install using trusted certificate authorities			FALSE	
+				Install with cluster-wide trust bundles			FALSE	
+		Enable pre-loaded container plugins							FALSE	
+		Browse and manage available plugins using the Extensions UI							FALSE	
+			Manage plugins						TRUE	
+				Control plugin administration access			FALSE	
+				Configure persistent storage for plugin installations			FALSE	
+				View plugins			FALSE	
+				Install and configure portal plugins			FALSE	
+				Validate plugin configurations locally			FALSE	
+				Enable and disable portal plugins			FALSE	
+				Disable the Extensions UI			FALSE	
+		Configure core front-end wiring for navigation and UI components							FALSE	
+			Requirements and workflows for front-end plugin wiring						TRUE	
+				Reasons for requiring front-end plugin wiring			FALSE	
+				Consequences of skipping front-end plugin wiring			FALSE	
+				Dynamic front-end plugins for application integration			FALSE	
+					Example workflow		FALSE	
+			Add custom icons to the internal icon catalog						FALSE	
+			Define dynamic routes to create plugin pages						FALSE	
+			Customize sidebar navigation menus						FALSE	
+		Configure route bindings and mount points for component integration							FALSE	
+			Bind dynamic plugins to existing routes						FALSE	
+			Configure mount points to attach custom UI components						TRUE	
+				Customize the entity page			FALSE	
+				Add application headers			FALSE	
+				Add application listeners			FALSE	
+				Add application providers			FALSE	
+			Customize and extend catalog entity tabs						FALSE	
+			Customize the platform theme using front-end plugins						FALSE	
+		Configure specialized front-end extensions for APIs and features							FALSE	
+			Configure custom sign-in pages for authentication						FALSE	
+			Add custom Scaffolder field extensions						FALSE	
+			Configure additional utility APIs						FALSE	
+			Add custom authentication provider settings to verify identities						FALSE	
+			Configure custom TechDocs add-ons						FALSE	
+		Filter plugins by support badges							FALSE	
+			Filter plugins by support and maturity						FALSE	
+	Develop custom dynamic plugins to support custom workflows								FALSE	
+		Prepare your development environment to write custom plugins							TRUE	
+				The development toolchain			FALSE	
+		Develop and test new plugin components locally							TRUE	
+				Determine RHDH version			FALSE	
+				Create a new Backstage application			FALSE	
+				Create a new plugin			FALSE	
+				Implement a plugin component			FALSE	
+				Test a plugin locally			FALSE	
+				Integrate custom user interface components			FALSE	
+		Convert standard plugins into dynamic plugins using the Plugin Factory							TRUE	
+				The dynamic plugin factory model			FALSE	
+		Package and deploy dynamic plugins as OCI images							FALSE	
+			Deploy custom dynamic plugins						FALSE	
+		Verify plugins locally							FALSE	
+	Manage containerized plugins securely by migrating to OCI artifacts								FALSE	
+		Migrate community plugins to the GitHub Container Registry							FALSE	
+			Update deployment configurations for OCI registry container images						FALSE	
+Troubleshoot									https://redhat.atlassian.net/browse/RHIDP-14693	Priyanka
+	Troubleshoot user access and authentication issues to restore user entry								FALSE	
+		Troubleshoot authentication issues							TRUE	
+				Reduce the size of issued tokens			FALSE	
+				Troubleshoot unexpected session expiration			FALSE	
+				Troubleshoot missing session expiration warnings			FALSE	
+				Troubleshoot missing login redirects			FALSE	
+				Troubleshoot login failed errors			FALSE	
+				Diagnose specific login failures			FALSE	
+				Troubleshoot catalog provider errors			FALSE	
+				Resolve malformed LDAP entity envelopes			FALSE	
+		Troubleshoot configuration issues							FALSE	
+			Maintain dynamic plugin settings in Helm deployments						FALSE	
+	Troubleshoot plugin and workflow deployment errors to resume automation								FALSE	
+		Troubleshoot pod startup failures							FALSE	
+		Diagnose serverless workflow issues							FALSE	
+			Troubleshoot HTTP error codes						FALSE	
+			Troubleshoot common deployment errors						FALSE	
+			Troubleshoot cross-namespace configuration						FALSE	
+			Troubleshoot missing workflows						FALSE	
+	Troubleshoot AI and tool integrations to restore intelligent features								FALSE	
+		Troubleshoot AI Connector functionality							TRUE	
+				Verify dynamic plugin status			FALSE	
+				Inspect plugin logs			FALSE	
+				Inspect the OpenShift AI Connector			FALSE	
+				Query model registries			FALSE	
+		Troubleshoot MCP server and client problems							TRUE	
+				Verify successful installation of MCP plugins			FALSE	
+				Check MCP tool logs			FALSE	
+				Validate tool inputs using error messages			FALSE	
+				Resolve unsupported tool calling errors			FALSE	
+				Resolve authentication issues			FALSE	
+				Resolve nonsensical MCP tool output			FALSE	
+Reference									https://redhat.atlassian.net/browse/RHIDP-14697	Fabrice
+	Dynamic plugin parameter reference for configuration paths								FALSE	
+		Preinstalled dynamic plugins reference							FALSE	
+		Red Hat supported plugins and configuration paths reference							FALSE	
+		Technology Preview plugins							FALSE	
+		Deprecated plugins							FALSE	
+		Other installable plugins							FALSE	
+	Permission policies and conditional rules reference for RBAC configurations								FALSE	
+		Permission policies							TRUE	
+				Plugin-specific permission strings			FALSE	
+		Conditional policy aliases and schemas							TRUE	
+				Conditional schemas			FALSE	
+	Trace attributes and OpenTelemetry configurations								FALSE	
+		OpenTelemetry configurations							TRUE	
+				OpenTelemetry properties			FALSE	
+		Trace attributes and lifecycle events							TRUE	
+				Span attributes			FALSE	
+				Process lifecycle and function call attributes			FALSE	
+				Propagation headers			FALSE	
+	Helm chart configuration parameters to define advanced deployment								FALSE	
+		Helm chart configuration parameters							TRUE	
+				Cluster-wide configuration and routing parameters			FALSE	
+				Upstream Backstage Helm values for application pods			FALSE	


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge**
> Draft PR for review. This adds the `/jtbd-map` skill and TOC mapping TSV used by the JTBD migration tooling.

**Version(s):** N/A (tooling only, no published content changes)

**Issue:** https://issues.redhat.com/browse/RHDHBUGS-3361

**Preview:** N/A

## Summary

Adds two files under `.claude/skills/jtbd-map/`:

### SKILL.md
The `/jtbd-map` skill populates JTBD navigation MAP files with actual `include::` directives. Workflow:
1. Identify scope from Jira ticket, category, or job name
2. Search assemblies then modules for matching content
3. Populate nav files with module includes
4. Populate concept files with assembly body content
5. Resolve xref dependencies
6. Ensure required attributes (platform table, context, etc.)
7. Validate with CQA and ccutil build

### jtbd-toc-mapping.tsv
728-line reference mapping all 16 categories to their jobs, topics, headings, file paths, assignees, and Jira tickets.