### PR TITLE
JTBD: Replace TODO concept placeholders in Configure and Observe categories

### DIFF
--- a/titles/product_product/category-maps/configure/con-configure-core-parameters-to-meet-infrastructure-requirements.adoc
+++ b/titles/product_product/category-maps/configure/con-configure-core-parameters-to-meet-infrastructure-requirements.adoc
@@ -3,4 +3,4 @@
 = Configure core parameters to meet infrastructure requirements
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure core parameters to meet infrastructure requirements.
+Configure the core parameters of your {product-short} deployment, including default configurations, custom config maps and secrets, routes, TLS connections, and corporate proxy settings.

--- a/titles/product_product/category-maps/configure/con-configure.adoc
+++ b/titles/product_product/category-maps/configure/con-configure.adoc
@@ -3,4 +3,4 @@
 = Configure
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure.
+Configure {product} to meet your infrastructure requirements, customize the user interface to reflect your organizational branding, and set up language localization for global accessibility.

--- a/titles/product_product/category-maps/configure/con-customize-the-sidebar-menu-items.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-the-sidebar-menu-items.adoc
@@ -3,4 +3,4 @@
 = Customize the sidebar menu items
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the sidebar menu items.
+Customize the sidebar menu items in {product-short} by localizing menu labels, configuring dynamic plugin menu items, and adding or modifying custom menu items.

--- a/titles/product_product/category-maps/configure/con-customize-the-user-interface-to-reflect-organizational-branding.adoc
+++ b/titles/product_product/category-maps/configure/con-customize-the-user-interface-to-reflect-organizational-branding.adoc
@@ -3,4 +3,4 @@
 = Customize the user interface to reflect organizational branding
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the user interface to reflect organizational branding.
+Customize the {product-short} user interface by configuring themes and branding, the global header, floating action buttons, quick starts, tech radar, learning paths, sidebar navigation, home page layout, and quick access cards.

--- a/titles/product_product/category-maps/observe/con-apply-deployment-manifests.adoc
+++ b/titles/product_product/category-maps/observe/con-apply-deployment-manifests.adoc
@@ -3,4 +3,4 @@
 = Apply deployment manifests
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Apply deployment manifests.
+Deploy a complete observability stack for SonataFlow workflows with ready-to-use Jaeger and Loki manifests. These pre-configured examples help you monitor workflow performance and logs immediately without manual setup.

--- a/titles/product_product/category-maps/observe/con-capture-and-review-audit-logs-to-trace-user-activities-and-maintain-accountability.adoc
+++ b/titles/product_product/category-maps/observe/con-capture-and-review-audit-logs-to-trace-user-activities-and-maintain-accountability.adoc
@@ -3,4 +3,31 @@
 = Capture and review audit logs to trace user activities and maintain accountability
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Capture and review audit logs to trace user activities and maintain accountability.
+Audit logs are a chronological set of records documenting the user activities, system events, and data changes that affect your {product} users, administrators, or components.
+
+Administrators can view {product-short} audit logs in the {ocp-short} web console to monitor scaffolder events, changes to the RBAC system, and changes to the Catalog database.
+Audit logs include the following information:
+
+* Name of the audited event
+* Actor that triggered the audited event, for example, terminal, port, IP address, or hostname
+* Event metadata, for example, date, time
+* Event status, for example, `success`, `failure`
+* Severity levels, for example, `info`, `debug`,  `warn`, `error`
+
+You can use the information in the audit log to achieve the following goals:
+
+Enhance security::
+Trace activities, including those initiated by automated systems and software templates, back to their source.
+Know when software templates are executed, and the details of application and component installations, updates, configuration changes, and removals.
+
+Automate compliance::
+Use streamlined processes to view log data for specified points in time for auditing purposes or continuous compliance maintenance.
+
+Debug issues::
+Use access records and activity details to fix issues with software templates or plugins.
+
+[NOTE]
+====
+Audit logs are not forwarded to the internal log store by default because the internal log store does not offer secure storage.
+You are responsible for ensuring that the system to which you forward audit logs is compliant with your organizational and governmental regulations, and is properly secured.
+====

