### PR TITLE
[RHIDP-14545][RHIDP-14546][RHIDP-14547][RHIDP-14548]: Populate Configure category MAP files with module includes

### DIFF
--- a/titles/product_product/category-maps/configure/con-add-custom-branding-logos.adoc
+++ b/titles/product_product/category-maps/configure/con-add-custom-branding-logos.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Add custom branding logos
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Add custom branding logos.

--- a/titles/product_product/category-maps/configure/con-configure-corporate-proxy-settings-to-enable-external-network-access.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-corporate-proxy-settings-to-enable-external-network-access.adoc
@@ -3,4 +3,11 @@
 = Configure corporate proxy settings to enable external network access
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure corporate proxy settings to enable external network access.
+In a network restricted environment, configure {product} to use your proxy to access remote network resources.
+
+You can run the {product-short} application behind a corporate proxy by setting any of the following environment variables before starting the application:
+
+`HTTP_PROXY`:: Denotes the proxy to use for HTTP requests.
+`HTTPS_PROXY`:: Denotes the proxy to use for HTTPS requests.
+
+`NO_PROXY`:: Set the environment variable to bypass the proxy for certain domains. The variable value is a comma-separated list of hostnames or IP addresses that do not require the proxy, even if you specify one.

--- a/titles/product_product/category-maps/configure/con-configure-floating-action-buttons-for-quick-access-to-workflows.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-floating-action-buttons-for-quick-access-to-workflows.adoc
@@ -3,4 +3,16 @@
 = Configure floating action buttons for quick access to workflows
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure floating action buttons for quick access to workflows.
+Configure any action as a floating button in the {product-short} instance by using the floating action button plugin.
+
+[IMPORTANT]
+====
+{product-very-short} 1.10 disables the Global Floating Action Button plugin by default. For new deployments, use the Global Header plugin, which uses quick links and starred items to improve navigation.
+
+Existing deployments that explicitly enable the Global Floating Action Button remain functional. However, as the plugin is deprecated, it will be removed in a future {product-very-short} version, and you must eventually adjust your configuration.
+====
+
+[role="_additional-resources"]
+== Additional resources
+* xref:configure-the-global-header-in-rhdh_customizing-rhdh[Configure the Global Header in {product}]
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/red_hat_developer_hub_release_notes/deprecated-features[Deprecated features in {product-very-short} 1.9.]

--- a/titles/product_product/category-maps/configure/con-configure-language-localization-to-improve-accessibility-for-global-users.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-language-localization-to-improve-accessibility-for-global-users.adoc
@@ -3,4 +3,4 @@
 = Configure language localization to improve accessibility for global users
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure language localization to improve accessibility for global users.
+{product} supports multiple languages through its localization framework, enabling international teams to use the platform in their preferred language.

--- a/titles/product_product/category-maps/configure/con-configure-quick-access-cards-to-surface-frequently-used-links.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-quick-access-cards-to-surface-frequently-used-links.adoc
@@ -3,4 +3,4 @@
 = Configure Quick access cards to surface frequently used links
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure Quick access cards to surface frequently used links.
+You can customize the Quick access card on the {product} Home page by configuring a proxy in your `app-config.yaml` file. You can provide data from JSON files hosted on GitHub or GitLab, or from a dedicated service that provides the data in JSON format by using an API.

--- a/titles/product_product/category-maps/configure/con-configure-the-global-header-for-consistent-top-level-navigation.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-the-global-header-for-consistent-top-level-navigation.adoc
@@ -3,4 +3,12 @@
 = Configure the global header for consistent top-level navigation
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure the global header for consistent top-level navigation.
+As an administrator, you can configure the {product} global header to create a consistent and flexible navigation bar across your {product-short} instance.
+By default, the {product-short} global header includes the following components:
+
+* *Self-service* button provides quick access to a variety of templates, enabling users to efficiently set up services, backend and front-end plugins within {product-short}
+* *Support* button that can link an internal or external support page
+* *Notifications* button displays alerts and updates from plugins and external services
+* *Search* input field allows users to find services, components, documentation, and other resources within {product-short}
+* *Plugin extension capabilities* provide a preinstalled and enabled catalog of available plugins in {product-short}
+* *User profile* drop-down menu provides access to profile settings, appearance customization, {product-short} metadata, and a logout button

--- a/titles/product_product/category-maps/configure/con-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc
@@ -3,4 +3,4 @@
 = Customize Learning Paths to integrate tailored e-learning content
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize Learning Paths to integrate tailored e-learning content.
+In {product}, you can configure Learning Paths by hosting the required data externally and by using the built-in proxy to deliver this data. You can provide Learning Paths data from a JSON file hosted on a web server or from a dedicated service that provides the data in JSON format by using an API.

