### PR TITLE
[RHIDP-14638]: JTBD Extend category MAP structure

### DIFF
--- a/titles/product_product/category-maps/extend/con-browse-and-manage-available-plugins-using-the-extensions-ui.adoc
+++ b/titles/product_product/category-maps/extend/con-browse-and-manage-available-plugins-using-the-extensions-ui.adoc
@@ -3,4 +3,4 @@
 = Browse and manage available plugins using the Extensions UI
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Browse and manage available plugins using the Extensions UI.
+Browse, install, and manage available plugins through the Extensions interface in {product}. The Extensions feature provides a centralized UI to discover plugins that extend platform functionality and streamline development workflows.

--- a/titles/product_product/category-maps/extend/con-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
+++ b/titles/product_product/category-maps/extend/con-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
@@ -3,4 +3,4 @@
 = Configure core front-end wiring for navigation and UI components
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure core front-end wiring for navigation and UI components.
+Configure front-end plugins to customize icons, create navigation entries, and define dynamic routes for new plugin pages. Front-end wiring connects dynamic plugin components to the {product} user interface without modifying core application code.

--- a/titles/product_product/category-maps/extend/con-configure-mount-points-to-attach-custom-ui-components.adoc
+++ b/titles/product_product/category-maps/extend/con-configure-mount-points-to-attach-custom-ui-components.adoc
@@ -3,4 +3,4 @@
 = Configure mount points to attach custom UI components
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure mount points to attach custom UI components.
+Attach UI components to predefined locations in the {product} interface by using mount points. Mount points let plugins inject content into entity pages, application headers, listeners, and providers without modifying the core application code.

--- a/titles/product_product/category-maps/extend/con-configure-route-bindings-and-mount-points-for-component-integration.adoc
+++ b/titles/product_product/category-maps/extend/con-configure-route-bindings-and-mount-points-for-component-integration.adoc
@@ -3,4 +3,4 @@
 = Configure route bindings and mount points for component integration
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure route bindings and mount points for component integration.
+Bind dynamic plugins to existing routes and attach custom UI components to predefined mount points. Route bindings and mount points enable plugins to extend entity pages, application headers, and providers without modifying the core platform layout.

--- a/titles/product_product/category-maps/extend/con-configure-specialized-front-end-extensions-for-apis-and-features.adoc
+++ b/titles/product_product/category-maps/extend/con-configure-specialized-front-end-extensions-for-apis-and-features.adoc
@@ -3,4 +3,4 @@
 = Configure specialized front-end extensions for APIs and features
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure specialized front-end extensions for APIs and features.
+Configure specialized front-end extensions including custom sign-in pages, Scaffolder field extensions, utility APIs, authentication provider settings, and TechDocs add-ons. These extensions enable advanced UI customization beyond standard route and mount point configuration.

--- a/titles/product_product/category-maps/extend/con-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
+++ b/titles/product_product/category-maps/extend/con-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
@@ -3,4 +3,4 @@
 = Convert standard plugins into dynamic plugins using the Plugin Factory
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Convert standard plugins into dynamic plugins using the Plugin Factory.
+Convert standard {backstage} plugins into dynamic plugins by using the Dynamic Plugin Factory. The factory model automates the export and packaging process to produce runtime-loadable plugin packages compatible with {product}.

--- a/titles/product_product/category-maps/extend/con-develop-and-test-new-plugin-components-locally.adoc
+++ b/titles/product_product/category-maps/extend/con-develop-and-test-new-plugin-components-locally.adoc
@@ -3,4 +3,4 @@
 = Develop and test new plugin components locally
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Develop and test new plugin components locally.
+Create, implement, and test new plugin components in a local development environment before deploying to a cluster. Local development with a {backstage} application enables rapid iteration and debugging of plugin functionality.

--- a/titles/product_product/category-maps/extend/con-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
+++ b/titles/product_product/category-maps/extend/con-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
@@ -3,4 +3,4 @@
 = Develop custom dynamic plugins to support custom workflows
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Develop custom dynamic plugins to support custom workflows.
+Develop, package, and deploy custom dynamic plugins when standard plugins do not meet organizational requirements. Custom plugin development enables teams to extend {product} with bespoke functionality and business logic.