--- a/titles/product_product/category-maps/observe/con-centralize-workflow-observability.adoc
+++ b/titles/product_product/category-maps/observe/con-centralize-workflow-observability.adoc
@@ -3,4 +3,4 @@
 = Centralize workflow observability
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Centralize workflow observability.
+Monitor and troubleshoot serverless workflows by deploying observability manifests, diagnosing failures with centralized logging, optimizing performance with distributed tracing, and filtering workflow data by trace attributes.

--- a/titles/product_product/category-maps/observe/con-collect-diagnostic-data-to-troubleshoot-platform-issues.adoc
+++ b/titles/product_product/category-maps/observe/con-collect-diagnostic-data-to-troubleshoot-platform-issues.adoc
@@ -3,4 +3,20 @@
 = Collect diagnostic data to troubleshoot platform issues
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Collect diagnostic data to troubleshoot platform issues.
+The must-gather tool collects diagnostic data and logging information from your cluster, which helps {company-name} Support resolve your deployment issues efficiently.
+
+include::{docdir}/artifacts/snip-technology-preview.adoc[]
+
+Use must-gather when you open a support ticket with {company-name} Global Support Services, troubleshoot deployment issues, or capture deployment state before {product-very-short} upgrades.
+
+[NOTE]
+====
+Typical collection size ranges from 10 MB to 50 MB for basic collections and 500 MB to 2 GB when including heap dumps.
+Plan for adequate storage and bandwidth when collecting for support tickets.
+====
+
+[IMPORTANT]
+====
+The must-gather output might contain sensitive information such as configuration values, environment variables, application logs, and resource definitions.
+While the tool automatically sanitizes known secret types, you should review the output before sharing it with support to check for domain-specific sensitive data.
+====

--- a/titles/product_product/category-maps/observe/con-configure-aws-monitoring.adoc
+++ b/titles/product_product/category-maps/observe/con-configure-aws-monitoring.adoc
@@ -3,4 +3,4 @@
 = Configure AWS monitoring
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure AWS monitoring.
+Configure {product-short} to use Amazon Prometheus for metrics monitoring and Amazon CloudWatch for logging when hosting on {aws-brand-name} ({aws-short}) infrastructure.

--- a/titles/product_product/category-maps/observe/con-configure-azure-monitoring.adoc
+++ b/titles/product_product/category-maps/observe/con-configure-azure-monitoring.adoc
@@ -3,4 +3,4 @@
 = Configure Azure monitoring
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure Azure monitoring.
+Monitor resource utilization, diagnose issues, and collect logs for {product-short} on {aks-name} ({aks-short}) by using Managed Prometheus Monitoring and {azure-short} Monitor.

--- a/titles/product_product/category-maps/observe/con-configure-log-levels.adoc
+++ b/titles/product_product/category-maps/observe/con-configure-log-levels.adoc
@@ -3,4 +3,4 @@
 = Configure log levels
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Configure log levels.
+Control the amount and type of information that {product-short} writes to its logs by configuring the `LOG_LEVEL` environment variable using the Operator or Helm chart.

--- a/titles/product_product/category-maps/observe/con-customize-the-segment-source.adoc
+++ b/titles/product_product/category-maps/observe/con-customize-the-segment-source.adoc
@@ -3,4 +3,9 @@
 = Customize the Segment source
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Customize the Segment source.
+The `analytics-provider-segment` plugin sends the collected web analytics data to {company-name} by default. However, you can configure a new Segment source that receives web analytics data based on your needs. For configuration, you need a unique Segment write key that points to the Segment source.
+
+[NOTE]
+====
+Create your own web analytics data collection notice for your application users.
+====

--- a/titles/product_product/category-maps/observe/con-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc
+++ b/titles/product_product/category-maps/observe/con-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Deploy observability manifests to configure the Jaeger and Loki stacks
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Deploy observability manifests to configure the Jaeger and Loki stacks.

--- a/titles/product_product/category-maps/observe/con-diagnose-workflow-failures-using-centralized-logging.adoc
+++ b/titles/product_product/category-maps/observe/con-diagnose-workflow-failures-using-centralized-logging.adoc
@@ -3,4 +3,4 @@
 = Diagnose workflow failures using centralized logging
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Diagnose workflow failures using centralized logging.
+Search all workflow logs from a single dashboard in {product} to diagnose failures quickly. Use structured logging to connect process instances with traces and set up automated alerts for workflow failures.