--- a/titles/product_product/category-maps/configure/con-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
@@ -3,4 +3,4 @@
 = Customize sidebar navigation and tabs to organize essential tools
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize sidebar navigation and tabs to organize essential tools.
+You can customize navigation elements in {product}, including sidebar menu items, entity tab titles, and entity detail tab layouts.

--- a/titles/product_product/category-maps/configure/con-customize-the-home-page-layout-to-optimize-developer-workflows.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-the-home-page-layout-to-optimize-developer-workflows.adoc
@@ -3,4 +3,4 @@
 = Customize the Home page layout to optimize developer workflows
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the Home page layout to optimize developer workflows.
+Persona-specific homepage layouts allow you to deliver targeted content, such as role-appropriate templates and links, to distinct user groups in {product}.

--- a/titles/product_product/category-maps/configure/con-customize-the-quick-start-to-guide-user-onboarding.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-the-quick-start-to-guide-user-onboarding.adoc
@@ -3,4 +3,4 @@
 = Customize the Quick Start to guide user onboarding
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the Quick Start to guide user onboarding.
+The quick start plugin provides guided onboarding for {product} users through customizable, interactive steps that help users get familiar with the platform.

--- a/titles/product_product/category-maps/configure/con-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc
@@ -3,4 +3,16 @@
 = Customize the Tech Radar page to visualize technology adoption
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the Tech Radar page to visualize technology adoption.
+In {product}, the Tech Radar page is provided by the `tech-radar` dynamic plugin, which is disabled by default. For information about enabling dynamic plugins in {product} see {configuring-dynamic-plugins-book-link}[{configuring-dynamic-plugins-book-title}].
+
+In {product}, you can configure Learning Paths by passing the data into the `{my-app-config-file}` file as a proxy. The base Tech Radar URL must include the `/developer-hub/tech-radar` proxy.
+
+[NOTE]
+====
+Due to the use of overlapping `pathRewrites` for both the `tech-radar` and `homepage` quick access proxies, you must create the `tech-radar` configuration (`^api/proxy/developer-hub/tech-radar`) before you create the `homepage` configuration (`^/api/proxy/developer-hub`).
+====
+
+You can provide data to the Tech Radar page from the following sources:
+
+* JSON files hosted on GitHub or GitLab.
+* A dedicated service that provides the Tech Radar data in JSON format using an API.

--- a/titles/product_product/category-maps/configure/con-customize-themes-and-branding-to-align-with-corporate-standards.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-themes-and-branding-to-align-with-corporate-standards.adoc
@@ -3,4 +3,20 @@
 = Customize themes and branding to align with corporate standards
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize themes and branding to align with corporate standards.
+By modifying the visual aspects of the interface, organizations can align {product} with their branding guidelines and improve the overall user experience.
+
+The following default theme configurations are available for {product}:
+
+The {product} theme:: Default theme configurations to make your developer portal look like a standard {product} instance.
+
+The {backstage} theme:: Default theme configurations to make your developer portal look like a standard {backstage} instance.
+
+You can change or disable particular parameters in a default theme or create a fully customized theme by modifying the `{my-app-config-file}` file. From the `{my-app-config-file}` file, you can customize common theme components, including the following components:
+
+* Company name and logo
+* Font color, size, and style of text in paragraphs, headings, headers, and buttons
+* Header color, gradient, and shape
+* Button color
+* Navigation indicator color
+
+You can also customize some components from the {product-short} GUI, such as the theme mode (*Light Theme*, *Dark Theme*, or *Auto*).

--- a/titles/product_product/category-maps/configure/con-customize-your-quick-start.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-your-quick-start.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Customize your quick start
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize your quick start.

--- a/titles/product_product/category-maps/configure/con-default-configurations-to-establish-a-deployment-foundation.adoc
+++ b/titles/product_product/category-maps/configure/con-default-configurations-to-establish-a-deployment-foundation.adoc
@@ -3,4 +3,4 @@
 = Default configurations to establish a deployment foundation
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Default configurations to establish a deployment foundation.
+Deploy a standard {product} instance, understand its structure, and tailor the instance to meet your needs.

--- a/titles/product_product/category-maps/configure/con-define-quicklinks.adoc
+++ b/titles/product_product/category-maps/configure/con-define-quicklinks.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Define Quicklinks
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Define Quicklinks.

--- a/titles/product_product/category-maps/configure/con-enable-the-localization-framework.adoc
+++ b/titles/product_product/category-maps/configure/con-enable-the-localization-framework.adoc
@@ -3,4 +3,4 @@
 = Enable the localization framework
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Enable the localization framework.
+{product} supports multiple languages through its localization framework. You can enable language selection, override default translations, and implement localization support in custom plugins.

--- a/titles/product_product/category-maps/configure/con-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc
+++ b/titles/product_product/category-maps/configure/con-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc
@@ -3,4 +3,4 @@
 = Provision custom config maps and secrets to define platform behavior
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Provision custom config maps and secrets to define platform behavior.
+Configure {product} by using config maps to mount files and directories and secrets to inject environment variables into your {ocp-brand-name} application.

