### PR TITLE
JTBD: Add 82 missing modules to product_product MAP structure

### DIFF
--- a/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
@@ -10,9 +10,11 @@ include::nav-default-configurations-to-establish-a-deployment-foundation.adoc[le
 
 include::nav-provision-custom-config-maps-and-secrets-to-define-platform-behavior.adoc[leveloffset=+1]
 
-include::modules/configure_configuring-rhdh/proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc[leveloffset=+1]
+include::modules/shared/proc-customize-your-rhdh-base-url.adoc[leveloffset=+1,navtitle="Configure the base URL to route frontend and backend traffic"]
 
 include::modules/configure_configuring-rhdh/con-rhdh-secrets.adoc[leveloffset=+1]
+
+include::modules/shared/proc-customize-rhdh-backend-secret.adoc[leveloffset=+1,navtitle="Generate and configure the backend secret"]
 
 include::modules/configure_configuring-rhdh/proc-inject-extra-files-and-environment-variables-into-containers.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/configure/nav-configure-language-localization-to-improve-accessibility-for-global-users.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-language-localization-to-improve-accessibility-for-global-users.adoc
@@ -6,6 +6,10 @@
 
 include::con-configure-language-localization-to-improve-accessibility-for-global-users.adoc[leveloffset=+1]
 
+include::modules/shared/con-language-detection.adoc[leveloffset=+1]
+
+include::modules/shared/con-language-persistence.adoc[leveloffset=+1]
+
 include::nav-enable-the-localization-framework.adoc[leveloffset=+1]
 
 include::modules/shared/ref-best-practices-for-implementing-localization-support-for-custom-plugins-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-sidebar-navigation-and-tabs-to-organize-essential-tools.adoc
@@ -13,3 +13,5 @@ include::nav-customize-the-sidebar-menu-items.adoc[leveloffset=+1]
 include::modules/shared/proc-configure-entity-tab-titles.adoc[leveloffset=+1]
 
 include::modules/shared/proc-configure-entity-detail-tab-layout.adoc[leveloffset=+1]
+
+include::modules/shared/proc-customize-the-sidebar-menu-items-for-your-rhdh-instance.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/configure/nav-customize-the-user-interface-to-reflect-organizational-branding.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-the-user-interface-to-reflect-organizational-branding.adoc
@@ -6,7 +6,7 @@
 
 include::con-customize-the-user-interface-to-reflect-organizational-branding.adoc[leveloffset=+1]
 
-// TODO: include Customize the display title
+include::modules/shared/proc-customize-your-rhdh-title.adoc[leveloffset=+1,navtitle="Customize the display title"]
 
 include::nav-customize-learning-paths-to-integrate-tailored-e-learning-content.adoc[leveloffset=+1]
 
@@ -26,4 +26,4 @@ include::nav-customize-the-home-page-layout-to-optimize-developer-workflows.adoc
 
 include::nav-configure-quick-access-cards-to-surface-frequently-used-links.adoc[leveloffset=+1]
 
-// TODO: include Customize the Metadata card to display internal build information
+include::modules/shared/proc-customize-the-rhdh-metadata-card-on-the-settings-page.adoc[leveloffset=+1,navtitle="Customize the Metadata card to display internal build information"]

--- a/titles/product_product/category-maps/configure/nav-customize-themes-and-branding-to-align-with-corporate-standards.adoc
+++ b/titles/product_product/category-maps/configure/nav-customize-themes-and-branding-to-align-with-corporate-standards.adoc
@@ -19,3 +19,7 @@ include::modules/shared/proc-customize-the-font-for-your-rhdh-instance.adoc[leve
 include::modules/shared/proc-load-a-custom-rhdh-theme-by-using-a-dynamic-plugin.adoc[leveloffset=+1]
 
 include::modules/shared/ref-custom-component-options-for-your-rhdh-instance.adoc[leveloffset=+1]
+
+include::modules/shared/ref-default-rhdh-theme.adoc[leveloffset=+1]
+
+include::modules/shared/ref-default-theme.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-automate-repository-onboarding-to-the-catalog.adoc
+++ b/titles/product_product/category-maps/develop/nav-automate-repository-onboarding-to-the-catalog.adoc
@@ -9,3 +9,5 @@ include::con-automate-repository-onboarding-to-the-catalog.adoc[leveloffset=+1]
 include::nav-import-source-code-repositories-in-bulk.adoc[leveloffset=+1]
 
 include::nav-configure-bulk-import-capabilities.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-github-repository-discovery.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-configure-techdocs-storage-and-cicd-pipelines.adoc
+++ b/titles/product_product/category-maps/develop/nav-configure-techdocs-storage-and-cicd-pipelines.adoc
@@ -6,6 +6,12 @@
 
 include::con-configure-techdocs-storage-and-cicd-pipelines.adoc[leveloffset=+1]
 
+include::modules/shared/proc-create-standalone-documentation-in-techdocs.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-documentation-for-an-existing-entity.adoc[leveloffset=+1]
+
 include::modules/configure_techdocs-for-rhdh/con-configuring-storage-for-techdocs-files.adoc[leveloffset=+1]
 
 include::nav-configure-amazon-s3-or-openshift-data-foundation-buckets.adoc[leveloffset=+1]
+
+include::modules/shared/proc-streamline-documentation-builds-using-github-actions.adoc[leveloffset=+1,navtitle="Automate builds with GitHub Actions"]

--- a/titles/product_product/category-maps/develop/nav-import-source-code-repositories-in-bulk.adoc
+++ b/titles/product_product/category-maps/develop/nav-import-source-code-repositories-in-bulk.adoc
@@ -12,6 +12,8 @@ include::modules/shared/proc-enable-and-authorize-bulk-import-capabilities-in-rh
 
 include::modules/shared/proc-import-multiple-github-repositories.adoc[leveloffset=+1]
 
+include::modules/shared/proc-import-multiple-gitlab-repositories.adoc[leveloffset=+1]
+
 include::modules/develop_streamline-software-development-and-management-in-rhdh/proc-manage-the-added-git-repositories.adoc[leveloffset=+1]
 
 include::modules/shared/proc-monitor-bulk-import-actions-using-audit-logs.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/develop/nav-register-new-software-components.adoc
+++ b/titles/product_product/category-maps/develop/nav-register-new-software-components.adoc
@@ -9,3 +9,5 @@ include::con-register-new-software-components.adoc[leveloffset=+1]
 include::modules/shared/proc-create-new-components-in-your-rhdh-instance.adoc[leveloffset=+1]
 
 include::modules/shared/proc-register-components-manually-in-your-rhdh-instance.adoc[leveloffset=+1]
+
+include::modules/shared/proc-add-new-components-to-your-rhdh-instance.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: CONCEPT
+
+= Build a private knowledge base with {ls-short} Notebooks
+
+[role="_abstract"]
+Use {ls-short} notebooks to create isolated research environments. These workspaces allow you to analyze project data securely by using a large language model (LLM) grounded in your specific documentation.
+
+include::../../artifacts/snip-developer-preview.adoc[]

--- a/titles/product_product/category-maps/discover/con-evaluate-ai-model-accuracy-and-response-quality.adoc
+++ b/titles/product_product/category-maps/discover/con-evaluate-ai-model-accuracy-and-response-quality.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: CONCEPT
+
+= AI model evaluation data to select the right AI model
+
+[role="_abstract"]
+Use the {ls-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ls-short}.
+
+With this automated toolset, you can measure how effectively various large language models (LLMs) answer questions based on {product} documentation.
+
+.Components of the evaluation framework
+[cols="1,3",options="header"]
+|===
+| Component | Description
+| Evaluation framework | Contains the core logic and scripts used to run evaluations.
+| Datasets | Includes the input files used to test the model.
+| Evaluation metrics integration | Provides scoring through various metrics, including Ragas, DeepEval, and custom metrics. Ragas is the primary metric used to validate {ls-short} performance.
+|===

--- a/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: MAP
+
+[id="build-a-private-knowledge-base-with-lightspeed-notebooks_{context}"]
+= Build a private knowledge base with {ls-short} Notebooks
+:context: build-a-private-knowledge-base-with-lightspeed-notebooks
+
+include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-isolated-research-workspaces.adoc[leveloffset=+1]
+
+include::modules/shared/proc-provide-project-context-to-the-ai.adoc[leveloffset=+1]
+
+include::modules/shared/proc-extract-and-verify-document-based-insights.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
@@ -6,4 +6,16 @@
 
 include::con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc[leveloffset=+1]
 
+include::modules/shared/con-chat-assistance-with.adoc[leveloffset=+1]
+
+include::modules/shared/con-ai-response-monitoring-and-context-management.adoc[leveloffset=+1]
+
+include::modules/shared/con-ai-reference-and-tool-calling-capabilities-through.adoc[leveloffset=+1]
+
 include::modules/shared/con-architecture-for-your-ai-backend-deployment.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-safety-guards-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-manage-chats.adoc[leveloffset=+1]
+
+include::modules/shared/ref-best-results-for-assistant-queries.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/nav-evaluate-ai-model-accuracy-and-response-quality.adoc
+++ b/titles/product_product/category-maps/discover/nav-evaluate-ai-model-accuracy-and-response-quality.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: MAP
+
+[id="ai-model-evaluation-data-to-select-the-right-ai-model_{context}"]
+= AI model evaluation data to select the right AI model
+:context: ai-model-evaluation-data-to-select-the-right-ai-model
+
+include::con-evaluate-ai-model-accuracy-and-response-quality.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-the-evaluation-environment-to-validate-model-accuracy.adoc[leveloffset=+1]
+
+include::modules/shared/proc-prepare-evaluation-datasets-to-verify-ai-generated-responses.adoc[leveloffset=+1]
+
+include::modules/shared/proc-run-performance-tests-to-ensure-ai-response-reliability.adoc[leveloffset=+1]
+
+include::modules/shared/proc-analyze-evaluation-results-to-identify-performance-gaps.adoc[leveloffset=+1]
+
+include::modules/shared/ref-evaluation-metrics-and-historical-data-reference.adoc[leveloffset=+1]
+
+include::modules/shared/ref-release-report-and-historical-data.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/nav-evaluate-rhdh-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/nav-evaluate-rhdh-capabilities.adoc
@@ -12,6 +12,10 @@ include::nav-system-architecture-for-deployment-strategy-planning.adoc[leveloffs
 
 include::nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc[leveloffset=+1]
 
+include::nav-evaluate-ai-model-accuracy-and-response-quality.adoc[leveloffset=+1]
+
+include::nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
+
 include::nav-platform-integrations-for-toolchain-connectivity.adoc[leveloffset=+1]
 
 include::modules/discover_about-rhdh/ref-supported-platforms.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
+++ b/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="platform-integrations-for-toolchain-connectivity_{context}"]
+[id="platform-integrations-for-toolchain-connectivity_developer-lightspeed-ai-virtual-assistant-capabilities"]
 = Platform integrations for toolchain connectivity
 :context: platform-integrations-for-toolchain-connectivity
 

--- a/titles/product_product/category-maps/extend/nav-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
+++ b/titles/product_product/category-maps/extend/nav-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc
@@ -6,6 +6,8 @@
 
 include::con-configure-core-front-end-wiring-for-navigation-and-ui-components.adoc[leveloffset=+1]
 
+include::modules/shared/con-front-end-plugin-wiring.adoc[leveloffset=+1]
+
 include::nav-requirements-and-workflows-for-front-end-plugin-wiring.adoc[leveloffset=+1]
 
 include::modules/shared/con-dynamic-front-end-plugins-for-application-use.adoc[leveloffset=+1]
@@ -15,3 +17,7 @@ include::modules/shared/proc-extend-internal-icon-catalog.adoc[leveloffset=+1]
 include::modules/shared/proc-define-dynamic-routes-for-new-plugin-pages.adoc[leveloffset=+1]
 
 include::modules/shared/ref-customizing-menu-items-in-the-sidebar-navigation.adoc[leveloffset=+1]
+
+include::modules/shared/ref-using-mount-points.adoc[leveloffset=+1]
+
+include::modules/shared/proc-display-the-front-end-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
+++ b/titles/product_product/category-maps/extend/nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc
@@ -7,3 +7,5 @@
 include::con-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-factory.adoc[leveloffset=+1]
 
 include::modules/shared/con-use-the-dynamic-plugin-factory-to-convert-plugins-into-dynamic-plugins.adoc[leveloffset=+1]
+
+include::modules/shared/proc-convert-a-custom-plugin-into-a-dynamic-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
+++ b/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
@@ -16,8 +16,9 @@ include::nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+
 
 include::modules/shared/proc-verify-plugins-locally.adoc[leveloffset=+1]
 
-// Backward-compatible anchor for xrefs using the old assembly context
-[id="export-plugins-in-rhdh_plugins-in-rhdh"]
+// Temporarily set old context for backward-compatible module IDs
+:context: plugins-in-rhdh
 include::modules/shared/proc-export-plugins-in-rhdh.adoc[leveloffset=+1]
+:context: develop-custom-dynamic-plugins-to-support-custom-workflows
 
 include::modules/shared/proc-override-core-backend-service-configuration.adoc[leveloffset=+1,navtitle="Override core backend services"]

--- a/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
+++ b/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
@@ -15,3 +15,7 @@ include::nav-convert-standard-plugins-into-dynamic-plugins-using-the-plugin-fact
 include::nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+1]
 
 include::modules/shared/proc-verify-plugins-locally.adoc[leveloffset=+1]
+
+include::modules/shared/proc-export-plugins-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-override-core-backend-service-configuration.adoc[leveloffset=+1,navtitle="Override core backend services"]

--- a/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
+++ b/titles/product_product/category-maps/extend/nav-develop-custom-dynamic-plugins-to-support-custom-workflows.adoc
@@ -16,6 +16,8 @@ include::nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+
 
 include::modules/shared/proc-verify-plugins-locally.adoc[leveloffset=+1]
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="export-plugins-in-rhdh_plugins-in-rhdh"]
 include::modules/shared/proc-export-plugins-in-rhdh.adoc[leveloffset=+1]
 
 include::modules/shared/proc-override-core-backend-service-configuration.adoc[leveloffset=+1,navtitle="Override core backend services"]