--- a/titles/product_product/category-maps/extend/con-extend.adoc
+++ b/titles/product_product/category-maps/extend/con-extend.adoc
@@ -3,4 +3,4 @@
 = Extend
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Extend.
+Add new capabilities to {product} by installing, configuring, and developing dynamic plugins without rebuilding or restarting the core platform. Dynamic plugins enable teams to tailor the developer portal to specific organizational workflows while maintaining upgrade compatibility.

--- a/titles/product_product/category-maps/extend/con-filter-plugins-by-support-badges.adoc
+++ b/titles/product_product/category-maps/extend/con-filter-plugins-by-support-badges.adoc
@@ -3,4 +3,4 @@
 = Filter plugins by support badges
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Filter plugins by support badges.
+Filter available plugins by support level and maturity badges to identify production-ready components. Support badges classify plugins by support tier and development maturity to help you assess production readiness.

--- a/titles/product_product/category-maps/extend/con-install-dynamic-plugins.adoc
+++ b/titles/product_product/category-maps/extend/con-install-dynamic-plugins.adoc
@@ -3,4 +3,4 @@
 = Install dynamic plugins
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Install dynamic plugins.
+Install dynamic plugins by using the Operator or Helm chart to add preinstalled or external capabilities to {product}. The backend plugin manager scans a configured root directory for dynamic plugin packages and loads them at startup.

--- a/titles/product_product/category-maps/extend/con-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc
+++ b/titles/product_product/category-maps/extend/con-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc
@@ -3,4 +3,4 @@
 = Install plugins using custom certificates to secure private registry connections
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Install plugins using custom certificates to secure private registry connections.
+Install OCI plugins from internal registries served over HTTPS with corporate CA certificates. Custom certificate configuration ensures {product} trusts your private registry connections during plugin installation.

--- a/titles/product_product/category-maps/extend/con-install-with-helm-chart.adoc
+++ b/titles/product_product/category-maps/extend/con-install-with-helm-chart.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Install with Helm Chart
+= Install with Helm chart
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Install with Helm Chart.
+Configure the Helm chart values file to install dynamic plugins during {product} deployment. The Helm chart approach provides fine-grained control over plugin packages and their initialization parameters.

--- a/titles/product_product/category-maps/extend/con-install-with-operator.adoc
+++ b/titles/product_product/category-maps/extend/con-install-with-operator.adoc
@@ -3,4 +3,4 @@
 = Install with Operator
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Install with Operator.
+Configure the {product} Operator custom resource to install dynamic plugins with dependency management and resource specifications. The Operator automates plugin lifecycle operations during deployments.

--- a/titles/product_product/category-maps/extend/con-manage-containerized-plugins-securely-by-migrating-to-oci-artifacts.adoc
+++ b/titles/product_product/category-maps/extend/con-manage-containerized-plugins-securely-by-migrating-to-oci-artifacts.adoc
@@ -3,4 +3,4 @@
 = Manage containerized plugins securely by migrating to OCI artifacts
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Manage containerized plugins securely by migrating to OCI artifacts.
+Migrate community and custom plugins to OCI artifact registries for improved security, versioning, and distribution. OCI-based plugin management replaces direct NPM registry access with container-native workflows that align with enterprise supply chain requirements.

--- a/titles/product_product/category-maps/extend/con-manage-plugins.adoc
+++ b/titles/product_product/category-maps/extend/con-manage-plugins.adoc
@@ -3,4 +3,4 @@
 = Manage plugins
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Manage plugins.
+Control access to plugin administration, configure persistent storage, and manage the plugin lifecycle through the Extensions UI. Role-based access control restricts who can install, enable, or disable plugins on the platform.

--- a/titles/product_product/category-maps/extend/con-manage-the-plugin-ecosystem-to-add-functionality-without-downtime.adoc
+++ b/titles/product_product/category-maps/extend/con-manage-the-plugin-ecosystem-to-add-functionality-without-downtime.adoc
@@ -3,4 +3,4 @@
 = Manage the plugin ecosystem to add functionality without downtime
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Manage the plugin ecosystem to add functionality without downtime.
+Discover, install, and manage dynamic plugins to extend {product} with new capabilities. Dynamic plugins load at runtime from a configured root directory, enabling platform teams to add functionality without rebuilding the application or scheduling downtime.