--- a/titles/product_product/category-maps/configure/nav-add-custom-branding-logos.adoc
+++ b/titles/product_product/category-maps/configure/nav-add-custom-branding-logos.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="add-custom-branding-logos_{context}"]
-= Add custom branding logos
-:context: add-custom-branding-logos
-
-include::con-add-custom-branding-logos.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
@@ -6,22 +6,22 @@
 
 include::con-configure-core-parameters-to-meet-infrastructure-requirements.adoc[leveloffset=+1]
 
-// TODO: include Default configurations to establish a deployment foundation
+include::nav-default-configurations-to-establish-a-deployment-foundation.adoc[leveloffset=+1]
 
 include::nav-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc[leveloffset=+1]
 
-// TODO: include Configure the base URL to route frontend and backend traffic
+include::modules/configure_configuring-rhdh/proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc[leveloffset=+1,navtitle="Configure the base URL to route frontend and backend traffic"]
 
-// TODO: include Configure backend secrets to secure service-to-service communication
+include::modules/configure_configuring-rhdh/con-rhdh-secrets.adoc[leveloffset=+1,navtitle="Configure backend secrets to secure service-to-service communication"]
 
-// TODO: include Inject extra files and variables to secure external service connections
+include::modules/configure_configuring-rhdh/proc-inject-extra-files-and-environment-variables-into-containers.adoc[leveloffset=+1,navtitle="Inject extra files and variables to secure external service connections"]
 
-// TODO: include Configure mount paths to safely attach default secrets and storage
+include::modules/configure_configuring-rhdh/proc-configure-mount-paths-for-default-secrets-and-persistent-volume-claims-pvcs.adoc[leveloffset=+1,navtitle="Configure mount paths to safely attach default secrets and storage"]
 
-// TODO: include Mount secrets to specific containers to isolate sensitive data
+include::modules/configure_configuring-rhdh/proc-mount-secrets-and-pvcs-to-specific-containers.adoc[leveloffset=+1,navtitle="Mount secrets to specific containers to isolate sensitive data"]
 
-// TODO: include Patch deployment resources to customize Operator pod specifications
+include::modules/configure_configuring-rhdh/ref-configure-rhdh-deployment-when-using-the-operator.adoc[leveloffset=+1,navtitle="Patch deployment resources to customize Operator pod specifications"]
 
-// TODO: include Configure TLS connections to encrypt external platform traffic
+include::modules/configure_configuring-rhdh/proc-configure-an-rhdh-instance-with-a-tls-connection-in-kubernetes.adoc[leveloffset=+1,navtitle="Configure TLS connections to encrypt external platform traffic"]
 
-// TODO: include Configure corporate proxy settings to enable external network access
+include::nav-configure-corporate-proxy-settings-to-enable-external-network-access.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-configure-corporate-proxy-settings-to-enable-external-network-access.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-corporate-proxy-settings-to-enable-external-network-access.adoc
@@ -5,3 +5,9 @@
 :context: configure-corporate-proxy-settings-to-enable-external-network-access
 
 include::con-configure-corporate-proxy-settings-to-enable-external-network-access.adoc[leveloffset=+1]
+
+include::modules/configure_configuring-rhdh/con-the-no-proxy-exclusion-rules.adoc[leveloffset=+1,navtitle="The NO_PROXY exclusion rules"]
+
+include::modules/configure_configuring-rhdh/proc-configure-proxy-information-in-operator-deployment.adoc[leveloffset=+1,navtitle="Configure proxy settings in Operator deployment"]
+
+include::modules/configure_configuring-rhdh/proc-configure-proxy-information-in-helm-deployment.adoc[leveloffset=+1,navtitle="Configure proxy settings in Helm deployment"]

--- a/titles/product_product/category-maps/configure/nav-configure-floating-action-buttons-for-quick-access-to-workflows.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-floating-action-buttons-for-quick-access-to-workflows.adoc
@@ -5,3 +5,14 @@
 :context: configure-floating-action-buttons-for-quick-access-to-workflows
 
 include::con-configure-floating-action-buttons-for-quick-access-to-workflows.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-a-floating-action-button-as-a-dynamic-plugin.adoc[leveloffset=+1]
+
+// Temporarily set old context for backward-compatible module IDs
+:context: configure-a-floating-action-button-in-rhdh
+include::modules/shared/con-floating-action-button-localization-support.adoc[leveloffset=+1,navtitle="Interface translation options"]
+:context: configure-floating-action-buttons-for-quick-access-to-workflows
+
+include::modules/shared/con-internal-translation-implementation.adoc[leveloffset=+1,navtitle="Internal translation implementation"]
+
+include::modules/shared/ref-floating-action-button-parameters.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-configure-language-localization-to-improve-accessibility-for-global-users.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-language-localization-to-improve-accessibility-for-global-users.adoc
@@ -6,6 +6,6 @@
 
 include::con-configure-language-localization-to-improve-accessibility-for-global-users.adoc[leveloffset=+1]
 