--- a/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
@@ -20,4 +20,6 @@ include::modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environmen
 
 include::nav-mirror-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="example-of-installing-a-custom-plugin-in-rhdh_plugins-in-rhdh"]
 include::modules/shared/proc-example-of-installing-a-custom-plugin-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
@@ -20,6 +20,7 @@ include::modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environmen
 
 include::nav-mirror-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]
 
-// Backward-compatible anchor for xrefs using the old assembly context
-[id="example-of-installing-a-custom-plugin-in-rhdh_plugins-in-rhdh"]
+// Temporarily set old context for backward-compatible module IDs
+:context: plugins-in-rhdh
 include::modules/shared/proc-example-of-installing-a-custom-plugin-in-rhdh.adoc[leveloffset=+1]
+:context: install-dynamic-plugins

--- a/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-install-dynamic-plugins.adoc
@@ -6,6 +6,8 @@
 
 include::con-install-dynamic-plugins.adoc[leveloffset=+1]
 
+include::modules/shared/con-dynamic-plugins.adoc[leveloffset=+1]
+
 include::nav-install-with-operator.adoc[leveloffset=+1]
 
 include::modules/shared/con-dynamic-plugins-dependency-management.adoc[leveloffset=+1]
@@ -17,3 +19,5 @@ include::modules/shared/ref-install-dynamic-plugins-in-an-air-gapped-environment
 include::modules/shared/proc-install-dynamic-plugins-in-an-air-gapped-environment-by-using-the-operator.adoc[leveloffset=+1]
 
 include::nav-mirror-dynamic-plugins-in-disconnected-environments.adoc[leveloffset=+1]
