### PR TITLE
JTBD: Add 3 orphan scorecard modules to Administer nav maps

### DIFF
--- a/titles/product_product/category-maps/administer/nav-configure-portfolio-health.adoc
+++ b/titles/product_product/category-maps/administer/nav-configure-portfolio-health.adoc
@@ -9,3 +9,5 @@ include::con-configure-portfolio-health.adoc[leveloffset=+1]
 include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc[leveloffset=+1]
+
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-identify-services-impacting-team-compliance-kpis.adoc
+++ b/titles/product_product/category-maps/administer/nav-identify-services-impacting-team-compliance-kpis.adoc
@@ -9,3 +9,5 @@ include::con-identify-services-impacting-team-compliance-kpis.adoc[leveloffset=+
 include::modules/observability_evaluate-project-health-using-scorecards/proc-view-detailed-metrics-from-aggregated-scorecard-kpis.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc[leveloffset=+1,navtitle="Retrieve metric data using the API"]
+
+include::modules/observability_evaluate-project-health-using-scorecards/ref-available-metric-data-for-entities.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-monitor-collective-health.adoc
+++ b/titles/product_product/category-maps/administer/nav-monitor-collective-health.adoc
@@ -7,3 +7,5 @@
 include::con-monitor-collective-health.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/con-monitor-portfolio-health-with-aggregated-kpis.adoc[leveloffset=+1]
+
+include::modules/observability_evaluate-project-health-using-scorecards/con-aggregated-kpis-in-the-scorecard.adoc[leveloffset=+1]


### PR DESCRIPTION
Add include directives for 3 modules from `modules/observability_evaluate-project-health-using-scorecards/` that were not included in any `product_product` nav file:

| Module | Added to |
|---|---|
| `con-aggregated-kpis-in-the-scorecard.adoc` | `nav-monitor-collective-health.adoc` |
| `proc-configure-a-default-scorecard-aggregation-card.adoc` | `nav-configure-portfolio-health.adoc` |
| `ref-available-metric-data-for-entities.adoc` | `nav-identify-services-impacting-team-compliance-kpis.adoc` |

**Validation:**
- `build-ccutil.sh`: 0 errors, 36 passed / 0 failed
- CQA: 19 pass, 3 fail (all pre-existing)
- All 3 modules confirmed no longer orphans