-// TODO: include Enable the localization framework
+include::nav-enable-the-localization-framework.adoc[leveloffset=+1]
 
-// TODO: include Localization best practices
+include::modules/shared/ref-best-practices-for-implementing-localization-support-for-custom-plugins-in-rhdh.adoc[leveloffset=+1,navtitle="Localization best practices"]

--- a/titles/product_product/category-maps/configure/nav-configure-quick-access-cards-to-surface-frequently-used-links.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-quick-access-cards-to-surface-frequently-used-links.adoc
@@ -4,4 +4,11 @@
 = Configure Quick access cards to surface frequently used links
 :context: configure-quick-access-cards-to-surface-frequently-used-links
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="customize-the-quick-access-card_customizing-rhdh"]
+
 include::con-configure-quick-access-cards-to-surface-frequently-used-links.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc[leveloffset=+1,navtitle="Use hosted JSON files to provide data"]
+
+include::modules/shared/proc-use-a-dedicated-service-to-provide-data-to-the-quick-access-card.adoc[leveloffset=+1,navtitle="Use a dedicated service to provide data"]

--- a/titles/product_product/category-maps/configure/nav-configure-the-global-header-for-consistent-top-level-navigation.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-the-global-header-for-consistent-top-level-navigation.adoc
@@ -4,10 +4,21 @@
 = Configure the global header for consistent top-level navigation
 :context: configure-the-global-header-for-consistent-top-level-navigation
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="configure-the-global-header-in-rhdh_customizing-rhdh"]
+
 include::con-configure-the-global-header-for-consistent-top-level-navigation.adoc[leveloffset=+1]
 
-// TODO: include Add custom branding logos
+include::modules/shared/proc-customize-your-rhdh-global-header.adoc[leveloffset=+1]
 
-// TODO: include Configure display names
+include::modules/shared/ref-mount-points-for-dynamic-plugin-integration.adoc[leveloffset=+1]
 
-// TODO: include Define Quicklinks
+include::modules/shared/proc-configure-the-logo-in-the-global-header.adoc[leveloffset=+1,navtitle="Add custom branding logos"]
+
+include::modules/shared/proc-enable-logo-in-the-sidebar.adoc[leveloffset=+1,navtitle="Enable logo in the sidebar"]
+
+include::modules/shared/proc-display-the-preferred-username-in-the-profile-dropdown.adoc[leveloffset=+1,navtitle="Configure display names"]
+
+include::modules/shared/con-quicklinks-and-starred-items-in-the-global-header.adoc[leveloffset=+1,navtitle="Define Quicklinks"]
+
+include::modules/shared/proc-enable-quicklinks-and-starred-items-after-an-upgrade.adoc[leveloffset=+1,navtitle="Enable Quicklinks and starred items after an upgrade"]

--- a/titles/product_product/category-maps/configure/nav-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc
@@ -5,3 +5,11 @@
 :context: customize-learning-paths-to-integrate-tailored-e-learning-content
 
 include::con-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc[leveloffset=+1]
+
+include::modules/shared/con-about-learning-paths.adoc[leveloffset=+1,navtitle="Structured learning paths for developers onboarding"]
+
+include::modules/shared/proc-customize-the-learning-paths-by-using-a-hosted-json-file.adoc[leveloffset=+1,navtitle="Customize by using a hosted JSON file"]
+
+include::modules/shared/proc-customize-the-learning-paths-by-using-a-customization-service.adoc[leveloffset=+1,navtitle="Customize by using a customization service"]
+
+include::modules/shared/proc-start-and-complete-lessons-in-learning-paths.adoc[leveloffset=+1,navtitle="Start and complete lessons"]

--- a/titles/product_product/category-maps/configure/nav-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
@@ -6,8 +6,10 @@
 
 include::con-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc[leveloffset=+1]
 
-// TODO: include Customize the sidebar menu items
+include::modules/shared/con-sidebar-menu-items.adoc[leveloffset=+1]
 
-// TODO: include Customize entity tab titles
+include::nav-customize-the-sidebar-menu-items.adoc[leveloffset=+1]
 
-// TODO: include Change entity detail tab layouts
+include::modules/shared/proc-configure-entity-tab-titles.adoc[leveloffset=+1,navtitle="Customize entity tab titles"]
+
+include::modules/shared/proc-configure-entity-detail-tab-layout.adoc[leveloffset=+1,navtitle="Change entity detail tab layouts"]