--- a/titles/product_product/category-maps/extend/con-migrate-community-plugins-to-the-github-container-registry.adoc
+++ b/titles/product_product/category-maps/extend/con-migrate-community-plugins-to-the-github-container-registry.adoc
@@ -3,4 +3,4 @@
 = Migrate community plugins to the GitHub Container Registry
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Migrate community plugins to the GitHub Container Registry.
+Migrate community plugins from NPM registries to the GitHub Container Registry (GHCR) for OCI-based distribution. Container registry hosting enables consistent versioning and access control aligned with your existing container image workflows.

--- a/titles/product_product/category-maps/extend/con-mirror-dynamic-plugins-in-disconnected-environments.adoc
+++ b/titles/product_product/category-maps/extend/con-mirror-dynamic-plugins-in-disconnected-environments.adoc
@@ -3,4 +3,4 @@
 = Mirror dynamic plugins in disconnected environments
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Mirror dynamic plugins in disconnected environments.
+Mirror dynamic plugin OCI artifacts to a local registry for deployments in restricted or air-gapped environments. {product} distributes plugins as Open Container Initiative (OCI) artifacts that must be accessible from within the cluster network.

--- a/titles/product_product/category-maps/extend/con-package-and-deploy-dynamic-plugins-as-oci-images.adoc
+++ b/titles/product_product/category-maps/extend/con-package-and-deploy-dynamic-plugins-as-oci-images.adoc
@@ -3,4 +3,4 @@
 = Package and deploy dynamic plugins as OCI images
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Package and deploy dynamic plugins as OCI images.
+Package dynamic plugins as OCI images and deploy them to container registries for distribution. OCI packaging enables versioned, portable plugin artifacts that integrate with standard container workflows and air-gapped deployment strategies.

--- a/titles/product_product/category-maps/extend/con-prepare-your-development-environment-to-write-custom-plugins.adoc
+++ b/titles/product_product/category-maps/extend/con-prepare-your-development-environment-to-write-custom-plugins.adoc
@@ -3,4 +3,4 @@
 = Prepare your development environment to write custom plugins
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Prepare your development environment to write custom plugins.
+Set up the required development toolchain including Node.js, NPM, Yarn, and the {product} Plugin Factory to begin developing custom dynamic plugins.

--- a/titles/product_product/category-maps/extend/con-requirements-and-workflows-for-front-end-plugin-wiring.adoc
+++ b/titles/product_product/category-maps/extend/con-requirements-and-workflows-for-front-end-plugin-wiring.adoc
@@ -3,4 +3,4 @@
 = Requirements and workflows for front-end plugin wiring
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Requirements and workflows for front-end plugin wiring.
+Understand why front-end plugin wiring is required and the consequences of skipping it. Front-end wiring ensures dynamic plugins integrate correctly with the {product} navigation, entity pages, and component framework.

--- a/titles/product_product/category-maps/extend/nav-browse-and-manage-available-plugins-using-the-extensions-ui.adoc
+++ b/titles/product_product/category-maps/extend/nav-browse-and-manage-available-plugins-using-the-extensions-ui.adoc
@@ -6,4 +6,4 @@
 
 include::con-browse-and-manage-available-plugins-using-the-extensions-ui.adoc[leveloffset=+1]
 
-// TODO: include Manage plugins
+include::nav-manage-plugins.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
+++ b/titles/product_product/category-maps/extend/nav-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
@@ -6,10 +6,12 @@
 
 include::con-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc[leveloffset=+1]
 
-// TODO: include Requirements and workflows for front-end plugin wiring
+include::nav-requirements-and-workflows-for-front-end-plugin-wiring.adoc[leveloffset=+1]
 
-// TODO: include Add custom icons to the internal icon catalog
+include::modules/shared/con-dynamic-front-end-plugins-for-application-use.adoc[leveloffset=+1,navtitle="Dynamic front-end plugins for application integration"]
 
-// TODO: include Define dynamic routes to create plugin pages
+include::modules/shared/proc-extend-internal-icon-catalog.adoc[leveloffset=+1,navtitle="Add custom icons to the internal icon catalog"]
 