+
+include::modules/shared/proc-example-of-installing-a-custom-plugin-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-manage-plugins.adoc
+++ b/titles/product_product/category-maps/extend/nav-manage-plugins.adoc
@@ -12,6 +12,10 @@ include::modules/shared/proc-configure-an-rhdh-development-environment-to-instal
 
 include::modules/shared/proc-view-available-plugins.adoc[leveloffset=+1]
 
+include::modules/shared/proc-search-for-plugins-by-name.adoc[leveloffset=+1]
+
+include::modules/shared/proc-view-installed-plugins.adoc[leveloffset=+1]
+
 include::modules/shared/proc-install-plugins-by-using-extensions.adoc[leveloffset=+1]
 
 include::modules/shared/proc-configure-rhdh-local-to-install-plugins-by-using-extensions.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/extend/nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc
+++ b/titles/product_product/category-maps/extend/nav-package-and-deploy-dynamic-plugins-as-oci-images.adoc
@@ -7,4 +7,16 @@
 
 include::con-package-and-deploy-dynamic-plugins-as-oci-images.adoc[leveloffset=+1]
 
-include::modules/shared/proc-add-a-dynamic-plugin-to-rhdh.adoc[leveloffset=+1]
+include::modules/shared/proc-add-a-dynamic-plugin-to-rhdh.adoc[leveloffset=+1,navtitle="Deploy custom dynamic plugins"]
+
+include::modules/shared/proc-add-a-custom-dynamic-plugin-to-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-load-a-plugin-packaged-as-a-javascript-package.adoc[leveloffset=+1]
+
+include::modules/shared/proc-load-a-plugin-packaged-as-a-tgz-file.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-javascript-package-with-dynamic-packages.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-tgz-file-with-dynamic-packages.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-an-oci-image-with-dynamic-packages.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/get-started/nav-import-and-use-an-existing-software-template-for-faster-development.adoc
+++ b/titles/product_product/category-maps/get-started/nav-import-and-use-an-existing-software-template-for-faster-development.adoc
@@ -5,3 +5,9 @@
 :context: import-and-use-an-existing-software-template-for-faster-development
 
 include::con-import-and-use-an-existing-software-template-for-faster-development.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-software-component-using-software-templates.adoc[leveloffset=+1,navtitle="Create a software component from a template"]