--- a/titles/product_product/category-maps/configure/nav-customize-the-home-page-layout-to-optimize-developer-workflows.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-home-page-layout-to-optimize-developer-workflows.adoc
@@ -4,4 +4,25 @@
 = Customize the Home page layout to optimize developer workflows
 :context: customize-the-home-page-layout-to-optimize-developer-workflows
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="deploy-persona-specific-homepages-to-provide-targeted-content-to-distinct-teams_customizing-rhdh"]
+
 include::con-customize-the-home-page-layout-to-optimize-developer-workflows.adoc[leveloffset=+1]
+
+include::modules/shared/proc-author-default-persona-based-layouts-to-curate-distinct-starting-experiences.adoc[leveloffset=+1,navtitle="Customize Home page dashboard cards"]
+
+include::modules/shared/proc-attach-homepages-to-groups-to-control-access-and-automate-layout-assignment.adoc[leveloffset=+1]
+
+include::modules/shared/ref-homepage-backend-configuration-reference.adoc[leveloffset=+1]
+
+include::modules/shared/ref-homepage-visibility-rule-syntax.adoc[leveloffset=+1]
+
+include::modules/shared/ref-available-homepage-cards.adoc[leveloffset=+1]
+
+include::modules/shared/proc-arrange-homepage-card-layouts-to-optimize-visual-organization.adoc[leveloffset=+1]
+
+include::modules/shared/proc-define-the-layout-of-the-rhdh-home-page.adoc[leveloffset=+1,navtitle="Set up dynamic homepage layouts"]
+
+include::modules/shared/proc-customize-your-dynamic-homepage.adoc[leveloffset=+1,navtitle="Configure interface shortcut links"]
+
+include::modules/shared/proc-customize-quickaccesscard-card-icons-on-the-rhdh-homepage.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-customize-the-quick-start-to-guide-user-onboarding.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-quick-start-to-guide-user-onboarding.adoc
@@ -6,10 +6,17 @@
 
 include::con-customize-the-quick-start-to-guide-user-onboarding.adoc[leveloffset=+1]
 
-// TODO: include Configure role-based access control for quick starts
+include::modules/shared/con-about-quick-starts.adoc[leveloffset=+1]
 
-// TODO: include Customize your quick start
+include::modules/shared/proc-configure-role-based-access-control-for-quick-starts.adoc[leveloffset=+1,navtitle="Configure role-based access control for quick starts"]
 
-// TODO: include Explore quick start onboarding steps
+include::modules/shared/proc-customize-your-rhdh-quick-start.adoc[leveloffset=+1,navtitle="Customize your quick start"]
 
-// TODO: include Localize quick start
+include::modules/shared/proc-disable-the-quick-start-plugin.adoc[leveloffset=+1,navtitle="Disable the quick start"]
+
+include::modules/shared/proc-use-quick-start-onboarding-steps.adoc[leveloffset=+1,navtitle="Explore quick start onboarding steps"]
+
+// Temporarily set old context for backward-compatible module IDs
+:context: customize-the-quick-start-plugin
+include::modules/shared/proc-enable-quick-start-localization-in-rhdh.adoc[leveloffset=+1,navtitle="Localize quick start"]
+:context: customize-the-quick-start-to-guide-user-onboarding

--- a/titles/product_product/category-maps/configure/nav-customize-the-sidebar-menu-items.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-sidebar-menu-items.adoc
@@ -5,3 +5,12 @@
 :context: customize-the-sidebar-menu-items
 
 include::con-customize-the-sidebar-menu-items.adoc[leveloffset=+1]
+
+// Temporarily set old context for backward-compatible module IDs
+:context: customize-rhdh-navigation
+include::modules/shared/proc-enable-sidebar-menu-items-localization-in-rhdh.adoc[leveloffset=+1,navtitle="Localize sidebar menu items"]
+:context: customize-the-sidebar-menu-items
+
+include::modules/shared/proc-configure-a-dynamic-plugin-menu-item-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Configure custom menu items"]
+
+include::modules/shared/proc-modify-or-add-a-custom-menu-items-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Modify or add a custom menu items"]

--- a/titles/product_product/category-maps/configure/nav-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc
@@ -5,3 +5,7 @@
 :context: customize-the-tech-radar-page-to-visualize-technology-adoption
 
 include::con-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc[leveloffset=+1]
+
+include::modules/shared/proc-customize-the-tech-radar-page-by-using-a-json-file.adoc[leveloffset=+1,navtitle="Customize by using a JSON file"]
+
+include::modules/shared/proc-customize-the-tech-radar-page-by-using-a-customization-service.adoc[leveloffset=+1,navtitle="Customize by using a customization service"]

--- a/titles/product_product/category-maps/configure/nav-customize-the-user-interface-to-reflect-organizational-branding.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-user-interface-to-reflect-organizational-branding.adoc
@@ -8,22 +8,22 @@ include::con-customize-the-user-interface-to-reflect-organizational-branding.ado
 
 // TODO: include Customize the display title
 
