### PR TITLE
CQA: add JTBD-02 orphan modules check (informational)

### DIFF
--- a/build/scripts/cqa/checks/jtbd-02-orphans.js
+++ b/build/scripts/cqa/checks/jtbd-02-orphans.js
@@ -1,0 +1,127 @@
+/**
+ * JTBD-02: Modules not yet wired into product_product
+ *
+ * Lists proc-*, con-*, and ref-* modules under modules/ that are NOT included
+ * in the product_product title (the new JTBD structure). Snippets (snip-*) are
+ * excluded because they are included transitively from within other modules.
+ *
+ * This check is purely informational — it always passes.
+ * Output is a collapsible report grouped by module subdirectory, appended
+ * after the CQA checklist via the getReport() method.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { resolve, basename, join } from 'node:path';
+import { Checker } from '../lib/checker.js';
+import { repoRoot, repoRelative, collectTitle } from '../lib/asciidoc.js';
+
+const PRODUCT_TITLE = 'titles/product_product/master.adoc';
+const MODULE_PREFIXES = ['proc-', 'con-', 'ref-'];
+
+export default class Jtbd02Orphans extends Checker {
+  id = 'jtbd-02';
+  name = 'Modules not yet in product_product (informational)';
+
+  /** Always passes — no issues returned. */
+  check(_masterAdocPath) {
+    return [];
+  }
+
+  /**
+   * Build a markdown report listing modules not included in product_product.
+   * Called by index.js after the checklist is printed.
+   * @returns {string} markdown report (empty string if nothing to report)
+   */
+  getReport() {
+    const root = repoRoot();
+    const masterPath = resolve(root, PRODUCT_TITLE);
+    if (!existsSync(masterPath)) return '';
+
+    const includedFiles = new Set(collectTitle(PRODUCT_TITLE));
+    const { orphansBySubdir, totalOrphans } = collectOrphans(root, includedFiles);
+
+    if (totalOrphans === 0) return '';
+    return formatReport(orphansBySubdir, totalOrphans);
+  }
+}
+
+/**
+ * Collect orphaned modules grouped by subdirectory.
+ * @param {string} root - absolute repo root
+ * @param {Set<string>} includedFiles - repo-relative paths included in product_product
+ * @returns {{ orphansBySubdir: Map<string, string[]>, totalOrphans: number }}
+ */
+function collectOrphans(root, includedFiles) {
+  const modulesDir = resolve(root, 'modules');
+  const orphansBySubdir = new Map();
+  let totalOrphans = 0;
+
+  if (!existsSync(modulesDir)) return { orphansBySubdir, totalOrphans };
+
+  for (const subdir of readdirSync(modulesDir, { withFileTypes: true })) {
+    if (!subdir.isDirectory()) continue;
+    const orphans = findOrphansInSubdir(join(modulesDir, subdir.name), includedFiles);
+
+    if (orphans.length > 0) {
+      orphansBySubdir.set(subdir.name, orphans);
+      totalOrphans += orphans.length;
+    }
+  }
+
+  return { orphansBySubdir, totalOrphans };
+}
+
+/**
+ * Find orphaned proc-/con-/ref- modules in a single subdirectory.
+ * @param {string} subdirPath - absolute path to the subdirectory
+ * @param {Set<string>} includedFiles - repo-relative paths included in product_product
+ * @returns {string[]} sorted repo-relative paths of orphaned modules
+ */
+function findOrphansInSubdir(subdirPath, includedFiles) {
+  const orphans = [];
+  for (const file of walkAdocFiles(subdirPath)) {
+    const bn = basename(file);
+    if (!MODULE_PREFIXES.some(p => bn.startsWith(p))) continue;
+
+    const relPath = repoRelative(file);
+    if (!includedFiles.has(relPath)) {
+      orphans.push(relPath);
+    }
+  }
+  return orphans.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Format the orphan report as a markdown string.
+ * @param {Map<string, string[]>} orphansBySubdir
+ * @param {number} totalOrphans
+ * @returns {string}
+ */
+function formatReport(orphansBySubdir, totalOrphans) {
+  const lines = [
+    `\n## Modules not yet in product_product\n`,
+    `${totalOrphans} modules (proc, con, ref) are not yet included in the \`product_product\` title.\n`,
+  ];
+
+  const sortedSubdirs = [...orphansBySubdir.keys()].sort((a, b) => a.localeCompare(b));
+  for (const subdir of sortedSubdirs) {
+    const orphans = orphansBySubdir.get(subdir);
+    lines.push(
+      `<details>`,
+      `<summary><code>modules/${subdir}/</code> (${orphans.length})</summary>\n`,
+      ...orphans.map(file => `- ${file}`),
+      `\n</details>\n`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+/** Recursively yield all .adoc files under a directory. */
+function* walkAdocFiles(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkAdocFiles(full);
+    else if (entry.isFile() && entry.name.endsWith('.adoc')) yield full;
+  }
+}

--- a/build/scripts/cqa/index.js
+++ b/build/scripts/cqa/index.js
@@ -42,6 +42,7 @@ const CHECKS_IN_ORDER = [
   'cqa-14b-inbound-link-stability.js',
   'cqa-15-redirects.js',
   'jtbd-01-navigation.js',
+  'jtbd-02-orphans.js',
 ];
 
 const VALE_CHECK_IDS = new Set(['01', '12', '16']);
@@ -238,6 +239,15 @@ function printAllChecksReport(sortedChecks, results, fixMode) {
   }
 
   printFinalSummary({ checksPass, checksFail, totalAutofixable, totalManual, totalDelegated, totalFixed, fixMode });
+
+  // Append informational reports from checks that define getReport()
+  for (const checker of sortedChecks) {
+    if (typeof checker.getReport === 'function') {
+      const report = checker.getReport();
+      if (report) console.log(report);
+    }
+  }
+
   return { checksPass, checksFail };
 }
 
@@ -278,7 +288,7 @@ function printHelp() {
   console.log(`Usage: node build/scripts/cqa/index.js [OPTIONS] [titles/<title>/master.adoc ...]
 
 Content Quality Assessment for Red Hat Developer Hub documentation.
-Runs 21 automated checks for modular docs compliance.
+Runs 22 automated checks for modular docs compliance.
 
 Options:
   --all          Run all checks against all titles in the repository
@@ -303,8 +313,9 @@ Checks (in workflow order):
   07   TOC depth (max 3 levels)      16  Official product names
   01   Vale AsciiDoc DITA            12  Grammar and style (Vale)
   17   Legal disclaimers             14  No broken links
-  14b  Inbound link stability        15  Redirects
+   14b  Inbound link stability        15  Redirects
   JTBD-01  Navigation MAP structure
+  JTBD-02  Modules not in product_product (informational)
 
 Output markers:
   [AUTOFIX]       Auto-fixable with --fix


### PR DESCRIPTION
## Summary

Add a new CQA check (**JTBD-02**) that lists `proc-`, `con-`, and `ref-` modules under `modules/` not yet included in the `product_product` title (the new JTBD structure).

## Behavior

- **Purely informational** — the check always passes and never fails the build
- Snippets (`snip-*`) are excluded (they are included transitively within other modules)
- The report is **grouped by module subdirectory** in collapsible `<details>` sections
- Appears after the CQA checklist in both local output and the PR Build Results comment
- No changes needed to `pr.yml` or `build-orchestrator.js` — the report flows through the existing CQA output pipeline

## Changes

| File | Change |
|------|--------|
| `build/scripts/cqa/checks/jtbd-02-orphans.js` | **New** — the check implementation (~100 lines) |
| `build/scripts/cqa/index.js` | Add to `CHECKS_IN_ORDER`, add `getReport()` hook in `printAllChecksReport()`, update help text |

## How it works

1. `check()` returns `[]` — always passes
2. `getReport()` collects the full `product_product` file tree via `collectTitle()`
3. Enumerates all `proc-`/`con-`/`ref-` modules under `modules/`
4. Lists those not found in the `product_product` include tree
5. Groups by subdirectory with counts

## Local testing

```bash
# Run just this check
node build/scripts/cqa/index.js --check jtbd-02 --all

# Run all checks (jtbd-02 report appended after checklist)
node build/scripts/cqa/index.js --all
```

Currently reports **484 modules** not yet wired into `product_product`, across 16 subdirectories.