### PR TITLE
fix(build): Use doctype book for ccutil compilation

### DIFF
--- a/build/scripts/build-orchestrator.js
+++ b/build/scripts/build-orchestrator.js
@@ -188,7 +188,7 @@ async function buildTitle(title, branch, repoRoot, verbose) {
     'ccutil', 'compile',
     '--format', 'html-single',
     '--lang', 'en-US',
-    '--doctype', 'article',
+    '--doctype', 'book',
   ];
 
   const { code, duration, output } = await spawnCapture('podman', podmanArgs, {


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge** without reviewer approval.

**Version(s):** N/A (build tooling only)

**Issue:** N/A

**Preview:** N/A

## Summary

Changes the ccutil `--doctype` flag from `article` to `book` in `build/scripts/build-orchestrator.js`.

### Why

The `article` doctype limits section nesting depth. The JTBD MAP file structure (category > job > sub-job > modules) creates 4+ levels of heading depth. When MAP files include actual module content (not just TODO placeholders), the generated DocBook XML fails RelaxNG validation under the `article` doctype.

The `book` doctype supports unlimited section nesting and eliminates both:
- The `product_product` title build failure (when MAP files are populated)
- Pre-existing RelaxNG validation warnings on all other titles

### Change

```diff
-    '--doctype', 'article',
+    '--doctype', 'book',
```

One line changed in `build/scripts/build-orchestrator.js:191`.

### Build validation

36/36 titles pass with `--doctype book`.