-// TODO: include Customize Learning Paths to integrate tailored e-learning content
+include::nav-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc[leveloffset=+1]
 
 include::nav-configure-the-global-header-for-consistent-top-level-navigation.adoc[leveloffset=+1]
 
-// TODO: include Configure floating action buttons for quick access to workflows
+include::nav-configure-floating-action-buttons-for-quick-access-to-workflows.adoc[leveloffset=+1]
 
 include::nav-customize-the-quick-start-to-guide-user-onboarding.adoc[leveloffset=+1]
 
-// TODO: include Customize the Tech Radar page to visualize technology adoption
+include::nav-customize-the-tech-radar-page-to-visualize-technology-adoption.adoc[leveloffset=+1]
 
 include::nav-customize-themes-and-branding-to-align-with-corporate-standards.adoc[leveloffset=+1]
 
 include::nav-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc[leveloffset=+1]
 
-// TODO: include Customize the Home page layout to optimize developer workflows
+include::nav-customize-the-home-page-layout-to-optimize-developer-workflows.adoc[leveloffset=+1]
 
-// TODO: include Configure Quick access cards to surface frequently used links
+include::nav-configure-quick-access-cards-to-surface-frequently-used-links.adoc[leveloffset=+1]
 
 // TODO: include Customize the Metadata card to display internal build information

--- a/titles/product_product/category-maps/configure/nav-customize-themes-and-branding-to-align-with-corporate-standards.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-themes-and-branding-to-align-with-corporate-standards.adoc
@@ -6,6 +6,16 @@
 
 include::con-customize-themes-and-branding-to-align-with-corporate-standards.adoc[leveloffset=+1]
 
-// TODO: include Load a custom React theme for advanced UI overrides
+include::modules/shared/proc-switch-the-theme-mode-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Configure the default theme mode"]
 
-// TODO: include Custom component options
+include::modules/shared/proc-customize-the-branding-logo-of-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Configure the branding logo"]
+
+include::modules/shared/proc-customize-the-theme-mode-color-palettes-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Define custom color palettes"]
+
+include::modules/shared/proc-customize-the-page-theme-header-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Configure the page theme header"]
+
+include::modules/shared/proc-customize-the-font-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Customize typography"]
+
+include::modules/shared/proc-load-a-custom-rhdh-theme-by-using-a-dynamic-plugin.adoc[leveloffset=+1,navtitle="Load a custom React theme for advanced UI overrides"]
+
+include::modules/shared/ref-custom-component-options-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Custom component options"]

--- a/titles/product_product/category-maps/configure/nav-customize-your-quick-start.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-your-quick-start.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="customize-your-quick-start_{context}"]
-= Customize your quick start
-:context: customize-your-quick-start
-
-include::con-customize-your-quick-start.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-default-configurations-to-establish-a-deployment-foundation.adoc
+++ b/titles/product_product/category-maps/configure/nav-default-configurations-to-establish-a-deployment-foundation.adoc
@@ -5,3 +5,9 @@
 :context: default-configurations-to-establish-a-deployment-foundation
 
 include::con-default-configurations-to-establish-a-deployment-foundation.adoc[leveloffset=+1]
+
+include::modules/configure_configuring-rhdh/ref-rhdh-default-configuration-guide.adoc[leveloffset=+1,navtitle="Default configurations"]
+
+include::modules/configure_configuring-rhdh/con-automated-operator-features.adoc[leveloffset=+1]
+
+include::modules/configure_configuring-rhdh/ref-time-syntax-in-rhdh.adoc[leveloffset=+1,navtitle="Time syntax"]

--- a/titles/product_product/category-maps/configure/nav-define-quicklinks.adoc
+++ b/titles/product_product/category-maps/configure/nav-define-quicklinks.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="define-quicklinks_{context}"]
-= Define Quicklinks
-:context: define-quicklinks
-
-include::con-define-quicklinks.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-enable-the-localization-framework.adoc
+++ b/titles/product_product/category-maps/configure/nav-enable-the-localization-framework.adoc
@@ -5,3 +5,11 @@
 :context: enable-the-localization-framework
 
 include::con-enable-the-localization-framework.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-the-localization-framework-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-override-translations.adoc[leveloffset=+1,navtitle="Override default translations using JSON maps"]
+
+include::modules/shared/proc-implement-localization-support-for-your-custom-plugins.adoc[leveloffset=+1,navtitle="Implement localization in custom plugins"]
+
+include::modules/shared/proc-select-the-language-for-your-rhdh-instance.adoc[leveloffset=+1,navtitle="Select a language"]

--- a/titles/product_product/category-maps/configure/nav-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc
+++ b/titles/product_product/category-maps/configure/nav-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc
@@ -4,10 +4,13 @@
 = Provision custom config maps and secrets to define platform behavior
 :context: provision-custom-config-maps-and-secrets-to-define-platform-behavior
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="provision-your-custom-rhdh-configuration_provision-and-use-your-custom-rhdh-configuration"]
+
 include::con-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc[leveloffset=+1]
 
