### PR TITLE
fix(vale): Resolve pre-existing Vale ERROR-level issues

### DIFF
--- a/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-use-developer-preview-features-to-install-and-test-plugins-in-rhdh.adoc
+++ b/assemblies/extend_installing-and-viewing-plugins-in-rhdh/assembly-use-developer-preview-features-to-install-and-test-plugins-in-rhdh.adoc
@@ -2,11 +2,11 @@
 ifdef::context[:parent-context: {context}]
 
 [id="use-developer-preview-features-to-install-and-test-plugins-in-rhdh_{context}"]
-= Use Developer Preview features to install and test plugins in {product}
+= Use {developer-preview} features to install and test plugins in {product}
 :context: developer-preview-features-in-rhdh
 
 [role="_abstract"]
-{product} ({product-very-short}) includes Developer Preview features that provide early access for developers to functionality that might be included in a future release of {product-very-short}. These features are for development and testing purposes only, not for production use.
+{product} ({product-very-short}) includes {developer-preview} features that provide early access for developers to functionality that might be included in a future release of {product-very-short}. These features are for development and testing purposes only, not for production use.
 
 include::{docdir}/artifacts/snip-developer-preview.adoc[]
 

--- a/modules/configure_configuring-rhdh/con-rhdh-secrets.adoc
+++ b/modules/configure_configuring-rhdh/con-rhdh-secrets.adoc
@@ -17,10 +17,11 @@ To create secrets, author the secret values in a local file (for example, `my-rh
 You can provision secrets using either of the following methods:
 
 * With the Operator: Reference secrets in the `{product-custom-resource-type}` custom resource by using the `spec.application.extraEnvs.secrets` field to inject secrets as environment variables, or the `spec.application.extraFiles.secrets` field to mount secrets as files, such as, TLS certificates.
-* With the Helm chart: Reference secrets by using the `upstream.backstage.extraEnvVarsSecrets` or `upstream.backstage.extraEnvVars` field with a [`secretKeyRef`](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables)). You can also mount secrets as files by using both the `upstream.backstage.extraVolumes` and `upstream.backstage.extraVolumeMounts` values.
+* With the Helm chart: Reference secrets by using the `upstream.backstage.extraEnvVarsSecrets` or `upstream.backstage.extraEnvVars` field with a `secretKeyRef`. You can also mount secrets as files by using both the `upstream.backstage.extraVolumes` and `upstream.backstage.extraVolumeMounts` values.
 
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables[Using secrets as environment variables] in the Kubernetes documentation
 * xref:provision-your-custom-rhdh-configuration_provision-and-use-your-custom-rhdh-configuration[Provisioning your custom {product} configuration]
 * {authentication-book-link}[{authentication-book-title}]

--- a/modules/configure_configuring-rhdh/proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc
+++ b/modules/configure_configuring-rhdh/proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc
@@ -8,8 +8,10 @@ To secure application traffic with your own certificate, configure the {product-
 
 [IMPORTANT]
 ====
-// cqa-17: suppress — Technology Preview refers to an OCP feature, not RHDH
+// vale DeveloperHub.ProductNames = NO
+// cqa-17: suppress — the TP label refers to an OCP feature, not a product feature
 On {ocp-brand-name} 4.18 and earlier, securing a route with an external certificate is a Technology Preview feature that requires enabling the `RouteExternalCertificate` Feature Gate.
+// vale DeveloperHub.ProductNames = YES
 On {ocp-brand-name} 4.19 and later, this feature is Generally Available and does not require a Feature Gate.
 
 For more information, see {ocp-docs-link}/html-single/networking/index#nw-ingress-route-secret-load-external-cert_secured-routes[Securing routes with external certificates in TLS secrets].

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/con-software-template-validation-with-scaffolder-dry-run-tools.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/con-software-template-validation-with-scaffolder-dry-run-tools.adoc
@@ -9,5 +9,5 @@ With Software Template validation, you can verify YAML configuration and executi
 The validation process involves the following key components:
 
 * User interaction: You must provide the template YAML content, required input values, and any additional files.
-* Agent invocation: The AI agent maps these inputs to the `templateYAML`, `values`, and `files` parameters to invoke the dry-run tool.
+* Agent invocation: The AI agent maps these inputs to the `templateYAML`, `values`, and `files` parameters to call the dry-run tool.
 * Outcome processing: The AI agent interprets the `valid` status and execution logs to provide a plain-language summary or troubleshooting steps if validation fails.

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
@@ -65,7 +65,7 @@ lightspeed:
 where:
 
 `name`:: Enter the server name. This must match the name configured in the {lcs-short}.
-`token`:: Optional: Enter the static token used to authorize requests. You can also configure the token through the *MCP Server Settings* in the *Developer Lightspeed* user interface. The setting remains disabled until you configure the token.
+`token`:: Optional: Enter the static token used to authorize requests. You can also configure the token through the *MCP Server Settings* in the *{ls-short}* user interface. The setting remains disabled until you configure the token.
 
 .. Optional: Query the {lcs-short} `/v1/streaming_query` endpoint directly by providing the `MCP_TOKEN` in the header:
 +

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-enable-encryption-and-database-storage-for-mcp-server-tokens.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-enable-encryption-and-database-storage-for-mcp-server-tokens.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 To protect sensitive credentials and persist user preferences, you must configure encryption and database settings in the `{my-app-config-file}` file. 
 
-Configuring encryption prevents the system from storing Model Context Protocol (MCP) tokens as plaintext in the database.
+Configuring encryption prevents the system from storing Model Context Protocol (MCP) tokens as plain text in the database.
 
 .Prerequisites
 

--- a/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 Adoption Insights is enabled by default on {product-short} instances.
 // cqa-17: suppress
-If you are migrating from a Developer Preview or you have installed Adoption Insights manually before, update your configuration.
+If you are migrating from a {developer-preview} or you have installed Adoption Insights manually before, update your configuration.
 
 .Procedure
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
@@ -8,7 +8,7 @@ Define aggregated Key Performance Indicators (KPIs) in your configuration to pro
 
 .Prerequisites
 * The scorecard plugin is installed and configured in your {product} instance.
-* You have identified the `metricId` you wish to aggregate.
+* You have identified the `metricId` you want to aggregate.
 
 .Procedure
 

--- a/modules/shared/con-servicenow-entity-linking-methods.adoc
+++ b/modules/shared/con-servicenow-entity-linking-methods.adoc
@@ -7,7 +7,7 @@ To view and manage ServiceNow incidents directly in {product} ({product-very-sho
 
 {product} provides two methods for linking these entities. You can choose the method that best fits your organization's security requirements and your ability to modify the ServiceNow schema.
 
-== Direct mapping (Backstage Entity ID column)
+== Direct mapping ({backstage} Entity ID column)
 
 The default method requires adding a custom column named `backstage_entity_id` to your ServiceNow incident table. You then manually or programmatically assign the specific {product-very-short} entity reference (for example, `component:default/my-service`) to this column in ServiceNow.
 

--- a/modules/shared/con-vertex-ai-integration-for-gemini-models.adoc
+++ b/modules/shared/con-vertex-ai-integration-for-gemini-models.adoc
@@ -4,7 +4,7 @@
 = Vertex AI integration for Gemini models
 
 [role="_abstract"]
-To use Gemini models with {ls-short}, you can configure Google Cloud Vertex AI to act as your managed large language model (LLM) inference provider. 
+To use Gemini models with {ls-short}, you can configure {gcp-brand-name} Vertex AI to act as your managed large language model (LLM) inference provider. 
 
 The underlying {lcs-short} service connects to Vertex AI to access hosted Gemini models. This integration provides {ls-short} with enterprise-grade language processing and chat assistance capabilities without requiring you to maintain a local inference server.
 

--- a/modules/shared/proc-configure-by-using-the-operator.adoc
+++ b/modules/shared/proc-configure-by-using-the-operator.adoc
@@ -36,6 +36,7 @@ stringData:
 
 . Map your secret inside the `extraEnvs` section of the {backstage} CR to complete container provisioning:
 +
+// vale DeveloperHub.ProductNames = NO
 [source,yaml]
 ----
 apiVersion: rhdh.redhat.com/v1alpha5
@@ -50,6 +51,7 @@ spec:
           containers:
             - lightspeed-core
 ----
+// vale DeveloperHub.ProductNames = YES
 
 . Optional: To protect settings such as Model Context Protocol (MCP) server additions from being overwritten during reconciliation loops, define a custom ConfigMap mapping in the `extraFiles` section of the CR:
 +

--- a/modules/shared/proc-create-isolated-research-workspaces.adoc
+++ b/modules/shared/proc-create-isolated-research-workspaces.adoc
@@ -9,7 +9,7 @@ image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-noteb
 
 .Procedure
 . In the {product-very-short} interface, click the *Open Lightspeed* floating action button (FAB).
-. In your *Developer Lightspeed* page, select the *Notebooks* tab.
+. In your *{ls-short}* page, select the *Notebooks* tab.
 . Click *Create a new notebook* to start a new workspace.
 . Optional: To manage your workspaces, click the *More options* icon on a notebook card to *Rename*, *Delete*, or add *Tags* to the session.
 +

--- a/modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc
+++ b/modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc
@@ -10,9 +10,9 @@ When you install the {product-short} Helm chart in {eks-name} ({eks-short}), it 
 
 .Prerequisites
 
-* You have an {eks-short} cluster with AWS Application Load Balancer (ALB) add-on installed. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html[Application load balancing on Amazon {product-short}] and https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[Installing the AWS Load Balancer Controller add-on].
-* You have configured a domain name for your {product-short} instance. The domain name can be a hosted zone entry on Route 53 or managed outside of AWS. For more information, see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html[Configuring Amazon Route 53 as your DNS service] documentation.
-* You have an entry in the AWS Certificate Manager for your preferred domain name. Make sure to keep a record of your Certificate Amazon Resource Name (ARN).
+* You have an {eks-short} cluster with {aws-short} Application Load Balancer (ALB) add-on installed. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html[Application load balancing on Amazon {product-short}] and https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[Installing the {aws-short} Load Balancer Controller add-on].
+* You have configured a domain name for your {product-short} instance. The domain name can be a hosted zone entry on Route 53 or managed outside of {aws-short}. For more information, see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html[Configuring Amazon Route 53 as your DNS service] documentation.
+* You have an entry in the {aws-short} Certificate Manager for your preferred domain name. Make sure to keep a record of your Certificate Amazon Resource Name (ARN).
 * You have subscribed to {rhcr-long}. For more information, see link:https://access.redhat.com/articles/RegistryAuthentication[{company-name} Container Registry Authentication].
 * You have set the context to the {eks-short} cluster in your current `kubeconfig`. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html[Creating or updating a `kubeconfig` file for an Amazon {eks-short} cluster].
 * You have installed `kubectl`. For more information, see https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html[Installing or updating the `kubectl` tool].

--- a/modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc
+++ b/modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc
@@ -11,7 +11,7 @@ When you install the {product-short} Helm chart in {gke-brand-name} ({gke-short}
 .Prerequisites
 * You have subscribed to the {rhcr-long}. For more information, see link:https://access.redhat.com/articles/RegistryAuthentication[{company-name} Container Registry Authentication].
 * You have installed `kubectl`. For more information, see https://kubernetes.io/docs/tasks/tools/#kubectl[Install the `kubectl` tool].
-* You have installed the Google Cloud CLI. For more information, see https://cloud.google.com/sdk/docs/install[Install the `gcloud` CLI].
+* You have installed the {gcp-brand-name} CLI. For more information, see https://cloud.google.com/sdk/docs/install[Install the `gcloud` CLI].
 * You have logged in to your Google account and created a https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster[{gke-short} Autopilot] or https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-zonal-cluster[{gke-short} Standard] cluster.
 * You have configured a domain name for your {product-short} instance.
 * You have reserved a static external Premium IPv4 Global IP address that is not attached to any VM. For more information see https://cloud.google.com/vpc/docs/reserve-static-external-ip-address#reserve_new_static[Reserve a new static external IP address]

--- a/modules/shared/proc-disable-by-using-the-operator.adoc
+++ b/modules/shared/proc-disable-by-using-the-operator.adoc
@@ -15,6 +15,7 @@ Disable the {ls-short} chat interface and stop associated container processes to
 . Open your {backstage} custom resource (CR) YAML file.
 . In the `spec` section, set the `enabled` flag to `false` for the `lightspeed` flavour. This disables the chat interface and prevents the Operator from injecting unconfigured sidecar containers:
 +
+// vale DeveloperHub.ProductNames = NO
 [source,yaml]
 ----
 apiVersion: rhdh.redhat.com/v1alpha5
@@ -26,6 +27,7 @@ spec:
     - name: lightspeed
       enabled: false
 ----
+// vale DeveloperHub.ProductNames = YES
 ... Apply the updated custom resource manifest to your cluster:
 +
 [source,bash]

--- a/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enable-data-persistence-for-developer-lightspeed-notebooks_{context}"]
-= Enable data persistence for Developer Lightspeed Notebooks
+= Enable data persistence for {ls-short} Notebooks
 
 [role="_abstract"]
 To persist Notebook sessions, documents, and AI history across service restarts, you must configure the Notebooks storage backends to use persistent volumes. 

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enable-secure-ai-research-with-developer-lightspeed-notebooks_{context}"]
-= Enable secure AI research with Developer Lightspeed Notebooks
+= Enable secure AI research with {ls-short} Notebooks
 
 [role="_abstract"]
 Configure {product} and {ls-brand-name} to provide users with private, document-based AI workspaces.

--- a/modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc
+++ b/modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc
@@ -16,9 +16,9 @@ create the required ingresses on {eks-short} and point your domain name to it.
 .Prerequisites
 * You have installed {product} by using the {product} Operator.
 * You have an {eks-short} cluster with {aws-short} Application Load Balancer (ALB) add-on installed.
-For more information, see https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html[Application load balancing on {eks-brand-name}] and https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[Installing the AWS Load Balancer Controller add-on].
+For more information, see https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html[Application load balancing on {eks-brand-name}] and https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html[Installing the {aws-short} Load Balancer Controller add-on].
 * You have configured a domain name for your {product-short} instance.
-The domain name can be a hosted zone entry on Route 53 or managed outside of AWS.
+The domain name can be a hosted zone entry on Route 53 or managed outside of {aws-short}.
 For more information, see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html[Configuring Amazon Route 53 as your DNS service] documentation.
 * You have an entry in the {aws-short} Certificate Manager for your preferred domain name.
 Make sure to keep a record of your Certificate Amazon Resource Name (ARN).

--- a/modules/shared/proc-install-the-topology-plugin.adoc
+++ b/modules/shared/proc-install-the-topology-plugin.adoc
@@ -20,7 +20,7 @@ If you have the {product-short} Kubernetes plugin configured, then the `ClusterR
 To enable it, set the disabled property to false as follows:
 +
 --
-.`{my-app-config-file}` fragment
+// {my-app-config-file} fragment
 [source,yaml]
 ----
 plugins:

--- a/modules/shared/proc-prepare-evaluation-datasets-to-verify-ai-generated-responses.adoc
+++ b/modules/shared/proc-prepare-evaluation-datasets-to-verify-ai-generated-responses.adoc
@@ -14,7 +14,9 @@ Prepare evaluation data sets to test the performance of {ls-short}. You can use 
 
 . Download pre-generated data sets: Use this method to test the performance of specific {product-very-short} releases. These data sets are generated using link:https://docs.ragas.io/en/stable/concepts/test_data_generation/rag/[Ragas testset generation for RAG].
 
+// vale RedHat.TermsErrors = NO
 .. In your terminal, navigate to the link:https://github.com/redhat-ai-dev/developer-lightspeed-evaluation/tree/main/dataset[/dataset folder] in the evaluation repository.
+// vale RedHat.TermsErrors = YES
 .. Locate the `.evaluation_dataset_yaml` files. These files are pre-configured for the evaluation tool.
 .. To test a historical release, switch to the corresponding branch.
 +

--- a/modules/shared/snip-installing-the-operator-common-steps.adoc
+++ b/modules/shared/snip-installing-the-operator-common-steps.adoc
@@ -70,6 +70,7 @@ EOF
 
 . To wait until the Operator deployment finishes to be able to run the next step, run:
 +
+// vale DeveloperHub.ProductNames = NO
 [source,terminal]
 ----
 $ until kubectl -n rhdh-operator get deployment rhdh-operator &>/dev/null; do
@@ -78,6 +79,7 @@ $ until kubectl -n rhdh-operator get deployment rhdh-operator &>/dev/null; do
 done
 echo "RHDH Operator Deployment created"
 ----
+// vale DeveloperHub.ProductNames = YES
 
 . Include your pull secret name in the Operator deployment manifest, to avoid `ImagePullBackOff` errors:
 +

--- a/modules/shared/snip-lightspeed-secret-keys.adoc
+++ b/modules/shared/snip-lightspeed-secret-keys.adoc
@@ -32,13 +32,13 @@ To disable an inference provider or configuration feature, you must leave the co
 | Enables the Vertex AI platform when set to `"true"`.
 
 | `VERTEX_AI_PROJECT`
-| Specifies your Google Cloud project ID.
+| Specifies your {gcp-brand-name} project ID.
 
 | `VERTEX_AI_LOCATION`
-| Specifies your target Google Cloud region.
+| Specifies your target {gcp-brand-name} region.
 
 | `GOOGLE_APPLICATION_CREDENTIALS`
-| Specifies the file path of your mounted Google Cloud service account credentials JSON file.
+| Specifies the file path of your mounted {gcp-brand-name} service account credentials JSON file.
 
 | `ENABLE_VALIDATION`
 | Activates query safety validation guardrails when set to `"true"`.


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** without reviewer approval.

**Version(s):** 1.5

**Issue:** N/A (housekeeping)

**Preview:** N/A

## Summary

Fixes 31 pre-existing Vale ERROR-level issues across 22 manually-maintained files. These errors surface on every PR due to the `assemblies/modules` symlink resolving into the `modules/` directory.

Auto-generated plugin reference files (`ref-community-supported-plugins.adoc`, `ref-ga-plugins.adoc`, `ref-technology-preview-plugins.adoc`) are excluded -- those 12 errors should be fixed in the generator script.

### Changes by category

**ProductNames attribute substitutions (18 fixes):**
- `Developer Preview` -> `{developer-preview}` (3 files)
- `Developer Lightspeed` -> `{ls-short}` (4 files)
- `Google Cloud` -> `{gcp-brand-name}` (3 files)
- `AWS` -> `{aws-short}` (2 files)
- `Backstage` -> `{backstage}` (1 file)

**TermsErrors fixes (4 fixes):**
- `invoke` -> `call` (scaffolder dry-run tool)
- `plaintext` -> `plain text` (MCP tokens)
- `wish` -> `want` (scorecards KPIs)
- `dataset` -> suppressed (GitHub URL path, cannot change link text)

**False positive suppressions (6 fixes):**
- `kind: Backstage` in YAML code blocks (2 files)
- `RHDH` in bash `echo` string (1 file)
- `Technology Preview` referring to an OCP feature, not RHDH (1 file)

**Structural fixes (3 fixes):**
- Move inline Markdown-style link to Additional resources section (1 file)
- Convert unsupported DITA block title to comment (1 file)

### Remaining errors (12, in auto-generated files)

These are in files regenerated weekly by `generate-supported-plugins-pr.yml` and need to be fixed in the generator:
- `ref-community-supported-plugins.adoc`: 8 errors (Azure/AWS in plugin names and env vars)
- `ref-ga-plugins.adoc`: 2 errors (RHDH_VERSION env var, quickstart in npm package name)
- `ref-technology-preview-plugins.adoc`: 2 errors (RHDH_EXTENSIONS_* env var names)