### PR TITLE
RHDHPLAN-1559: Add missing Scorecard modules to Administer category

### DIFF
--- a/titles/product_product/category-maps/administer/nav-configure-aggregated-scorecard-kpis.adoc
+++ b/titles/product_product/category-maps/administer/nav-configure-aggregated-scorecard-kpis.adoc
@@ -6,6 +6,10 @@
 
 include::con-configure-aggregated-scorecard-kpis.adoc[leveloffset=+1]
 
+include::modules/observability_evaluate-project-health-using-scorecards/con-aggregated-kpis-in-the-scorecard.adoc[leveloffset=+1]
+
+include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc[leveloffset=+1]
+
 include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-a-status-grouped-tracking-type.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-retrieve-metric-data-using-the-api.adoc
+++ b/titles/product_product/category-maps/administer/nav-retrieve-metric-data-using-the-api.adoc
@@ -7,3 +7,5 @@
 include::con-retrieve-metric-data-using-the-api.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc[leveloffset=+1]
+
+include::modules/observability_evaluate-project-health-using-scorecards/ref-available-metric-data-for-entities.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** main
**Issue:** https://redhat.atlassian.net/browse/RHDHPLAN-1559
**Preview:** N/A

## Summary

- Wire 3 orphaned Scorecard modules from `modules/observability_evaluate-project-health-using-scorecards/` into the Administer JTBD MAP structure
- Add `con-aggregated-kpis-in-the-scorecard` and `proc-configure-a-default-scorecard-aggregation-card` to `nav-configure-aggregated-scorecard-kpis`
- Add `ref-available-metric-data-for-entities` to `nav-retrieve-metric-data-using-the-api`

## Modules placed (3)

| Type | Module | Target nav | Content |
|------|--------|-----------|---------|
| con | `con-aggregated-kpis-in-the-scorecard` | nav-configure-aggregated-scorecard-kpis | Aggregated KPI concept for portfolio monitoring |
| proc | `proc-configure-a-default-scorecard-aggregation-card` | nav-configure-aggregated-scorecard-kpis | Default aggregation card setup procedure |
| ref | `ref-available-metric-data-for-entities` | nav-retrieve-metric-data-using-the-api | API metric data reference for entities |

## Validation

- ccutil build: 36/36 passed, 0 failed
- All module file paths verified via symlink
- No xref issues


Made with [Cursor](https://cursor.com)