-// TODO: include Provision your custom configuration
+include::modules/shared/proc-provision-your-custom-rhdh-configuration.adoc[leveloffset=+1,navtitle="Provision your custom configuration"]
 
-// TODO: include Deploy a custom configuration using an Operator
+include::modules/shared/proc-use-the-rhdh-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1,navtitle="Deploy a custom configuration using an Operator"]
 
-// TODO: include Deploy a custom configuration using Helm Chart
+include::modules/configure_configuring-rhdh/proc-use-the-rhdh-helm-chart-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1,navtitle="Deploy a custom configuration using Helm Chart"]

--- a/titles/product_product/category-maps/develop/con-automate-template-lifecycle-management.adoc
+++ b/titles/product_product/category-maps/develop/con-automate-template-lifecycle-management.adoc
@@ -3,4 +3,8 @@
 = Automate template lifecycle management
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Automate template lifecycle management.
+Automatically apply template updates to all downstream repositories to maintain compliance without manual file comparisons.
+
+When Software Templates receive security updates or configuration changes, you can apply those updates to all downstream repositories automatically so that your applications remain compliant without manual file comparisons.
+
+Automated template lifecycle management maintains consistency by monitoring your source templates. When a template version changes, the `scaffolder-relation-processor` plugin identifies all entities provisioned from that template and creates a pull request (PR) or merge request (MR) containing the necessary file updates, additions, or deletions.

--- a/titles/product_product/category-maps/develop/con-standardized-project-generation-with-software-templates.adoc
+++ b/titles/product_product/category-maps/develop/con-standardized-project-generation-with-software-templates.adoc
@@ -3,4 +3,4 @@
 = Standardized project generation with software templates
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Standardized project generation with software templates.
+Use Software Templates in {product} to provide standardized project starter kits that improve developer productivity and ensure that new projects follow organizational standards.

--- a/titles/product_product/category-maps/develop/con-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
+++ b/titles/product_product/category-maps/develop/con-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
@@ -3,4 +3,8 @@
 = Track component provenance to map dependencies back to source templates
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Track component provenance to map dependencies back to source templates.
+Track the dependency link between a generated entity and its source template to simplify lifecycle management.
+
+Platform engineers use custom actions within the Software Template scaffolding process to establish and track the dependency link between a generated entity (Component or Resource) and its source template. This relationship is called scaffolding provenance.
+
+Platform administrators use custom actions such as `catalog:scaffolded-from` and `catalog:template:version` in the Scaffolder backend module to track the template version and the corresponding entity version, which simplifies lifecycle management.

--- a/titles/product_product/category-maps/develop/con-version-software-templates-to-track-template-updates-and-dependencies.adoc
+++ b/titles/product_product/category-maps/develop/con-version-software-templates-to-track-template-updates-and-dependencies.adoc
@@ -3,4 +3,5 @@
 = Version Software Templates to track template updates and dependencies
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Version Software Templates to track template updates and dependencies.
+Software Templates in {product} provide a streamlined way to create software components and publish them to different version control repositories such as Git.
+Platform engineers create and maintain Software Templates in {product}.

--- a/titles/product_product/category-maps/develop/nav-automate-template-lifecycle-management.adoc
+++ b/titles/product_product/category-maps/develop/nav-automate-template-lifecycle-management.adoc
@@ -6,6 +6,8 @@
 
 include::con-automate-template-lifecycle-management.adoc[leveloffset=+1]
 
-// TODO: include Enable the scaffolder-relation-processor
+include::modules/shared/proc-enable-automated-template-updates.adoc[leveloffset=+1,navtitle="Enable the scaffolder-relation-processor"]
 
-// TODO: include Template sync limitations
+include::modules/shared/ref-template-sync-considerations-and-limitations.adoc[leveloffset=+1,navtitle="Template sync limitations"]
+
+include::modules/shared/ref-template-synchronization-and-notification-outcomes.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-project-standardization-with-software-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-project-standardization-with-software-templates.adoc
@@ -6,15 +6,15 @@
 
 include::con-project-standardization-with-software-templates.adoc[leveloffset=+1]
 
-// TODO: include Create new Software Templates
+include::modules/shared/proc-create-a-basic-software-template.adoc[leveloffset=+1,navtitle="Create new Software Templates"]
 
-// TODO: include Use sample templates
+include::modules/shared/ref-default-environment-parameters-and-secrets.adoc[leveloffset=+1,navtitle="Use sample templates"]
 
-// TODO: include Publish template definitions to the catalog
+include::modules/shared/proc-share-software-templates-with-your-organization.adoc[leveloffset=+1,navtitle="Publish template definitions to the catalog"]
 
-// TODO: include Extend templates using conditional logic and external fetch capabilities
+include::modules/shared/ref-extending-software-templates-for-complex-project-requirements.adoc[leveloffset=+1,navtitle="Extend templates using conditional logic and external fetch capabilities"]
 
