### PR TITLE
JTBD: Update module titles for chapters 1-8 to match JTBD TOC mapping

### DIFF
--- a/modules/develop_streamline-software-development-and-management-in-rhdh/proc-manage-the-added-git-repositories.adoc
+++ b/modules/develop_streamline-software-development-and-management-in-rhdh/proc-manage-the-added-git-repositories.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="manage-the-added-git-repositories_{context}"]
-= Manage the added Git repositories
+= Manage imported repositories
 
 [role="_abstract"]
 You can oversee and manage the Git repositories that are imported to {product-short}.

--- a/modules/discover_about-rhdh/con-compare-the-helm-chart-and-operator-to-choose-the-optimal-deployment-method.adoc
+++ b/modules/discover_about-rhdh/con-compare-the-helm-chart-and-operator-to-choose-the-optimal-deployment-method.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="compare-the-helm-chart-and-operator-to-choose-the-optimal-deployment-method_{context}"]
-= Compare the Helm chart and Operator to choose the optimal deployment method
+= Pros and cons of each deployment method
 
 [role="_abstract"]
 When planning your {product} deployment, you must choose between the Helm chart and Operator installation methods. Use the following table to choose the method that aligns with your operational model and team capabilities:

--- a/modules/discover_about-rhdh/ref-sizing-requirements-for-rhdh.adoc
+++ b/modules/discover_about-rhdh/ref-sizing-requirements-for-rhdh.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="sizing-requirements-for-rhdh_{context}"]
-= Sizing requirements for {product}
+= Compute and storage resource guidelines
 
 [role="_abstract"]
 Plan infrastructure resources for {product} deployments using sizing requirements for the application, database, and Operator.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/con-air-gapped-environment.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/con-air-gapped-environment.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="air-gapped-environment_{context}"]
-= Air-gapped environment
+= Isolated network deployments for air-gapped environments
 
 [role="_abstract"]
 An air-gapped environment ensures security by physically segregating systems from external networks.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-in-a-fully-disconnected-environment-with-the-operator_{context}"]
-= Install {product} in a fully disconnected environment with the Operator
+= Mirror Operator images to deploy in fully disconnected networks
 
 [role="_abstract"]
 Mirror Operator images to disk and transfer them to a fully disconnected environment without internet access.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-in-a-partially-disconnected-environment-with-the-operator_{context}"]
-= Install {product} in a partially disconnected environment with the Operator
+= Mirror Operator images to local registries for partially disconnected networks
 
 [role="_abstract"]
 Mirror Operator images directly to a target registry in a partially disconnected environment.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-a-supported-kubernetes-platform-in-a-fully-disconnected-environment-with-the-helm-chart_{context}"]
-= Install {product} on a supported Kubernetes platform in a fully disconnected environment with the Helm chart
+= Mirror Helm images to deploy in fully disconnected Kubernetes networks
 
 [role="_abstract"]
 Mirror Helm chart images to disk and transfer them to a fully disconnected Kubernetes environment.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-a-supported-kubernetes-platform-in-a-partially-disconnected-environment-with-the-helm-chart_{context}"]
-= Install {product} on a supported Kubernetes platform in a partially disconnected environment with the Helm chart
+= Mirror Helm images to local registries for partially disconnected Kubernetes networks
 
 [role="_abstract"]
 Mirror Helm chart images directly to a target registry in a partially disconnected Kubernetes environment.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart_{context}"]
-= Install {product} on {ocp-short} in a fully disconnected environment with the Helm chart
+= Mirror Helm images to deploy in fully disconnected OpenShift networks
 
 [role="_abstract"]
 Mirror Helm chart images to disk and transfer them to a fully disconnected {ocp-short} environment.

--- a/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart_{context}"]
-= Install {product} on {ocp-short} in a partially disconnected environment with the Helm chart
+= Mirror Helm images to local registries for partially disconnected networks
 
 [role="_abstract"]
 Mirror Helm chart images directly to a target registry in a partially disconnected {ocp-short} environment.

--- a/modules/install_installing-rhdh-on-ocp/con-rhdh-installation-methods-on-ocp.adoc
+++ b/modules/install_installing-rhdh-on-ocp/con-rhdh-installation-methods-on-ocp.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="rhdh-installation-methods-on-ocp_{context}"]
-= {product} installation methods on {ocp-short}
+= Compare the Helm chart and Operator deployment methods
 
 [role="_abstract"]
 You can install {product} on {ocp-short} by using one of the following installers:

--- a/modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-from-the-ocp-web-console-with-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-from-the-ocp-web-console-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="deploy-rhdh-from-the-ocp-web-console-with-the-helm-chart_{context}"]
-= Deploy {product-short} from the {ocp-short} web console with the Helm Chart
+= Deploy from the web console
 
 [role="_abstract"]
 You can use a Helm chart to install {product-short} on the {ocp-brand-name} web console.

--- a/modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-on-ocp-with-the-helm-cli.adoc
+++ b/modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-on-ocp-with-the-helm-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="deploy-rhdh-on-ocp-with-the-helm-cli_{context}"]
-= Deploy {product-short} on {ocp-short} with the Helm CLI
+= Deploy with the Helm CLI
 
 [role="_abstract"]
 You can use the Helm CLI to install {product} on {ocp-brand-name}.

--- a/modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-helm-chart.adoc
+++ b/modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-on-using-the-helm-chart_{context}"]
-= Install {product} on {osd-short} on {gcp-short} using the Helm Chart
+= Deploy on OpenShift Dedicated using the Helm chart
 
 [role="_abstract"]
 Deploy {product-short} on {osd-short} on {gcp-short} using Helm for flexible, customizable configuration management.

--- a/modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-operator.adoc
+++ b/modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-rhdh-on-on-using-the-operator_{context}"]
-= Install {product} on {osd-short} on {gcp-short} using the Operator
+= Install on OpenShift Dedicated using the Operator
 
 [role="_abstract"]
 Deploy {product-short} on {osd-short} on {gcp-short} using the Operator for centralized lifecycle management and automated updates.

--- a/modules/observability_adoption-insights-in-rhdh/proc-customize-the-adoption-insights-plugin-in-rhdh.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-customize-the-adoption-insights-plugin-in-rhdh.adoc
@@ -5,7 +5,7 @@
 // * assemblies/assembly-rhdh-observability.adoc
 
 [id="customize-the-adoption-insights-plugin-in-rhdh_{context}"]