+
+include::modules/shared/proc-import-an-existing-software-template.adoc[leveloffset=+1]
+
+include::modules/shared/proc-search-and-filter-software-templates-in-your-rhdh-instance.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate.adoc
+++ b/titles/product_product/category-maps/integrate.adoc
@@ -9,3 +9,9 @@ include::integrate/con-integrate.adoc[leveloffset=+1]
 include::integrate/nav-enable-ai-assistance-for-developers.adoc[leveloffset=+1]
 
 include::integrate/nav-integrate-cicd-and-infrastructure-tools-to-visualize-pipelines-and-workloads.adoc[leveloffset=+1]
+
+include::integrate/nav-extend-software-templates-with-kubernetes-custom-actions.adoc[leveloffset=+1]
+
+include::integrate/nav-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc[leveloffset=+1]
+
+include::integrate/nav-enable-ansible-plugins-for-automation-workflows.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/con-enable-ansible-plugins-for-automation-workflows.adoc
+++ b/titles/product_product/category-maps/integrate/con-enable-ansible-plugins-for-automation-workflows.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: CONCEPT
+
+= Enable Ansible plugins for automation workflows
+
+[role="_abstract"]
+Use the Ansible plugins for {product} to integrate Ansible Automation Platform capabilities into your developer portal.