-// TODO: include Customize sidebar navigation menus
+include::modules/shared/proc-define-dynamic-routes-for-new-plugin-pages.adoc[leveloffset=+1,navtitle="Define dynamic routes to create plugin pages"]
+
+include::modules/shared/ref-customizing-menu-items-in-the-sidebar-navigation.adoc[leveloffset=+1,navtitle="Customize sidebar navigation menus"]

--- a/titles/product_product/category-maps/extend/nav-configure-mount-points-to-attach-custom-ui-components.adoc
+++ b/titles/product_product/category-maps/extend/nav-configure-mount-points-to-attach-custom-ui-components.adoc
@@ -5,3 +5,11 @@
 :context: configure-mount-points-to-attach-custom-ui-components
 
 include::con-configure-mount-points-to-attach-custom-ui-components.adoc[leveloffset=+1]
+
+include::modules/shared/ref-customizing-entity-page.adoc[leveloffset=+1,navtitle="Customize the entity page"]
+
+include::modules/shared/ref-adding-application-header.adoc[leveloffset=+1,navtitle="Add application headers"]
+
+include::modules/shared/ref-adding-application-listeners.adoc[leveloffset=+1,navtitle="Add application listeners"]
+
+include::modules/shared/ref-adding-application-providers.adoc[leveloffset=+1,navtitle="Add application providers"]

--- a/titles/product_product/category-maps/extend/nav-configure-route-bindings-and-mount-points-for-component-integration.adoc
+++ b/titles/product_product/category-maps/extend/nav-configure-route-bindings-and-mount-points-for-component-integration.adoc
@@ -6,10 +6,10 @@
 
 include::con-configure-route-bindings-and-mount-points-for-component-integration.adoc[leveloffset=+1]
 
-// TODO: include Bind dynamic plugins to existing routes
+include::modules/shared/ref-binding-to-existing-plugins.adoc[leveloffset=+1,navtitle="Bind dynamic plugins to existing routes"]
 
-// TODO: include Configure mount points to attach custom UI components
+include::nav-configure-mount-points-to-attach-custom-ui-components.adoc[leveloffset=+1]
 
-// TODO: include Customize and extend catalog entity tabs
+include::modules/shared/ref-customizing-and-extending-entity-tabs.adoc[leveloffset=+1,navtitle="Customize and extend catalog entity tabs"]
 
-// TODO: include Customize the platform theme using front-end plugins
+include::modules/shared/ref-customizing-rhdh-theme.adoc[leveloffset=+1,navtitle="Customize the platform theme using front-end plugins"]

--- a/titles/product_product/category-maps/extend/nav-configure-specialized-front-end-extensions-for-apis-and-features.adoc
+++ b/titles/product_product/category-maps/extend/nav-configure-specialized-front-end-extensions-for-apis-and-features.adoc
@@ -6,12 +6,12 @@
 
 include::con-configure-specialized-front-end-extensions-for-apis-and-features.adoc[leveloffset=+1]
 
-// TODO: include Configure custom sign-in pages for authentication
+include::modules/shared/con-using-a-custom-signinpage-component.adoc[leveloffset=+1,navtitle="Configure custom sign-in pages for authentication"]
 
-// TODO: include Add custom Scaffolder field extensions
+include::modules/shared/con-providing-custom-scaffolder-field-extensions.adoc[leveloffset=+1,navtitle="Add custom Scaffolder field extensions"]
 
-// TODO: include Configure additional utility APIs
+include::modules/shared/ref-providing-additional-utility-apis.adoc[leveloffset=+1,navtitle="Configure additional utility APIs"]
 
-// TODO: include Add custom authentication provider settings to verify identities
+include::modules/shared/ref-adding-custom-authentication-provider-settings.adoc[leveloffset=+1,navtitle="Add custom authentication provider settings to verify identities"]
 
-// TODO: include Configure custom TechDocs add-ons
+include::modules/shared/ref-providing-custom-techdocs-add-ons.adoc[leveloffset=+1,navtitle="Configure custom TechDocs add-ons"]

--- a/titles/product_product/category-maps/extend/nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
+++ b/titles/product_product/category-maps/extend/nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
@@ -5,3 +5,5 @@
 :context: convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory
 
 include::con-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc[leveloffset=+1]