-= Customize the Adoption Insights plugin in {product}
+= Customize the Adoption Insights plugin
 
 [role="_abstract"]
 Customize buffer size, flush interval, debug settings, licensed users, and RBAC permissions for the Adoption Insights plugin.

--- a/modules/observability_adoption-insights-in-rhdh/proc-filter-records-to-display-specific-catalog-entities-in-top-catalog-entities.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-filter-records-to-display-specific-catalog-entities-in-top-catalog-entities.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="filter-records-to-display-specific-catalog-entities-in-top-catalog-entities_{context}"]
-= Filter records to display specific catalog entities in Top catalog entities
+= Filter records
 
 [role="_abstract"]
 By default, the *Top catalog entities* card displays all of the items in your {product-short} instance.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-searches.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-searches.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-searches_{context}"]
-= View searches
+= View platform searches
 
 [role="_abstract"]
 View portal search trends over time, including total searches and average searches per time period in the Searches card.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-active-users.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-active-users.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-active-users_{context}"]
-= View the active users
+= View active users
 
 [role="_abstract"]
 View the total number of active users over time, including returning and new users, and export the data in CSV format.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-plugins.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-plugins.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-top-3-plugins_{context}"]
-= View the top 3 plugins
+= View top plugins
 
 [role="_abstract"]
 View the most commonly used plugins, including name, popularity trend, and total views in the Top 3 plugins card.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-techdocs-documents.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-techdocs-documents.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-top-3-techdocs-documents_{context}"]
-= View the top 3 TechDocs documents
+= View top TechDocs
 
 [role="_abstract"]
 View the most-viewed TechDocs documentation entries including name, entity type, last used date, and total views.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-templates.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-templates.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-top-3-templates_{context}"]
-= View the top 3 templates
+= View top templates
 
 [role="_abstract"]
 View the most commonly used templates including name, most frequent user type, and total executions in the Top 3 templates card.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-catalog-entities.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-top-catalog-entities.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-top-catalog-entities_{context}"]
-= View the top catalog entities
+= View top catalog entities
 
 [role="_abstract"]
 View the most-viewed catalog entities including name, type, last used date, and total views in the Top catalog entities card.

--- a/modules/observability_adoption-insights-in-rhdh/proc-view-the-total-number-of-users.adoc
+++ b/modules/observability_adoption-insights-in-rhdh/proc-view-the-total-number-of-users.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="view-the-total-number-of-users_{context}"]
-= View the total number of users
+= View total users
 
 [role="_abstract"]
 View the total number of licensed users, and compare logged-in users versus licensed users in numeric and percentage format.

--- a/modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="scorecard-metric-threshold-categorization-rules_{context}"]
-= Scorecard metric threshold categorization rules
+= Metric categorization criteria
 
 [role="_abstract"]
 A threshold defines conditions or expressions to assign metric values to specific visual categories.

--- a/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="standardize-scorecard-metric-thresholds-across-components_{context}"]
-= Standardize Scorecard metric thresholds across components
+= Standardize metric thresholds across components
 
 [role="_abstract"]
 You can define global thresholds in your `{product-very-short} {my-app-config-file}` file to standardize health indicators across all components. Global configurations replace the default thresholds provided by a metric source.

--- a/modules/observability_evaluate-project-health-using-scorecards/con-verify-logical-flow-in-scorecard-threshold-rules.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/con-verify-logical-flow-in-scorecard-threshold-rules.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="verify-logical-flow-in-scorecard-threshold-rules_{context}"]
-= Verify logical flow in Scorecard threshold rules
+= Logical flow verification
 
 [role="_abstract"]
 To ensure Scorecard assigns the correct health status, order rules carefully, because the evaluation stops at the first matching rule.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="adjust-metric-retention-to-manage-storage_{context}"]
-= Adjust metric retention to manage storage
+= Adjust metric retention
 
 [role="_abstract"]
 To manage storage capacity and comply with data retention policies, adjust the number of days the Scorecard plugin retains metric data to align with your organization's policies. By default, the system retains metrics for 365 days.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-portfolio-health-on-a-customizable-home-page_{context}"]
-= Configure portfolio health on a customizable home page
+= Configure on a customizable home page
 
 [role="_abstract"]
 You can add the aggregated Scorecard widget to a customizable {product-very-short} home page to monitor the collective technical health of your portfolio.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-portfolio-health-on-a-read-only-home-page_{context}"]
-= Configure portfolio health on a read-only home page
+= Configure on a read-only home page
 
 [role="_abstract"]
 You can add the aggregated Scorecard widget to a read-only {product-very-short} home page to monitor the collective technical health of your portfolio.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rbac-for-scorecards-by-using-the-rbac-csv-file_{context}"]
-= Configure RBAC for Scorecards by using the RBAC CSV file
+= Configure RBAC using the CSV file
 
 [role="_abstract"]
 You can grant read access to Scorecard metrics by adding permission policies to your RBAC CSV file.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rbac-for-scorecards-by-using-the-web-ui_{context}"]
-= Configure RBAC for Scorecards by using the Web UI
+= Configure RBAC using the Web UI
 
 [role="_abstract"]
 You can grant read access to Scorecard metrics by using the RBAC Web UI in {product-very-short}.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="integrate-github-health-metrics-using-scorecards_{context}"]
-= Integrate GitHub health metrics using Scorecards
+= Integrate GitHub health metrics
 
 [role="_abstract"]
 You can configure the GitHub Scorecard plugin to display repository metrics in your {product-very-short} catalog. This integration allows you to monitor component health and security risks directly from {product}.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="integrate-jira-health-metrics-using-scorecards_{context}"]
-= Integrate Jira health metrics using Scorecards
+= Integrate Jira health metrics
 
 [role="_abstract"]
 You can configure the Jira Scorecard plugin to display project tracking and delivery velocity data in your {product-very-short} instance. This integration centralizes development status and facilitates the evaluation of component readiness.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="monitor-component-health-and-readiness-with-scorecard-metrics_{context}"]
-= Monitor component health and readiness with Scorecard metrics
+= Monitor component health
 
 [role="_abstract"]
 You can view metrics to evaluate the health and security of your software components directly in the {product-very-short} catalog.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="schedule-metrics-to-avoid-api-limits_{context}"]