--- a/titles/product_product/category-maps/integrate/con-extend-software-templates-with-kubernetes-custom-actions.adoc
+++ b/titles/product_product/category-maps/integrate/con-extend-software-templates-with-kubernetes-custom-actions.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: CONCEPT
+
+= Kubernetes custom actions in {product}
+
+[role="_abstract"]
+You can create and manage Kubernetes resources by using custom scaffolder actions in {product} templates. The Kubernetes custom actions plugin is preinstalled in a disabled state.

--- a/titles/product_product/category-maps/integrate/con-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc
+++ b/titles/product_product/category-maps/integrate/con-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+
+= ServiceNow custom actions in {product}
+
+[role="_abstract"]
+Integrate ServiceNow with {product} to manage ServiceNow records by using Scaffolder actions and view ServiceNow data on entity pages.
+
+In {product}, you can use `ServiceNow` custom actions to fetch and register resources within the catalog.
+
+The custom actions in {product-short} help you automate the management of records. By using the custom actions, you can:
+
+* Create, update, or delete a record
+* Retrieve information about a single record or many records
+
+The `ServiceNow` custom actions plugin is community-sourced.

--- a/titles/product_product/category-maps/integrate/nav-enable-ansible-plugins-for-automation-workflows.adoc
+++ b/titles/product_product/category-maps/integrate/nav-enable-ansible-plugins-for-automation-workflows.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+[id="enable-ansible-plugins-for-automation-workflows_{context}"]
+= Enable Ansible plugins for automation workflows
+:context: enable-ansible-plugins-for-automation-workflows
+
+include::con-enable-ansible-plugins-for-automation-workflows.adoc[leveloffset=+1]
+
+include::modules/shared/con-installing-ansible-plugins-for-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/con-using-ansible-plug-ins-for-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-extend-software-templates-with-kubernetes-custom-actions.adoc
+++ b/titles/product_product/category-maps/integrate/nav-extend-software-templates-with-kubernetes-custom-actions.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: MAP
+
+[id="kubernetes-custom-actions-in-rhdh_{context}"]
+= Extend software templates with Kubernetes custom actions
+:context: kubernetes-custom-actions-in-rhdh
+
+include::con-extend-software-templates-with-kubernetes-custom-actions.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-kubernetes-custom-actions-plugin-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-kubernetes-custom-actions-plugin-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-create-a-template-using-kubernetes-custom-actions-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/ref-supported-kubernetes-custom-actions-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-integrate-cicd-and-infrastructure-tools-to-visualize-pipelines-and-workloads.adoc
+++ b/titles/product_product/category-maps/integrate/nav-integrate-cicd-and-infrastructure-tools-to-visualize-pipelines-and-workloads.adoc
@@ -14,6 +14,10 @@ include::nav-manage-identity-data-by-integrating-keycloak.adoc[leveloffset=+1]
 
 include::nav-view-build-artifacts-using-nexus-repository-manager.adoc[leveloffset=+1]
 