+
+include::modules/shared/con-use-the-dynamic-plugin-factory-to-convert-plugins-into-dynamic-plugins.adoc[leveloffset=+1,navtitle="The dynamic plugin factory model"]

--- a/titles/product_product/category-maps/extend/nav-develop-and-test-new-plugin-components-locally.adoc
+++ b/titles/product_product/category-maps/extend/nav-develop-and-test-new-plugin-components-locally.adoc
@@ -5,3 +5,15 @@
 :context: develop-and-test-new-plugin-components-locally
 
 include::con-develop-and-test-new-plugin-components-locally.adoc[leveloffset=+1]
+
+include::modules/shared/con-determine-rhdh-version.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-new-application.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-new-plugin.adoc[leveloffset=+1,navtitle="Create a new plugin"]
+
+include::modules/shared/proc-implement-a-plugin-component.adoc[leveloffset=+1,navtitle="Implement a plugin component"]
+
+include::modules/shared/proc-test-a-plugin-locally.adoc[leveloffset=+1,navtitle="Test a plugin locally"]
+
+include::modules/shared/proc-configure-front-end-plugin-wiring.adoc[leveloffset=+1,navtitle="Integrate custom user interface components"]

--- a/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
+++ b/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
@@ -6,12 +6,12 @@
 
 include::con-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc[leveloffset=+1]
 
-// TODO: include Prepare your development environment to write custom plugins
+include::nav-prepare-your-development-environment-to-write-custom-plugins.adoc[leveloffset=+1]
 
-// TODO: include Develop and test new plugin components locally
+include::nav-develop-and-test-new-plugin-components-locally.adoc[leveloffset=+1]
 
-// TODO: include Convert standard plugins into dynamic plugins using the Plugin Factory
+include::nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc[leveloffset=+1]
 
 include::nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+1]
 
-// TODO: include Verify plugins locally
+include::modules/shared/proc-verify-plugins-locally.adoc[leveloffset=+1,navtitle="Verify plugins locally"]

--- a/titles/product_product/category-maps/extend/nav-filter-plugins-by-support-badges.adoc
+++ b/titles/product_product/category-maps/extend/nav-filter-plugins-by-support-badges.adoc
@@ -6,4 +6,4 @@
 
 include::con-filter-plugins-by-support-badges.adoc[leveloffset=+1]
 
-// TODO: include Filter plugins by support and maturity
+include::modules/shared/proc-navigate-the-plugin-marketplace-and-filter-plugins-using-badges.adoc[leveloffset=+1,navtitle="Filter plugins by support and maturity"]

--- a/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
@@ -6,10 +6,14 @@
 
 include::con-install-dynamic-plugins.adoc[leveloffset=+1]
 
-// TODO: include Install with Operator
+include::nav-install-with-operator.adoc[leveloffset=+1]
 
-// TODO: include Install with Helm Chart
+include::modules/shared/con-dynamic-plugins-dependency-management.adoc[leveloffset=+1,navtitle="Dynamic plugin dependency requirements and resource specifications"]
 
-// TODO: include Install in an air-gapped environment
+include::nav-install-with-helm-chart.adoc[leveloffset=+1]
 
-// TODO: include Mirror dynamic plugins in disconnected environments
+include::modules/shared/ref-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-helm-chart.adoc[leveloffset=+1,navtitle="Install in an air-gapped environment using the Helm chart"]
+
+include::modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc[leveloffset=+1,navtitle="Install in an air-gapped environment using the Operator"]
+
+include::nav-mirror-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc
@@ -5,3 +5,9 @@
 :context: install-plugins-using-custom-certificates-to-secure-private-registry-connections
 
 include::con-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc[leveloffset=+1]
+
+include::modules/shared/proc-install-plugins-from-oci-plugins-by-using-per-registry-tls-configuration.adoc[leveloffset=+1,navtitle="Install from secure container registries"]
+
+include::modules/shared/proc-install-plugins-from-oci-plugins-by-mounting-the-ca-bundle.adoc[leveloffset=+1,navtitle="Install using trusted certificate authorities"]
+
+include::modules/shared/proc-install-plugins-from-oci-plugins-in-openshift.adoc[leveloffset=+1,navtitle="Install with cluster-wide trust bundles"]