-= Schedule metrics to avoid API limits
+= Schedule metrics
 
 [role="_abstract"]
 To balance data freshness with system performance and API rate limits, you can customize the collection frequency for Scorecard metrics. Scorecard uses the {backstage} built-in scheduler service. The default refresh frequency is hourly, but you can adjust it for each metric.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="available-scorecard-metric-providers-and-metric-ids_{context}"]
-= Available scorecard metric providers and metric IDs
+= Supported Scorecard metrics providers
 
 [role="_abstract"]
 The Scorecard plugin gathers data from third-party systems through metric providers. Use the following table to identify which metrics are available for each supported provider.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-establishing-ownership-in-the-software-catalog.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-establishing-ownership-in-the-software-catalog.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="establishing-ownership-in-the-software-catalog_{context}"]
-= Establishing ownership in the Software Catalog
+= Establish ownership in the software catalog
 
 [role="_abstract"]
 To enable automatic metric aggregation in the Scorecard plugin, you must establish ownership relationships between users, groups, and components in the Software Catalog. The Scorecard plugin uses these definitions to calculate health trends based on who owns the entities.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="override-rules-to-configure-entity-specific-thresholds-in-scorecards_{context}"]
-= Override rules to configure entity-specific thresholds in Scorecards
+= Component-specific threshold rules
 
 [role="_abstract"]
 Use annotations in the `catalog-info.yaml` file of a component to override global threshold rules. These annotations merge with and take precedence over the global rules defined in your {product-very-short} `{my-app-config-file}` file.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-metric-threshold-precedence.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-metric-threshold-precedence.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="scorecard-metric-threshold-precedence_{context}"]
-= Scorecard metric threshold precedence
+= Resolve configuration conflicts using threshold precedence
 
 [role="_abstract"]
 Threshold rules follow a specific order of precedence. Higher-priority configurations override lower-priority settings, allowing you to define global defaults with entity-specific exceptions.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="scorecard-plugin-rest-api-endpoints-and-parameters_{context}"]
-= Scorecard plugin REST API endpoints and parameters
+= API endpoints and parameter details
 
 [role="_abstract"]
 REST API endpoints for the scorecard plugin used to fetch portfolio evaluations and component summaries.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-supported-scorecard-threshold-expression-syntax.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-supported-scorecard-threshold-expression-syntax.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id='supported-scorecard-threshold-expression-syntax_{context}']
-= Supported Scorecard threshold expression syntax
+= Threshold expression syntax
 
 [role="_abstract"]
 Metric threshold expressions use mathematical and logical operators to evaluate data. Use the following operators to define health criteria based on the metric data type.

--- a/modules/shared/con-software-templates-in-rhdh.adoc
+++ b/modules/shared/con-software-templates-in-rhdh.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="software-templates-in-rhdh_{context}"]
-= Software Templates in {product}
+= Run Software Templates from the UI
 
 [role="_abstract"]
 You can use Software Templates in {product-very-short} to automate the project setup process to reduce manual configuration and errors for developers. These Software Templates are part of the {backstage} Scaffolder system.

--- a/modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc
+++ b/modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-provenance-and-software-template-versioning-rhdh_{context}"]
-= Configure provenance and Software Template versioning {product}
+= Configure provenance annotations
 
 [role="_abstract"]
 Modify the Software Template YAML definition to add provenance information during the scaffolding process.

--- a/modules/shared/proc-create-a-basic-software-template.adoc
+++ b/modules/shared/proc-create-a-basic-software-template.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="create-a-basic-software-template_{context}"]
-= Create a basic software template
+= Create new Software Templates
 
 [role="_abstract"]
 To automate the setup of standardized environments for your developers, you must create a template definition. This definition allows {product-very-short} to automate the repetitive tasks of repository creation and initial configuration.

--- a/modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc
+++ b/modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="deploy-on-eks-with-the-helm-chart_{context}"]
-= Deploy {product-short} on {eks-short} with the Helm chart
+= Deploy on Amazon EKS using the Helm chart
 
 [role="_abstract"]
 Deploy {product-short} on {eks-short} by using the Helm chart for building, testing, and deploying applications.

--- a/modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc
+++ b/modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="deploy-on-gke-with-the-helm-chart_{context}"]
-= Deploy {product-short} on {gke-short} with the Helm chart
+= Deploy on GKE using the Helm chart
 
 [role="_abstract"]
 Deploy {product-short} on {gke-short} by using the Helm chart for building, testing, and deploying applications.

--- a/modules/shared/proc-deploy-rhdh-on-with-the-helm-chart.adoc
+++ b/modules/shared/proc-deploy-rhdh-on-with-the-helm-chart.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="deploy-rhdh-on-with-the-helm-chart_{context}"]
-= Deploy {product-short} on {aks-short} with the Helm chart
+= Deploy on AKS using the Helm chart
 
 [role="_abstract"]
 Deploy {product-short} on {aks-short} by using the Helm chart for building, testing, and deploying applications.

--- a/modules/shared/proc-enable-automated-template-updates.adoc
+++ b/modules/shared/proc-enable-automated-template-updates.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enable-automated-template-updates_{context}"]
-= Enable automated template updates
+= Enable the scaffolder-relation-processor
 
 [role="_abstract"]
 Configure the scaffolder-relation-processor plugin to synchronize Software Template changes to downstream repositories.

--- a/modules/shared/proc-enable-software-template-version-update-notifications-in-rhdh.adoc
+++ b/modules/shared/proc-enable-software-template-version-update-notifications-in-rhdh.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enable-software-template-version-update-notifications-in-rhdh_{context}"]
-= Enable Software Template version update notifications in {product}
+= Enable update notifications
 
 [role="_abstract"]
 Enable notification alerts for template version updates so that component owners are automatically notified when the Software Template used to generate their components is updated to a new version.

--- a/modules/shared/proc-expose-your-operator-based-instance-on-aks.adoc
+++ b/modules/shared/proc-expose-your-operator-based-instance-on-aks.adoc
@@ -5,7 +5,7 @@
 :installing-the-operator-by-using-olm-xref: xref:install-the-operator-on-{platform-id}-by-using-olm_{context}
 
 [id="expose-your-operator-based-instance-on-{platform-id}_{context}"]
-= Expose your Operator-based {product-short} instance on {platform-long}
+= Expose your Operator instance using an Ingress resource
 
 [role="_abstract"]
 On {aks-brand-name} ({aks-short}), Kubernetes ingresses replace {ocp-short} routes.