--- a/titles/product_product/category-maps/observe/con-disable-telemetry-collection.adoc
+++ b/titles/product_product/category-maps/observe/con-disable-telemetry-collection.adoc
@@ -3,4 +3,6 @@
 = Disable telemetry collection
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Disable telemetry collection.
+You can disable telemetry data collection by disabling the `analytics-provider-segment` plugin. Use either the Helm chart or the {product} Operator.
+
+For example, in an air-gapped environment, you can disable this feature to avoid outbound requests that affect the responsiveness of the {product-very-short} application.

--- a/titles/product_product/category-maps/observe/con-enable-metrics-monitoring-on-openshift-container-platform.adoc
+++ b/titles/product_product/category-maps/observe/con-enable-metrics-monitoring-on-openshift-container-platform.adoc
@@ -3,4 +3,8 @@
 = Enable metrics monitoring on OpenShift Container Platform
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Enable metrics monitoring on OpenShift Container Platform.
+Enable metrics monitoring for {product-short} on {ocp-short} by creating a `ServiceMonitor` custom resource (CR) to scrape metrics from the `/metrics` service endpoint.
+
+[role="_additional-resources"]
+== Additional resources
+* {ocp-docs-link}/html-single/monitoring/index[Configuring and using the monitoring stack in {ocp-brand-name}]

--- a/titles/product_product/category-maps/observe/con-enable-telemetry-collection.adoc
+++ b/titles/product_product/category-maps/observe/con-enable-telemetry-collection.adoc
@@ -3,4 +3,4 @@
 = Enable telemetry collection
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Enable telemetry collection.
+{product} enables the telemetry data collection feature by default. However, if you have disabled the feature and want to re-enable it, you must enable the `analytics-provider-segment` plugin by using the Helm chart or the {product} Operator configuration.

--- a/titles/product_product/category-maps/observe/con-manage-telemetry-collection-to-balance-data-insights-with-privacy-requirements.adoc
+++ b/titles/product_product/category-maps/observe/con-manage-telemetry-collection-to-balance-data-insights-with-privacy-requirements.adoc
@@ -3,4 +3,28 @@
 = Manage telemetry collection to balance data insights with privacy requirements
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Manage telemetry collection to balance data insights with privacy requirements.
+{product} collects and analyzes telemetry data by default to improve your experience.
+
+{company-name} collects and analyzes the following data:
+
+Web Analytics::
+Web Analytics use the Segment tool.
+It is the tracking of user behavior and interactions with {product}.
+Specifically, it tracks the following:
+
+* Events of page visits and clicks on links or buttons.
+* System-related information, for example, locale, time zone, user agent including browser and operating system details.
+* Page-related information, for example, title, category, extension name, URL, path, referrer, and search parameters.
+* Anonymous IP addresses, recorded as `0.0.0.0`.
+* Anonymous username hashes, which are unique identifiers used solely to identify the number of unique users of the {product-very-short} application.
+
+System Observability::
+System Observability uses the OpenTelemetry tool.
+It is the tracking of the performance of the {product-very-short}.
+Specifically, it tracks the following metrics:
+
+* Key system metrics such as CPU usage, memory usage, and other performance indicators.
+* Information about system components, such as the locale, time zone, and user agent (including details of the browser and operating system).
+* Traces and logs monitor system processes, allowing you to troubleshoot potential issues impacting the performance of {product-very-short}.
+
+With {product-very-short}, you can customize the _Web Analytics_ and _System Observability_ configuration based on your needs.

--- a/titles/product_product/category-maps/observe/con-monitor-system-logs-and-application-metrics-to-ensure-platform-availability.adoc
+++ b/titles/product_product/category-maps/observe/con-monitor-system-logs-and-application-metrics-to-ensure-platform-availability.adoc
@@ -3,4 +3,4 @@
 = Monitor system logs and application metrics to ensure platform availability
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Monitor system logs and application metrics to ensure platform availability.
+Monitor {product-short} by configuring log levels, enabling metrics monitoring on {ocp-short}, and setting up platform-specific monitoring with Amazon Prometheus or Azure Monitor.