--- a/titles/product_product/category-maps/extend/nav-install-with-helm-chart.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-with-helm-chart.adoc
@@ -1,7 +1,11 @@
 :_mod-docs-content-type: MAP
 
 [id="install-with-helm-chart_{context}"]
-= Install with Helm Chart
+= Install with Helm chart
 :context: install-with-helm-chart
 
 include::con-install-with-helm-chart.adoc[leveloffset=+1]
+
+include::modules/shared/con-installing-dynamic-plugins-using-the-helm-chart.adoc[leveloffset=+1]
+
+include::modules/shared/ref-example-helm-chart-configurations-for-dynamic-plugin-installations.adoc[leveloffset=+1,navtitle="Example configurations"]

--- a/titles/product_product/category-maps/extend/nav-install-with-operator.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-with-operator.adoc
@@ -5,3 +5,5 @@
 :context: install-with-operator
 
 include::con-install-with-operator.adoc[leveloffset=+1]
+
+include::modules/shared/proc-install-dynamic-plugins-with-the-rhdh-operator.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-manage-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-manage-plugins.adoc
@@ -5,3 +5,17 @@
 :context: manage-plugins
 
 include::con-manage-plugins.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-rbac-to-manage-extensions.adoc[leveloffset=+1,navtitle="Control plugin administration access"]
+
+include::modules/shared/proc-configure-an-rhdh-development-environment-to-install-plugins-by-using-extensions.adoc[leveloffset=+1,navtitle="Configure persistent storage for plugin installations"]
+
+include::modules/shared/proc-view-available-plugins.adoc[leveloffset=+1,navtitle="View plugins"]
+
+include::modules/shared/proc-install-plugins-by-using-extensions.adoc[leveloffset=+1,navtitle="Install and configure portal plugins"]
+
+include::modules/shared/proc-configure-rhdh-local-to-install-plugins-by-using-extensions.adoc[leveloffset=+1,navtitle="Validate plugin configurations locally"]
+
+include::modules/shared/proc-enable-and-disable-plugins-by-using-extensions.adoc[leveloffset=+1,navtitle="Enable and disable portal plugins"]
+
+include::modules/shared/proc-disable-the-extensions-interface.adoc[leveloffset=+1,navtitle="Disable the Extensions UI"]

--- a/titles/product_product/category-maps/extend/nav-manage-the-plugin-ecosystem-to-add-functionality-without-downtime.adoc
+++ b/titles/product_product/category-maps/extend/nav-manage-the-plugin-ecosystem-to-add-functionality-without-downtime.adoc
@@ -8,9 +8,9 @@ include::con-manage-the-plugin-ecosystem-to-add-functionality-without-downtime.a
 
 include::nav-install-dynamic-plugins.adoc[leveloffset=+1]
 
-// TODO: include Install plugins using custom certificates to secure private registry connections
+include::nav-install-plugins-using-custom-certificates-to-secure-private-registry-connections.adoc[leveloffset=+1]
 
-// TODO: include Enable pre-loaded container plugins
+include::modules/shared/proc-enable-plugins-added-in-the-rhdh-container-image.adoc[leveloffset=+1,navtitle="Enable pre-loaded container plugins"]
 
 include::nav-browse-and-manage-available-plugins-using-the-extensions-ui.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/extend/nav-migrate-community-plugins-to-the-github-container-registry.adoc
+++ b/titles/product_product/category-maps/extend/nav-migrate-community-plugins-to-the-github-container-registry.adoc
@@ -6,4 +6,4 @@
 
 include::con-migrate-community-plugins-to-the-github-container-registry.adoc[leveloffset=+1]
 
-// TODO: include Update deployment configurations for OCI registry container images
+include::modules/shared/proc-load-a-plugin-packaged-as-an-oci-image.adoc[leveloffset=+1,navtitle="Update deployment configurations for OCI registry container images"]

--- a/titles/product_product/category-maps/extend/nav-mirror-dynamic-plugins-in-disconnected-environments.adoc
+++ b/titles/product_product/category-maps/extend/nav-mirror-dynamic-plugins-in-disconnected-environments.adoc
@@ -5,3 +5,13 @@
 :context: mirror-dynamic-plugins-in-disconnected-environments
 
 include::con-mirror-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]