--- a/modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc
+++ b/modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc
@@ -5,7 +5,7 @@
 :installing-the-operator-by-using-olm-xref: xref:install-the-operator-on-{platform-id}-by-using-olm_{context}
 
 [id="expose-your-operator-based-instance-on-{platform-id}_{context}"]
-= Expose your Operator-based {product-short} instance on {platform-long}
+= Expose your Operator instance using an Ingress resource
 
 [role="_abstract"]
 On {eks-brand-name} ({eks-short}), Kubernetes ingresses replace {ocp-short} routes.

--- a/modules/shared/proc-expose-your-operator-based-instance-on-gke.adoc
+++ b/modules/shared/proc-expose-your-operator-based-instance-on-gke.adoc
@@ -5,7 +5,7 @@
 :installing-the-operator-by-using-olm-xref: xref:install-the-operator-on-{platform-id}-by-using-olm_{context}
 
 [id="expose-your-operator-based-instance-on-{platform-id}_{context}"]
-= Expose your Operator-based {product-short} instance on {platform-long}
+= Expose your Operator instance using an Ingress resource
 
 [role="_abstract"]
 On {gke-brand-name} ({gke-short}), Kubernetes ingresses replace {ocp-short} routes.

--- a/modules/shared/proc-install-the-operator-on-aks-by-using-olm.adoc
+++ b/modules/shared/proc-install-the-operator-on-aks-by-using-olm.adoc
@@ -4,7 +4,7 @@
 :platform-id: aks
 
 [id="install-the-operator-on-{platform-id}-by-using-olm_{context}"]
-= Install the Operator on {platform-long} by using OLM
+= Install the Operator using OLM to automate deployments
 
 [role="_abstract"]
 Install the {product} Operator on {platform} by using the Operator Lifecycle Manager (OLM) framework.

--- a/modules/shared/proc-install-the-operator-on-eks-by-using-olm.adoc
+++ b/modules/shared/proc-install-the-operator-on-eks-by-using-olm.adoc
@@ -4,7 +4,7 @@
 :platform-id: eks
 
 [id="install-the-operator-on-{platform-id}-by-using-olm_{context}"]
-= Install the Operator on {platform-long} by using OLM
+= Install the Operator using OLM to automate deployments
 
 [role="_abstract"]
 Install the {product} Operator on {platform} by using the Operator Lifecycle Manager (OLM) framework.

--- a/modules/shared/proc-install-the-operator-on-gke-by-using-olm.adoc
+++ b/modules/shared/proc-install-the-operator-on-gke-by-using-olm.adoc
@@ -4,7 +4,7 @@
 :platform-id: gke
 
 [id="install-the-operator-on-{platform-id}-by-using-olm_{context}"]
-= Install the Operator on {platform-long} by using OLM
+= Install the Operator using OLM to automate deployments
 
 [role="_abstract"]
 Install the {product} Operator on {platform} by using the Operator Lifecycle Manager (OLM) framework.

--- a/modules/shared/proc-install-the-rhdh-operator.adoc
+++ b/modules/shared/proc-install-the-rhdh-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="install-the-rhdh-operator_{context}"]
-= Install the {product} Operator
+= Install the Operator
 
 [role="_abstract"]
 As an administrator, you can install the {product} Operator. Authorized users can use the Operator to install {product} on {ocp-brand-name} ({ocp-short}) and supported Kubernetes platforms.

--- a/modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc
+++ b/modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="provision-your-pull-secret-to-your-rhdh-instance-namespace_{context}"]
-= Provision your {rhcr} pull secret to your {product} instance namespace
+= Provision a pull secret to access the container registry
 
 [role="_abstract"]
 On {platform-long}, provision your {rhcr} pull secret in your {product} instance namespace because the pull secret is not managed globally.

--- a/modules/shared/proc-share-software-templates-with-your-organization.adoc
+++ b/modules/shared/proc-share-software-templates-with-your-organization.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="share-software-templates-with-your-organization_{context}"]
-= Share software templates with your organization
+= Publish template definitions to the catalog
 
 [role="_abstract"]
 To allow developers to create new projects independently using your standards, you must publish the Software Template definition to the {product-very-short} catalog. This registration makes the template a selectable option in the software creator interface.

--- a/modules/shared/proc-version-a-software-template-in-rhdh.adoc
+++ b/modules/shared/proc-version-a-software-template-in-rhdh.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="version-a-software-template-in-rhdh_{context}"]
-= Version a Software Template in {product}
+= Version Software Templates
 
 [role="_abstract"]
 Version Software Templates by using the `catalog:scaffolded-from` and `catalog:template:version` custom actions to track template versions and the entities created from them.

--- a/modules/shared/proc-view-software-template-dependencies.adoc
+++ b/modules/shared/proc-view-software-template-dependencies.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="view-software-template-dependencies_{context}"]
-= View Software Template dependencies
+= View template dependencies in the catalog
 
 [role="_abstract"]
 View all entities created from a specific Software Template to identify the complete dependency and impact map.

--- a/modules/shared/ref-default-environment-parameters-and-secrets.adoc
+++ b/modules/shared/ref-default-environment-parameters-and-secrets.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="default-environment-parameters-and-secrets_{context}"]
-= Default environment parameters and secrets
+= Use sample templates
 
 [role="_abstract"]
 The scaffolder supports a `defaultEnvironment` configuration

--- a/modules/shared/ref-extending-software-templates-for-complex-project-requirements.adoc
+++ b/modules/shared/ref-extending-software-templates-for-complex-project-requirements.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="extending-software-templates-for-complex-project-requirements_{context}"]
-= Extending software templates for complex project requirements
+= Extend templates using conditional logic and external fetch capabilities
 
 [role="_abstract"]
 Use advanced logic to create Software Templates that adapt to specific project requirements and user inputs. Advanced templating includes parameterization, conditional logic, and fetch-and-run capabilities.

--- a/modules/shared/ref-sample-software-template.adoc
+++ b/modules/shared/ref-sample-software-template.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="sample-software-template_{context}"]
-= Sample software template
+= Browse available templates
 
 [role="_abstract"]
 This sample Software Template defines project parameters and publishes the generated code to a GitHub repository.