--- a/titles/product_product/category-maps/observe/con-observe.adoc
+++ b/titles/product_product/category-maps/observe/con-observe.adoc
@@ -3,4 +3,4 @@
 = Observe
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Observe.
+Monitor, troubleshoot, and maintain your {product-short} deployment by configuring system logs and application metrics, managing telemetry collection, reviewing audit logs, centralizing workflow observability, and collecting diagnostic data.

--- a/titles/product_product/category-maps/observe/con-optimize-workflow-performance.adoc
+++ b/titles/product_product/category-maps/observe/con-optimize-workflow-performance.adoc
@@ -3,4 +3,4 @@
 = Optimize workflow performance
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Optimize workflow performance.
+To maintain high performance in {product}, you must identify and resolve execution delays. Use distributed tracing to visualize the execution path and workflows and determine where time is spent across service boundaries.

--- a/titles/product_product/category-maps/observe/con-review-rbac-audit-log-events.adoc
+++ b/titles/product_product/category-maps/observe/con-review-rbac-audit-log-events.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Review RBAC audit log events
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Review RBAC audit log events.

--- a/titles/product_product/category-maps/observe/con-run-must-gather-on-openshift-to-collect-diagnostic-data.adoc
+++ b/titles/product_product/category-maps/observe/con-run-must-gather-on-openshift-to-collect-diagnostic-data.adoc
@@ -3,4 +3,4 @@
 = Run must-gather on OpenShift to collect diagnostic data
 
 [role="_abstract"]
-TODO: Replace this placeholder with an overview of Run must-gather on OpenShift to collect diagnostic data.
+Run the must-gather tool on {ocp-short} or Kubernetes clusters to collect diagnostic data for troubleshooting {product-short} deployments. You can also collect diagnostic data from air-gapped clusters by using a mirrored must-gather image.

--- a/titles/product_product/category-maps/observe/con-trace-attribute-definitions-and-filtering-keys.adoc
+++ b/titles/product_product/category-maps/observe/con-trace-attribute-definitions-and-filtering-keys.adoc
@@ -1,6 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-= Trace attribute definitions and filtering keys
-
-[role="_abstract"]
-TODO: Replace this placeholder with an overview of Trace attribute definitions and filtering keys.

--- a/titles/product_product/category-maps/observe/nav-capture-and-review-audit-logs-to-trace-user-activities-and-maintain-accountability.adoc
+++ b/titles/product_product/category-maps/observe/nav-capture-and-review-audit-logs-to-trace-user-activities-and-maintain-accountability.adoc
@@ -6,12 +6,10 @@
 
 include::con-capture-and-review-audit-logs-to-trace-user-activities-and-maintain-accountability.adoc[leveloffset=+1]
 
-include::modules/observability_audit-logs-in-rhdh/con-audit-logs-overview.adoc[leveloffset=+1]
-
 include::modules/observability_audit-logs-in-rhdh/proc-configure-audit-logs-for-rhdh-on-ocp.adoc[leveloffset=+1]
 
 include::modules/observability_audit-logs-in-rhdh/proc-forward-rhdh-audit-logs-to-splunk.adoc[leveloffset=+1]
 
 include::modules/observability_audit-logs-in-rhdh/proc-view-audit-logs-in-rhdh.adoc[leveloffset=+1]
 
-include::nav-review-rbac-audit-log-events.adoc[leveloffset=+1]
+include::modules/observability_audit-logs-in-rhdh/ref-rbac-audit-log-events.adoc[leveloffset=+1,navtitle="Review RBAC audit log events"]

--- a/titles/product_product/category-maps/observe/nav-centralize-workflow-observability.adoc
+++ b/titles/product_product/category-maps/observe/nav-centralize-workflow-observability.adoc
@@ -6,10 +6,10 @@
 
 include::con-centralize-workflow-observability.adoc[leveloffset=+1]
 
-include::nav-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc[leveloffset=+1]
+include::nav-apply-deployment-manifests.adoc[leveloffset=+1]
 
 include::nav-diagnose-workflow-failures-using-centralized-logging.adoc[leveloffset=+1]
 
 include::nav-optimize-workflow-performance.adoc[leveloffset=+1]
 