+
+include::modules/shared/proc-mirror-plugins-from-a-catalog-index-to-a-partially-disconnected-environment.adoc[leveloffset=+1,navtitle="Mirror to a partially disconnected environment"]
+
+include::modules/shared/proc-mirror-plugins-from-a-catalog-index-to-a-fully-disconnected-environment.adoc[leveloffset=+1,navtitle="Mirror to a fully disconnected environment"]
+
+include::modules/shared/proc-mirror-specific-plugins-by-direct-reference.adoc[leveloffset=+1,navtitle="Mirror specific plugins"]
+
+include::modules/shared/proc-mirror-plugins-from-a-file.adoc[leveloffset=+1,navtitle="Mirror plugins from a file"]
+
+include::modules/shared/proc-combine-many-plugin-sources.adoc[leveloffset=+1,navtitle="Combine plugin sources"]

--- a/titles/product_product/category-maps/extend/nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc
+++ b/titles/product_product/category-maps/extend/nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc
@@ -1,9 +1,10 @@
 :_mod-docs-content-type: MAP
 
 [id="package-and-deploy-dynamic-plugins-as-oci-images_{context}"]
+[id="package-and-publish-plugins-as-dynamic-plugins_plugins-in-rhdh"]
 = Package and deploy dynamic plugins as OCI images
 :context: package-and-deploy-dynamic-plugins-as-oci-images
 
 include::con-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+1]
 
-// TODO: include Deploy custom dynamic plugins
+include::modules/shared/proc-add-a-dynamic-plugin-to-rhdh.adoc[leveloffset=+1,navtitle="Deploy custom dynamic plugins"]

--- a/titles/product_product/category-maps/extend/nav-prepare-your-development-environment-to-write-custom-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-prepare-your-development-environment-to-write-custom-plugins.adoc
@@ -5,3 +5,5 @@
 :context: prepare-your-development-environment-to-write-custom-plugins
 
 include::con-prepare-your-development-environment-to-write-custom-plugins.adoc[leveloffset=+1]
+
+include::modules/shared/con-prepare-your-development-environment.adoc[leveloffset=+1,navtitle="The development toolchain"]

--- a/titles/product_product/category-maps/extend/nav-requirements-and-workflows-for-front-end-plugin-wiring.adoc
+++ b/titles/product_product/category-maps/extend/nav-requirements-and-workflows-for-front-end-plugin-wiring.adoc
@@ -5,3 +5,7 @@
 :context: requirements-and-workflows-for-front-end-plugin-wiring
 
 include::con-requirements-and-workflows-for-front-end-plugin-wiring.adoc[leveloffset=+1]
+
+include::modules/shared/con-understand-why-front-end-wiring-is-required.adoc[leveloffset=+1,navtitle="Reasons for requiring front-end plugin wiring"]
+
+include::modules/shared/con-consequences-of-skipping-front-end-wiring.adoc[leveloffset=+1,navtitle="Consequences of skipping front-end plugin wiring"]


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge**

## Version(s)

RHDH 1.10 / 2.1

## Issue

https://redhat.atlassian.net/browse/RHIDP-14638

## Preview

N/A (MAP structure files only — no new rendered content)

## Summary

Creates the JTBD MAP file hierarchy for the **Extend** category:

- 3 Level-2 jobs: Manage plugin ecosystem, Develop custom plugins, Manage containerized plugins (OCI)
- 22 concept files with WHAT+WHY abstracts
- 21 navigation MAP files connecting existing modules to the JTBD structure
- All module references validated (zero missing includes)
- Vale DITA compliant (0 actionable errors, 0 warnings — only known `DocumentId` false positives for MAP concept files)
- CQA 2.1 compliant

### Fixes applied

- Replaced hardcoded `Backstage` with `{backstage}` attribute
- Replaced hardcoded `Technology Preview` with `{technology-preview}` attribute
- Fixed `using` → `by using` per RedHat.Using rule
- Fixed sentence-case title inconsistency (`Helm Chart` → `Helm chart`)
- Removed redundant navtitles where module titles already match


Made with [Cursor](https://cursor.com)