-include::modules/shared/proc-enable-the-tekton-plugin.adoc[leveloffset=+1]
+include::modules/shared/proc-enable-the-tekton-plugin.adoc[leveloffset=+1,navtitle="Enable the Tekton plugin"]
+
+include::modules/shared/proc-use-the-tekton-plugin.adoc[leveloffset=+1]
 
 include::nav-visualize-kubernetes-workloads-and-pod-health-with-topology.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-the-github-events-module-plugin.adoc[leveloffset=+1,navtitle="Configure the GitHub Events Module for real-time updates"]

--- a/titles/product_product/category-maps/integrate/nav-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc
+++ b/titles/product_product/category-maps/integrate/nav-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: MAP
+
+[id="servicenow-custom-actions-in-rhdh_{context}"]
+= Integrate ServiceNow for incident management and scaffolder actions
+:context: servicenow-custom-actions-in-rhdh
+
+include::con-integrate-servicenow-for-incident-management-and-scaffolder-actions.adoc[leveloffset=+1]
+
+include::modules/shared/con-servicenow-entity-linking-methods.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-servicenow-custom-actions-plugin-in-rhdh.adoc[leveloffset=+1]
+
+include::modules/shared/proc-configure-the-servicenow-plugin-in-the-configmap.adoc[leveloffset=+1]
+
+include::modules/shared/proc-link-servicenow-tickets-to-catalog-entities.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-servicenow-scaffolder-actions-in-software-templates.adoc[leveloffset=+1]
+
+include::modules/shared/ref-servicenow-configuration-parameters.adoc[leveloffset=+1]
+
+include::modules/shared/ref-supported-servicenow-custom-actions-in-rhdh.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-manage-identity-data-by-integrating-keycloak.adoc
+++ b/titles/product_product/category-maps/integrate/nav-manage-identity-data-by-integrating-keycloak.adoc
@@ -11,3 +11,5 @@ include::modules/shared/proc-enable-the-keycloak-plugin.adoc[leveloffset=+1]
 include::modules/shared/proc-configure-the-keycloak-plugin.adoc[leveloffset=+1]
 
 include::modules/shared/ref-keycloak-plugin-metrics.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-keycloak.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-track-build-artifacts-using-the-jfrog-plugin.adoc