-// TODO: include Version Software Templates to track template updates and dependencies
+include::nav-version-software-templates-to-track-template-updates-and-dependencies.adoc[leveloffset=+1]
 
 include::nav-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/develop/nav-standardized-project-generation-with-software-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-standardized-project-generation-with-software-templates.adoc
@@ -6,8 +6,8 @@
 
 include::con-standardized-project-generation-with-software-templates.adoc[leveloffset=+1]
 
-// TODO: include Run Software Templates from the UI
+include::modules/shared/con-software-templates-in-rhdh.adoc[leveloffset=+1,navtitle="Run Software Templates from the UI"]
 
-// TODO: include Browse available templates
+include::modules/shared/ref-sample-software-template.adoc[leveloffset=+1,navtitle="Browse available templates"]
 
-// TODO: include Import an existing template file using the Catalog Processor
+include::modules/shared/proc-share-software-templates-with-your-organization.adoc[leveloffset=+1,navtitle="Import an existing template file using the Catalog Processor"]

--- a/titles/product_product/category-maps/develop/nav-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
@@ -6,6 +6,6 @@
 
 include::con-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc[leveloffset=+1]
 
-// TODO: include Configure provenance annotations
+include::modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc[leveloffset=+1,navtitle="Configure provenance annotations"]
 
-// TODO: include View template dependencies in the catalog
+include::modules/shared/proc-view-software-template-dependencies.adoc[leveloffset=+1,navtitle="View template dependencies in the catalog"]

--- a/titles/product_product/category-maps/develop/nav-version-software-templates-to-track-template-updates-and-dependencies.adoc
+++ b/titles/product_product/category-maps/develop/nav-version-software-templates-to-track-template-updates-and-dependencies.adoc
@@ -5,3 +5,7 @@
 :context: version-software-templates-to-track-template-updates-and-dependencies
 
 include::con-version-software-templates-to-track-template-updates-and-dependencies.adoc[leveloffset=+1]
+
+include::modules/shared/proc-version-a-software-template-in-rhdh.adoc[leveloffset=+1,navtitle="Version Software Templates"]
+
+include::modules/shared/proc-enable-software-template-version-update-notifications-in-rhdh.adoc[leveloffset=+1,navtitle="Enable update notifications"]


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** without reviewer approval.

**Version(s):** 1.5

**Issue:**
- https://issues.redhat.com/browse/RHIDP-14545
- https://issues.redhat.com/browse/RHIDP-14546
- https://issues.redhat.com/browse/RHIDP-14547
- https://issues.redhat.com/browse/RHIDP-14548

**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2387/product_product/

## Summary

Populates nav and concept files for the **Configure** category, wiring actual module includes from existing assemblies into the JTBD MAP structure.

### [RHIDP-14546](https://issues.redhat.com/browse/RHIDP-14546): Configure core parameters

- Default configurations (8 modules from `assembly-rhdh-default-configuration`)
- Provision custom config maps and secrets (3 modules)
- Corporate proxy settings (3 modules)
- 7 leaf modules wired directly: base URL, backend secrets, inject files, mount paths, mount secrets, patch deployment, TLS connections

### [RHIDP-14547](https://issues.redhat.com/browse/RHIDP-14547): Customize the user interface

- Learning Paths (4 modules)
- Global header (7 modules, collapsed Add branding logos + Define Quicklinks sub-navs)
- Floating action buttons (4 modules, deprecated with IMPORTANT admonition)
- Quick Start (6 modules, collapsed Customize your quick start sub-nav)
- Tech Radar (2 modules)
- Themes and branding (9 modules)
- Sidebar navigation (7 modules including sidebar menu items sub-nav)
- Home page layout (9 modules from persona-specific homepages assembly)
- Quick access cards (2 modules)

### [RHIDP-14548](https://issues.redhat.com/browse/RHIDP-14548): Configure language localization

- Localization framework (7 modules from `assembly-localization-in-rhdh`)
- Localization best practices (1 ref module wired directly)

### Develop category (bonus from `configure_customizing-rhdh` assemblies)

- Version Software Templates (2 modules)
- Track component provenance (2 modules)
- Automate template lifecycle (3 modules)
- Standardized project generation (3 modules)

### Structural changes

- **Collapsed 3 single-include nav+con pairs** into parent navs (Add branding logos, Define Quicklinks, Customize your quick start)
- **4 backward-compatible anchors** for old assembly IDs
- **3 temporary context switches** for modules with hardcoded xrefs using old context values

### File changes

- 46 files changed (244 insertions, 100 deletions)
- 6 files deleted (3 collapsed nav+con pairs)
- 94 module includes wired from 17 source assemblies

### Build

36/36 titles passed (requires `--doctype book` change in build-orchestrator.js, submitted in PR 2388).