--- a/modules/shared/ref-template-sync-considerations-and-limitations.adoc
+++ b/modules/shared/ref-template-sync-considerations-and-limitations.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="template-sync-considerations-and-limitations_{context}"]
-= Template sync considerations and limitations
+= Template sync limitations
 
 [role="_abstract"]
 Review reviewer assignment, variable resolution limitations, and other details to troubleshoot the synchronization process.

--- a/titles/product_product/category-maps/administer/nav-adoption-insights.adoc
+++ b/titles/product_product/category-maps/administer/nav-adoption-insights.adoc
@@ -6,8 +6,8 @@
 
 include::con-adoption-insights.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc[leveloffset=+1,navtitle="Enable the Adoption Insights plugin"]
+include::modules/observability_adoption-insights-in-rhdh/proc-enable-the-adoption-insights-plugin.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-disable-the-adoption-insights-plugin.adoc[leveloffset=+1,navtitle="Disable the Adoption Insights plugin"]
+include::modules/observability_adoption-insights-in-rhdh/proc-disable-the-adoption-insights-plugin.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-customize-the-adoption-insights-plugin-in-rhdh.adoc[leveloffset=+1,navtitle="Customize the Adoption Insights plugin"]
+include::modules/observability_adoption-insights-in-rhdh/proc-customize-the-adoption-insights-plugin-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-analyze-platform-adoption-trends-to-measure-engagement-and-tool-popularity.adoc
+++ b/titles/product_product/category-maps/administer/nav-analyze-platform-adoption-trends-to-measure-engagement-and-tool-popularity.adoc
@@ -14,8 +14,8 @@ include::nav-view-the-adoption-insights-cards.adoc[leveloffset=+1]
 
 // TODO: include Display human-readable entity titles (module not yet available)
 