-include::nav-trace-attribute-definitions-and-filtering-keys.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/ref-span-attributes-for-workflow-filtering.adoc[leveloffset=+1,navtitle="Trace attribute definitions and filtering keys"]

--- a/titles/product_product/category-maps/observe/nav-collect-diagnostic-data-to-troubleshoot-platform-issues.adoc
+++ b/titles/product_product/category-maps/observe/nav-collect-diagnostic-data-to-troubleshoot-platform-issues.adoc
@@ -6,8 +6,6 @@
 
 include::con-collect-diagnostic-data-to-troubleshoot-platform-issues.adoc[leveloffset=+1]
 
-include::modules/observe_diagnostic-data-collection/con-diagnostic-data-collection-overview.adoc[leveloffset=+1]
-
 include::nav-run-must-gather-on-openshift-to-collect-diagnostic-data.adoc[leveloffset=+1]
 
 include::modules/observe_diagnostic-data-collection/proc-collect-heap-dumps-to-diagnose-memory-issues.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/observe/nav-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc
+++ b/titles/product_product/category-maps/observe/nav-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks_{context}"]
-= Deploy observability manifests to configure the Jaeger and Loki stacks
-:context: deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks
-
-include::con-deploy-observability-manifests-to-configure-the-jaeger-and-loki-stacks.adoc[leveloffset=+1]
-
-include::nav-apply-deployment-manifests.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/observe/nav-manage-telemetry-collection-to-balance-data-insights-with-privacy-requirements.adoc
+++ b/titles/product_product/category-maps/observe/nav-manage-telemetry-collection-to-balance-data-insights-with-privacy-requirements.adoc
@@ -6,8 +6,6 @@
 
 include::con-manage-telemetry-collection-to-balance-data-insights-with-privacy-requirements.adoc[leveloffset=+1]
 
-include::modules/observability_telemetry-data-collection-and-analysis/con-telemetry-data-collection-and-analysis.adoc[leveloffset=+1]
-
 include::nav-disable-telemetry-collection.adoc[leveloffset=+1]
 
 include::nav-enable-telemetry-collection.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/observe/nav-review-rbac-audit-log-events.adoc
+++ b/titles/product_product/category-maps/observe/nav-review-rbac-audit-log-events.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="review-rbac-audit-log-events_{context}"]
-= Review RBAC audit log events
-:context: review-rbac-audit-log-events
-
-include::con-review-rbac-audit-log-events.adoc[leveloffset=+1]
-
-include::modules/observability_audit-logs-in-rhdh/ref-rbac-audit-log-events.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/observe/nav-trace-attribute-definitions-and-filtering-keys.adoc
+++ b/titles/product_product/category-maps/observe/nav-trace-attribute-definitions-and-filtering-keys.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: MAP
-
-[id="trace-attribute-definitions-and-filtering-keys_{context}"]
-= Trace attribute definitions and filtering keys
-:context: trace-attribute-definitions-and-filtering-keys
-
-include::con-trace-attribute-definitions-and-filtering-keys.adoc[leveloffset=+1]
-
-include::modules/extend_orchestrator-in-rhdh/ref-span-attributes-for-workflow-filtering.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10, 2.0
**Issue:** N/A (JTBD MAP migration housekeeping)
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2430/product_product/

## Summary

- Replace all 24 TODO placeholder abstracts in Configure (4) and Observe (20) concept files with actual content
- **Tier 1 (9 files):** Extract abstracts and body content from matching assemblies (AWS/Azure monitoring, log levels, telemetry, metrics, workflow diagnostics/optimization, segment source)
- **Tier 2 (3 files):** Promote existing concept modules (`con-audit-logs-overview`, `con-diagnostic-data-collection-overview`, `con-telemetry-data-collection-and-analysis`) into MAP concept files; remove duplicate includes from nav files
- **Tier 3 (3 files):** Write inferred abstracts from included module content (deployment manifests, must-gather, centralized observability)
- **Tier 4 (6 files):** Write parent/rollup abstracts summarizing child topics (category intros, section groupings)
- **Tier 5 (3 nav+con pairs deleted):** Simplify single-entry nav files by collapsing into parent navs (RBAC audit log events, trace attributes, deploy observability manifests)
- 31 files changed, 102 insertions, 75 deletions, 6 files deleted
- ccutil build passes cleanly