+++ b/titles/product_product/category-maps/integrate/nav-track-build-artifacts-using-the-jfrog-plugin.adoc
@@ -9,3 +9,5 @@ include::con-track-build-artifacts-using-the-jfrog-plugin.adoc[leveloffset=+1]
 include::modules/shared/proc-enable-the-jfrog-artifactory-plugin.adoc[leveloffset=+1]
 
 include::modules/shared/proc-configure-the-jfrog-artifactory-plugin.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-the-jfrog-artifactory-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-track-deployment-history-and-rollouts-with-argo-cd.adoc
+++ b/titles/product_product/category-maps/integrate/nav-track-deployment-history-and-rollouts-with-argo-cd.adoc
@@ -9,3 +9,5 @@ include::con-track-deployment-history-and-rollouts-with-argo-cd.adoc[leveloffset
 include::modules/shared/proc-enable-the-argo-cd-plugin.adoc[leveloffset=+1]
 
 include::modules/shared/proc-enable-argo-cd-rollouts.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-the-argo-cd-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-view-build-artifacts-using-nexus-repository-manager.adoc
+++ b/titles/product_product/category-maps/integrate/nav-view-build-artifacts-using-nexus-repository-manager.adoc
@@ -9,3 +9,5 @@ include::con-view-build-artifacts-using-nexus-repository-manager.adoc[leveloffse
 include::modules/shared/proc-enable-the-nexus-repository-manager-plugin.adoc[leveloffset=+1]
 
 include::modules/shared/proc-configure-the-nexus-repository-manager-plugin.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-the-nexus-repository-manager-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-visualize-kubernetes-workloads-and-pod-health-with-topology.adoc
+++ b/titles/product_product/category-maps/integrate/nav-visualize-kubernetes-workloads-and-pod-health-with-topology.adoc
@@ -21,3 +21,7 @@ include::modules/shared/proc-add-a-label-selector-query-annotation.adoc[leveloff
 include::modules/shared/proc-display-a-runtime-icon-in-the-topology-node.adoc[leveloffset=+1]
 include::modules/shared/proc-group-applications-in-the-topology-view.adoc[leveloffset=+1]
 include::modules/shared/proc-node-connector.adoc[leveloffset=+1]
+
+include::modules/shared/proc-use-the-topology-plugin.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-users-to-use-the-topology-plugin.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/migrate.adoc
+++ b/titles/product_product/category-maps/migrate.adoc
@@ -7,3 +7,5 @@
 include::migrate/con-migrate.adoc[leveloffset=+1]
 
 include::migrate/nav-migrate-from-a-local-database-to-an-external-postgresql-server.adoc[leveloffset=+1]
+
+include::migrate/nav-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/migrate/con-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
+++ b/titles/product_product/category-maps/migrate/con-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: CONCEPT
+
+= Migrate to the front-end system to use blueprint-based dynamic routing
+
+[role="_abstract"]
+Migrate your {product} environment to the extension-based front-end system to use blueprint-based dynamic routing for improved extensibility and performance.
+
+include::../../artifacts/snip-developer-preview.adoc[]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.9/html/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/get-ai-assisted-help-for-your-development-tasks_interacting-with-developer-lightspeed-for-rhdh[Get AI-assisted help for your development tasks]

--- a/titles/product_product/category-maps/migrate/nav-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
+++ b/titles/product_product/category-maps/migrate/nav-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: MAP
+
+[id="migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing_{context}"]
+= Migrate to the front-end system to use blueprint-based dynamic routing
+:context: migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing
+
+include::con-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc[leveloffset=+1]
+
+include::modules/shared/proc-customize-platform-appearance-to-reflect-your-brand-identity.adoc[leveloffset=+1]
+
+include::modules/shared/proc-update-global-header-mount-points-to-integrate-securely-with-the-new-blueprint-architecture.adoc[leveloffset=+1]
+
+include::modules/shared/proc-add-navigation-shortcuts-to-reduce-clicks-to-frequently-used-resources.adoc[leveloffset=+1]
+
+include::modules/shared/proc-add-plugin-specific-buttons-to-the-toolbar-for-quick-actions.adoc[leveloffset=+1]
+
+include::modules/shared/proc-add-plugin-links-to-drop-down-menus-to-organize-navigation-access.adoc[leveloffset=+1]
+
+include::modules/shared/proc-reorganize-or-remove-header-items-to-align-with-your-team-priorities.adoc[leveloffset=+1]
+
+include::modules/shared/proc-migrate-the-homepage-to-function-as-a-dynamic-plugin-loaded-through-blueprints.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-guided-tutorials-to-learn-platform-features.adoc[leveloffset=+1]
+
+include::modules/shared/proc-preserve-custom-integrations-when-migrating-to-the-front-end-system.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/secure/nav-define-authorization-policies-to-restrict-access-based-on-user-roles.adoc
+++ b/titles/product_product/category-maps/secure/nav-define-authorization-policies-to-restrict-access-based-on-user-roles.adoc
@@ -6,6 +6,8 @@
 
 include::con-define-authorization-policies-to-restrict-access-based-on-user-roles.adoc[leveloffset=+1]
 
+include::modules/shared/con-role-based-access-control-in-rhdh.adoc[leveloffset=+1]
+
 include::modules/shared/proc-enable-and-give-access-to-the-role-based-access-control-rbac-feature.adoc[leveloffset=+1]
 
 include::modules/shared/proc-determine-permission-policy-and-role-configuration-source.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/secure/nav-import-users-and-groups-to-synchronize-enterprise-directory-data.adoc
+++ b/titles/product_product/category-maps/secure/nav-import-users-and-groups-to-synchronize-enterprise-directory-data.adoc
@@ -15,3 +15,5 @@ include::nav-import-users-and-groups-from-github.adoc[leveloffset=+1]
 include::nav-import-users-and-groups-from-microsoft-azure.adoc[leveloffset=+1]
 
 include::nav-import-users-and-groups-from-gitlab.adoc[leveloffset=+1]
+
+include::modules/shared/proc-enable-transitive-parent-groups.adoc[leveloffset=+1,navtitle="Enable transitive parent group resolution"]

--- a/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automation.adoc
+++ b/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automation.adoc
@@ -8,4 +8,6 @@ include::con-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automa
 
 include::modules/extend_orchestrator-in-rhdh/proc-resolve-pod-startup-failure-when-upgrading-to-rhdh-1-8-6-with-orchestrator.adoc[leveloffset=+1]
 
+include::modules/shared/proc-troubleshoot-a-pod-startup-failure-after-enabling-a-plugin.adoc[leveloffset=+1]
+
 include::nav-diagnose-serverless-workflow-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10+
**Issue:** N/A (JTBD migration completeness)
**Preview:** https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-PENDING/product_product/

## Summary

- Add all 82 modules from `modules/shared/` that were not yet included in the `product_product` JTBD MAP structure
- Create 12 new files (6 nav + 6 concept) for K8s custom actions, ServiceNow, Ansible plugins, front-end blueprint migration, AI model evaluation, and Lightspeed notebooks
- Add module includes to 29 existing nav files across 10 categories (configure, develop, discover, extend, get-started, integrate, migrate, secure, troubleshoot)
- Fix 2 TODOs and 1 wrong module reference in existing nav files

## Test plan

- [ ] Verify HTML build completes for `product_product`
- [ ] Verify no "Unknown ID" errors in xref resolution
- [ ] Spot-check new integration sections (K8s, ServiceNow, Ansible)
- [ ] Spot-check front-end migration nav under Migrate category
- [ ] Spot-check AI evaluation and notebooks navs under Discover category

🤖 Generated with [Claude Code](https://claude.com/claude-code)