-include::modules/observability_adoption-insights-in-rhdh/proc-change-the-number-of-displayed-records.adoc[leveloffset=+1,navtitle="Change the number of displayed records"]
+include::modules/observability_adoption-insights-in-rhdh/proc-change-the-number-of-displayed-records.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-filter-records-to-display-specific-catalog-entities-in-top-catalog-entities.adoc[leveloffset=+1,navtitle="Filter records"]
+include::modules/observability_adoption-insights-in-rhdh/proc-filter-records-to-display-specific-catalog-entities-in-top-catalog-entities.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-searches.adoc[leveloffset=+1,navtitle="View platform searches"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-searches.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-configure-aggregated-scorecard-kpis.adoc
+++ b/titles/product_product/category-maps/administer/nav-configure-aggregated-scorecard-kpis.adoc
@@ -8,10 +8,10 @@ include::con-configure-aggregated-scorecard-kpis.adoc[leveloffset=+1]
 
 include::nav-configure-portfolio-health.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc[leveloffset=+1,navtitle="Schedule metrics"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-schedule-metrics-to-avoid-api-limits.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc[leveloffset=+1,navtitle="Adjust metric retention"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-adjust-metric-retention-to-manage-storage.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-establishing-ownership-in-the-software-catalog.adoc[leveloffset=+1,navtitle="Establish ownership in the software catalog"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-establishing-ownership-in-the-software-catalog.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-view-aggregated-metrics-for-owned-entities.adoc[leveloffset=+1,navtitle="View aggregated metrics for owned entities"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-view-aggregated-metrics-for-owned-entities.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-configure-portfolio-health.adoc
+++ b/titles/product_product/category-maps/administer/nav-configure-portfolio-health.adoc
@@ -6,6 +6,6 @@
 
 include::con-configure-portfolio-health.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc[leveloffset=+1,navtitle="Configure on a customizable home page"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc[leveloffset=+1,navtitle="Configure on a read-only home page"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
@@ -6,7 +6,7 @@
 
 include::con-evaluate-component-compliance-using-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc[leveloffset=+1,navtitle="Supported Scorecard metrics providers"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc[leveloffset=+1]
 
 include::nav-set-up-scorecards.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
@@ -17,4 +17,4 @@ include::nav-install-and-configure-scorecards.adoc[leveloffset=+1]
 include::nav-manage-metric-thresholds.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc[leveloffset=+1,navtitle="Monitor component health"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-install-and-configure-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-install-and-configure-scorecards.adoc
@@ -6,6 +6,6 @@
 
 include::con-install-and-configure-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc[leveloffset=+1,navtitle="Integrate GitHub health metrics"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc[leveloffset=+1,navtitle="Integrate Jira health metrics"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
+++ b/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
@@ -6,14 +6,14 @@
 
 include::con-manage-metric-thresholds.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc[leveloffset=+1,navtitle="Metric categorization criteria"]
+include::modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-supported-scorecard-threshold-expression-syntax.adoc[leveloffset=+1,navtitle="Threshold expression syntax"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-supported-scorecard-threshold-expression-syntax.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-metric-threshold-precedence.adoc[leveloffset=+1,navtitle="Resolve configuration conflicts using threshold precedence"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-metric-threshold-precedence.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc[leveloffset=+1,navtitle="Standardize metric thresholds across components"]
+include::modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc[leveloffset=+1,navtitle="Component-specific threshold rules"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/con-verify-logical-flow-in-scorecard-threshold-rules.adoc[leveloffset=+1,navtitle="Logical flow verification"]
+include::modules/observability_evaluate-project-health-using-scorecards/con-verify-logical-flow-in-scorecard-threshold-rules.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-monitor-collective-health.adoc
+++ b/titles/product_product/category-maps/administer/nav-monitor-collective-health.adoc
@@ -6,4 +6,4 @@
 
 include::con-monitor-collective-health.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/con-monitor-portfolio-health-with-aggregated-kpis.adoc[leveloffset=+1,navtitle="Monitor portfolio health with aggregated KPIs"]
+include::modules/observability_evaluate-project-health-using-scorecards/con-monitor-portfolio-health-with-aggregated-kpis.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-retrieve-metric-data-using-the-api.adoc
+++ b/titles/product_product/category-maps/administer/nav-retrieve-metric-data-using-the-api.adoc
@@ -6,4 +6,4 @@
 
 include::con-retrieve-metric-data-using-the-api.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc[leveloffset=+1,navtitle="API endpoints and parameter details"]
+include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-set-up-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-set-up-scorecards.adoc
@@ -6,8 +6,8 @@
 
 include::con-set-up-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc[leveloffset=+1,navtitle="Enable Scorecards"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc[leveloffset=+1,navtitle="Configure RBAC using the CSV file"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc[leveloffset=+1]
 
-include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc[leveloffset=+1,navtitle="Configure RBAC using the Web UI"]
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-web-ui.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-use-adoption-insights.adoc
+++ b/titles/product_product/category-maps/administer/nav-use-adoption-insights.adoc
@@ -6,4 +6,4 @@
 
 include::con-use-adoption-insights.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-set-the-duration-of-data-metrics.adoc[leveloffset=+1,navtitle="Set the duration of data metrics"]
+include::modules/observability_adoption-insights-in-rhdh/proc-set-the-duration-of-data-metrics.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-view-the-adoption-insights-cards.adoc
+++ b/titles/product_product/category-maps/administer/nav-view-the-adoption-insights-cards.adoc
@@ -6,14 +6,14 @@
 
 include::con-view-the-adoption-insights-cards.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-active-users.adoc[leveloffset=+1,navtitle="View active users"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-active-users.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-total-number-of-users.adoc[leveloffset=+1,navtitle="View total users"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-total-number-of-users.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-catalog-entities.adoc[leveloffset=+1,navtitle="View top catalog entities"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-catalog-entities.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-templates.adoc[leveloffset=+1,navtitle="View top templates"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-templates.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-techdocs-documents.adoc[leveloffset=+1,navtitle="View top TechDocs"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-techdocs-documents.adoc[leveloffset=+1]
 
-include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-plugins.adoc[leveloffset=+1,navtitle="View top plugins"]
+include::modules/observability_adoption-insights-in-rhdh/proc-view-the-top-3-plugins.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-automate-template-lifecycle-management.adoc
+++ b/titles/product_product/category-maps/develop/nav-automate-template-lifecycle-management.adoc
@@ -6,8 +6,8 @@
 
 include::con-automate-template-lifecycle-management.adoc[leveloffset=+1]
 
-include::modules/shared/proc-enable-automated-template-updates.adoc[leveloffset=+1,navtitle="Enable the scaffolder-relation-processor"]
+include::modules/shared/proc-enable-automated-template-updates.adoc[leveloffset=+1]
 
-include::modules/shared/ref-template-sync-considerations-and-limitations.adoc[leveloffset=+1,navtitle="Template sync limitations"]
+include::modules/shared/ref-template-sync-considerations-and-limitations.adoc[leveloffset=+1]
 
 include::modules/shared/ref-template-synchronization-and-notification-outcomes.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-import-source-code-repositories-in-bulk.adoc
+++ b/titles/product_product/category-maps/develop/nav-import-source-code-repositories-in-bulk.adoc
@@ -12,6 +12,6 @@ include::modules/shared/proc-enable-and-authorize-bulk-import-capabilities-in-rh
 
 include::modules/shared/proc-import-multiple-github-repositories.adoc[leveloffset=+1]
 
-include::modules/develop_streamline-software-development-and-management-in-rhdh/proc-manage-the-added-git-repositories.adoc[leveloffset=+1,navtitle="Manage imported repositories"]
+include::modules/develop_streamline-software-development-and-management-in-rhdh/proc-manage-the-added-git-repositories.adoc[leveloffset=+1]
 
 include::modules/shared/proc-monitor-bulk-import-actions-using-audit-logs.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-project-standardization-with-software-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-project-standardization-with-software-templates.adoc
@@ -6,13 +6,13 @@
 
 include::con-project-standardization-with-software-templates.adoc[leveloffset=+1]
 
-include::modules/shared/proc-create-a-basic-software-template.adoc[leveloffset=+1,navtitle="Create new Software Templates"]
+include::modules/shared/proc-create-a-basic-software-template.adoc[leveloffset=+1]
 
-include::modules/shared/ref-default-environment-parameters-and-secrets.adoc[leveloffset=+1,navtitle="Use sample templates"]
+include::modules/shared/ref-default-environment-parameters-and-secrets.adoc[leveloffset=+1]
 
-include::modules/shared/proc-share-software-templates-with-your-organization.adoc[leveloffset=+1,navtitle="Publish template definitions to the catalog"]
+include::modules/shared/proc-share-software-templates-with-your-organization.adoc[leveloffset=+1]
 
-include::modules/shared/ref-extending-software-templates-for-complex-project-requirements.adoc[leveloffset=+1,navtitle="Extend templates using conditional logic and external fetch capabilities"]
+include::modules/shared/ref-extending-software-templates-for-complex-project-requirements.adoc[leveloffset=+1]
 
 include::nav-version-software-templates-to-track-template-updates-and-dependencies.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/develop/nav-standardized-project-generation-with-software-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-standardized-project-generation-with-software-templates.adoc
@@ -6,8 +6,8 @@
 
 include::con-standardized-project-generation-with-software-templates.adoc[leveloffset=+1]
 
-include::modules/shared/con-software-templates-in-rhdh.adoc[leveloffset=+1,navtitle="Run Software Templates from the UI"]
+include::modules/shared/con-software-templates-in-rhdh.adoc[leveloffset=+1]
 
-include::modules/shared/ref-sample-software-template.adoc[leveloffset=+1,navtitle="Browse available templates"]
+include::modules/shared/ref-sample-software-template.adoc[leveloffset=+1]
 
 include::modules/shared/proc-share-software-templates-with-your-organization.adoc[leveloffset=+1,navtitle="Import an existing template file using the Catalog Processor"]

--- a/titles/product_product/category-maps/develop/nav-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
+++ b/titles/product_product/category-maps/develop/nav-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc
@@ -6,6 +6,6 @@
 
 include::con-track-component-provenance-to-map-dependencies-back-to-source-templates.adoc[leveloffset=+1]
 
-include::modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc[leveloffset=+1,navtitle="Configure provenance annotations"]
+include::modules/shared/proc-configure-provenance-and-software-template-versioning-rhdh.adoc[leveloffset=+1]
 
-include::modules/shared/proc-view-software-template-dependencies.adoc[leveloffset=+1,navtitle="View template dependencies in the catalog"]
+include::modules/shared/proc-view-software-template-dependencies.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-version-software-templates-to-track-template-updates-and-dependencies.adoc
+++ b/titles/product_product/category-maps/develop/nav-version-software-templates-to-track-template-updates-and-dependencies.adoc
@@ -6,6 +6,6 @@
 
 include::con-version-software-templates-to-track-template-updates-and-dependencies.adoc[leveloffset=+1]
 
-include::modules/shared/proc-version-a-software-template-in-rhdh.adoc[leveloffset=+1,navtitle="Version Software Templates"]
+include::modules/shared/proc-version-a-software-template-in-rhdh.adoc[leveloffset=+1]
 
-include::modules/shared/proc-enable-software-template-version-update-notifications-in-rhdh.adoc[leveloffset=+1,navtitle="Enable update notifications"]
+include::modules/shared/proc-enable-software-template-version-update-notifications-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/get-started/con-get-started.adoc
+++ b/titles/product_product/category-maps/get-started/con-get-started.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Get started
+= Get Started
 
 [role="_abstract"]
 Set up your first {product} instance, configure authentication, and navigate the platform interface to start using developer portal capabilities.

--- a/titles/product_product/category-maps/install/nav-deploy-on-kubernetes-platforms-using-helm-in-air-gapped-environments.adoc
+++ b/titles/product_product/category-maps/install/nav-deploy-on-kubernetes-platforms-using-helm-in-air-gapped-environments.adoc
@@ -6,6 +6,6 @@
 
 include::con-deploy-on-kubernetes-platforms-using-helm-in-air-gapped-environments.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-fully-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Mirror Helm images to deploy in fully disconnected Kubernetes networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-fully-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-partially-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Mirror Helm images to local registries for partially disconnected Kubernetes networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-a-supported-kubernetes-platform-in-a-partially-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-deploy-on-openshift-using-helm-in-an-air-gapped-environment.adoc
+++ b/titles/product_product/category-maps/install/nav-deploy-on-openshift-using-helm-in-an-air-gapped-environment.adoc
@@ -6,6 +6,6 @@
 
 include::con-deploy-on-openshift-using-helm-in-an-air-gapped-environment.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Mirror Helm images to deploy in fully disconnected OpenShift networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-fully-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Mirror Helm images to local registries for partially disconnected networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-on-ocp-in-a-partially-disconnected-environment-with-the-helm-chart.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-in-an-air-gapped-environment-using-the-operator.adoc
+++ b/titles/product_product/category-maps/install/nav-install-in-an-air-gapped-environment-using-the-operator.adoc
@@ -6,6 +6,6 @@
 
 include::con-install-in-an-air-gapped-environment-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc[leveloffset=+1,navtitle="Mirror Operator images to deploy in fully disconnected networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-fully-disconnected-environment-with-the-operator.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc[leveloffset=+1,navtitle="Mirror Operator images to local registries for partially disconnected networks"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/proc-install-rhdh-in-a-partially-disconnected-environment-with-the-operator.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-in-an-air-gapped-environment.adoc
+++ b/titles/product_product/category-maps/install/nav-install-in-an-air-gapped-environment.adoc
@@ -6,7 +6,7 @@
 
 include::con-install-in-an-air-gapped-environment.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-in-an-air-gapped-environment/con-air-gapped-environment.adoc[leveloffset=+1,navtitle="Isolated network deployments for air-gapped environments"]
+include::modules/install_installing-rhdh-in-an-air-gapped-environment/con-air-gapped-environment.adoc[leveloffset=+1]
 
 include::nav-install-in-an-air-gapped-environment-using-the-operator.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/install/nav-install-on-amazon-elastic-kubernetes-service-using-the-operator.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-amazon-elastic-kubernetes-service-using-the-operator.adoc
@@ -6,12 +6,12 @@
 
 include::con-install-on-amazon-elastic-kubernetes-service-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-install-the-operator-on-eks-by-using-olm.adoc[leveloffset=+1,navtitle="Install the Operator using OLM to automate deployments"]
+include::modules/shared/proc-install-the-operator-on-eks-by-using-olm.adoc[leveloffset=+1]
 
 include::modules/shared/proc-provision-your-custom-rhdh-configuration.adoc[leveloffset=+1,navtitle="Provision custom configuration files and secrets to your cluster"]
 
-include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1,navtitle="Provision a pull secret to access the container registry"]
+include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1]
 
 include::modules/shared/proc-use-the-rhdh-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1,navtitle="Apply the custom resource to initialize the platform"]
 
-include::modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc[leveloffset=+1,navtitle="Expose your Operator instance using an Ingress resource"]
+include::modules/shared/proc-expose-your-operator-based-instance-on-eks.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-on-google-kubernetes-engine-using-the-operator.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-google-kubernetes-engine-using-the-operator.adoc
@@ -6,12 +6,12 @@
 
 include::con-install-on-google-kubernetes-engine-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-install-the-operator-on-gke-by-using-olm.adoc[leveloffset=+1,navtitle="Install the Operator using OLM to automate deployments"]
+include::modules/shared/proc-install-the-operator-on-gke-by-using-olm.adoc[leveloffset=+1]
 
 include::modules/shared/proc-provision-your-custom-rhdh-configuration.adoc[leveloffset=+1,navtitle="Provision custom configuration files and secrets to your cluster"]
 
-include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1,navtitle="Provision a pull secret to access the container registry"]
+include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1]
 
 include::modules/shared/proc-use-the-rhdh-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1,navtitle="Apply the custom resource to initialize the platform"]
 
-include::modules/shared/proc-expose-your-operator-based-instance-on-gke.adoc[leveloffset=+1,navtitle="Expose your Operator instance using an Ingress resource"]
+include::modules/shared/proc-expose-your-operator-based-instance-on-gke.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-on-managed-hyperscaler-environments-to-integrate-with-cloud-resources.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-managed-hyperscaler-environments-to-integrate-with-cloud-resources.adoc
@@ -11,7 +11,7 @@ include::../../platform-eks.adoc[]
 
 include::nav-install-on-amazon-elastic-kubernetes-service-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Deploy on Amazon EKS using the Helm chart"]
+include::modules/shared/proc-deploy-on-eks-with-the-helm-chart.adoc[leveloffset=+1]
 
 // Restore platform attributes to OCP defaults
 include::../../platform-ocp.adoc[]
@@ -21,7 +21,7 @@ include::../../platform-gke.adoc[]
 
 include::nav-install-on-google-kubernetes-engine-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Deploy on GKE using the Helm chart"]
+include::modules/shared/proc-deploy-on-gke-with-the-helm-chart.adoc[leveloffset=+1]
 
 // Restore platform attributes to OCP defaults
 include::../../platform-ocp.adoc[]
@@ -31,11 +31,11 @@ include::../../platform-aks.adoc[]
 
 include::nav-install-on-microsoft-azure-kubernetes-service-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-deploy-rhdh-on-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Deploy on AKS using the Helm chart"]
+include::modules/shared/proc-deploy-rhdh-on-with-the-helm-chart.adoc[leveloffset=+1]
 
 // Restore platform attributes to OCP defaults
 include::../../platform-ocp.adoc[]
 
-include::modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-operator.adoc[leveloffset=+1,navtitle="Install on OpenShift Dedicated using the Operator"]
+include::modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-helm-chart.adoc[leveloffset=+1,navtitle="Deploy on OpenShift Dedicated using the Helm chart"]
+include::modules/install_installing-rhdh-on-osd-on-gcp/proc-install-rhdh-on-on-using-the-helm-chart.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-on-microsoft-azure-kubernetes-service-using-the-operator.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-microsoft-azure-kubernetes-service-using-the-operator.adoc
@@ -6,12 +6,12 @@
 
 include::con-install-on-microsoft-azure-kubernetes-service-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-install-the-operator-on-aks-by-using-olm.adoc[leveloffset=+1,navtitle="Install the Operator using OLM to automate deployments"]
+include::modules/shared/proc-install-the-operator-on-aks-by-using-olm.adoc[leveloffset=+1]
 
 include::modules/shared/proc-provision-your-custom-rhdh-configuration.adoc[leveloffset=+1,navtitle="Provision custom configuration files and secrets to your cluster"]
 
-include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1,navtitle="Provision a pull secret to access the container registry"]
+include::modules/shared/proc-provision-your-pull-secret-to-your-rhdh-instance-namespace.adoc[leveloffset=+1]
 
 include::modules/shared/proc-use-the-rhdh-operator-to-run-rhdh-with-your-custom-configuration.adoc[leveloffset=+1,navtitle="Apply the custom resource to initialize the platform"]
 
-include::modules/shared/proc-expose-your-operator-based-instance-on-aks.adoc[leveloffset=+1,navtitle="Expose your Operator instance using an Ingress resource"]
+include::modules/shared/proc-expose-your-operator-based-instance-on-aks.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-to-leverage-existing-red-hat-infrastructure.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-to-leverage-existing-red-hat-infrastructure.adoc
@@ -6,7 +6,7 @@
 
 include::con-install-on-openshift-container-platform-to-leverage-existing-red-hat-infrastructure.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-on-ocp/con-rhdh-installation-methods-on-ocp.adoc[leveloffset=+1,navtitle="Compare the Helm chart and Operator deployment methods"]
+include::modules/install_installing-rhdh-on-ocp/con-rhdh-installation-methods-on-ocp.adoc[leveloffset=+1]
 
 include::nav-install-on-openshift-container-platform-using-the-operator.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-using-the-helm-chart.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-using-the-helm-chart.adoc
@@ -6,6 +6,6 @@
 
 include::con-install-on-openshift-container-platform-using-the-helm-chart.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-from-the-ocp-web-console-with-the-helm-chart.adoc[leveloffset=+1,navtitle="Deploy from the web console"]
+include::modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-from-the-ocp-web-console-with-the-helm-chart.adoc[leveloffset=+1]
 
-include::modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-on-ocp-with-the-helm-cli.adoc[leveloffset=+1,navtitle="Deploy with the Helm CLI"]
+include::modules/install_installing-rhdh-on-ocp/proc-deploy-rhdh-on-ocp-with-the-helm-cli.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-using-the-operator.adoc
+++ b/titles/product_product/category-maps/install/nav-install-on-openshift-container-platform-using-the-operator.adoc
@@ -6,6 +6,6 @@
 
 include::con-install-on-openshift-container-platform-using-the-operator.adoc[leveloffset=+1]
 
-include::modules/shared/proc-install-the-rhdh-operator.adoc[leveloffset=+1,navtitle="Install the Operator"]
+include::modules/shared/proc-install-the-rhdh-operator.adoc[leveloffset=+1]
 
 include::modules/shared/proc-provision-your-custom-rhdh-configuration.adoc[leveloffset=+1,navtitle="Deploy the instance"]

--- a/titles/product_product/category-maps/plan/nav-compare-the-helm-chart-and-operator-deployment-methods.adoc
+++ b/titles/product_product/category-maps/plan/nav-compare-the-helm-chart-and-operator-deployment-methods.adoc
@@ -6,4 +6,4 @@
 
 include::con-compare-the-helm-chart-and-operator-deployment-methods.adoc[leveloffset=+1]
 
-include::modules/discover_about-rhdh/con-compare-the-helm-chart-and-operator-to-choose-the-optimal-deployment-method.adoc[leveloffset=+1,navtitle="Pros and cons of each deployment method"]
+include::modules/discover_about-rhdh/con-compare-the-helm-chart-and-operator-to-choose-the-optimal-deployment-method.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/plan/nav-sizing-requirements-for-cluster-resource-provisioning.adoc
+++ b/titles/product_product/category-maps/plan/nav-sizing-requirements-for-cluster-resource-provisioning.adoc
@@ -6,4 +6,4 @@
 
 include::con-sizing-requirements-for-cluster-resource-provisioning.adoc[leveloffset=+1]
 
-include::modules/discover_about-rhdh/ref-sizing-requirements-for-rhdh.adoc[leveloffset=+1,navtitle="Compute and storage resource guidelines"]
+include::modules/discover_about-rhdh/ref-sizing-requirements-for-rhdh.adoc[leveloffset=+1]


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge** — check the preview links and resolve all review comments first.

## Version(s)

All

## Issue

N/A (JTBD migration follow-up)

## Preview

N/A

## Summary

Companion to PR #2431 (chapters 9-16). Same transformation for chapters 1-8 (Discover through Develop):

- Update 65 module `= Title` headings to match their JTBD titles from `jtbd-toc-mapping.tsv`
- Remove 74 now-redundant `navtitle` attributes from nav file includes
- Fix "Get started" → "Get Started" capitalization in 1 MAP concept file
- Handle 3 conflict cases (module with different titles in different nav files — broader title becomes `= Title`, alternate kept as `navtitle` override)
- 5 cross-chapter modules (shared with ch 9-16) left unchanged — their ch 1-8 navtitle overrides remain intact

97 files changed, 140 insertions, 140 deletions (pure title-line replacements, no content or ID changes).

Build validation: 36/36 titles pass ccutil, 0 link errors.