### PR TITLE
RHDHPLAN-1559: Place remaining extend_* orphan modules across categories

### DIFF
--- a/titles/product_product/category-maps/develop/nav-build-workflow-container-images-locally-using-the-build-sh-script.adoc
+++ b/titles/product_product/category-maps/develop/nav-build-workflow-container-images-locally-using-the-build-sh-script.adoc
@@ -13,3 +13,5 @@ include::modules/extend_orchestrator-in-rhdh/con-environment-variables-supported
 include::modules/extend_orchestrator-in-rhdh/con-required-tools.adoc[leveloffset=+1]
 
 include::modules/extend_orchestrator-in-rhdh/proc-build-the-01-basic-workflow.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/proc-build-workflow-images-locally.adoc[leveloffset=+1]
+

--- a/titles/product_product/category-maps/develop/nav-install-orchestrator-helm-charts.adoc
+++ b/titles/product_product/category-maps/develop/nav-install-orchestrator-helm-charts.adoc
@@ -9,3 +9,10 @@ include::con-install-orchestrator-helm-charts.adoc[leveloffset=+1]
 include::modules/extend_orchestrator-in-rhdh/proc-install-the-orchestrator-software-templates-infra-chart.adoc[leveloffset=+1]
 
 include::modules/extend_orchestrator-in-rhdh/proc-install-the-orchestrator-software-templates-chart.adoc[leveloffset=+1]
+// Temporarily set old context for backward-compatible xref resolution
+:context: enable-and-configure-the-orchestrator-extension
+include::modules/extend_orchestrator-in-rhdh/proc-install-rhdh-on-ocp-with-the-orchestrator-using-the-helm-cli.adoc[leveloffset=+1]
+:context: install-orchestrator-helm-charts
+
+include::modules/extend_orchestrator-in-rhdh/proc-install-rhdh-using-helm-from-the-ocp-web-console.adoc[leveloffset=+1]
+

--- a/titles/product_product/category-maps/develop/nav-pre-built-workflow-container-image-capabilities.adoc
+++ b/titles/product_product/category-maps/develop/nav-pre-built-workflow-container-image-capabilities.adoc
@@ -7,5 +7,7 @@
 include::con-pre-built-workflow-container-image-capabilities.adoc[leveloffset=+1]
 
 include::modules/extend_orchestrator-in-rhdh/con-project-structure-overview.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/con-benefits-of-workflow-images.adoc[leveloffset=+1]
+
 
 include::modules/extend_orchestrator-in-rhdh/proc-create-and-run-your-serverless-workflow-project-locally.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/observe/nav-diagnose-workflow-failures-using-centralized-logging.adoc
+++ b/titles/product_product/category-maps/observe/nav-diagnose-workflow-failures-using-centralized-logging.adoc
@@ -19,5 +19,7 @@ include::modules/extend_orchestrator-in-rhdh/proc-monitor-workflow-health-with-a
 include::modules/extend_orchestrator-in-rhdh/proc-route-alerts-to-existing-tools-to-reduce-response-time.adoc[leveloffset=+1]
 
 include::modules/extend_orchestrator-in-rhdh/proc-diagnose-missing-observability-data-to-restore-visibility.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/proc-integrate-loki-logs-for-orchestrator-workflows.adoc[leveloffset=+1]
+
 
 include::modules/extend_orchestrator-in-rhdh/ref-opentelemetry-configuration-reference-for-controlling-trace-behavior.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/reference/nav-dynamic-plugin-parameter-reference-for-configuration-paths.adoc
+++ b/titles/product_product/category-maps/reference/nav-dynamic-plugin-parameter-reference-for-configuration-paths.adoc
@@ -16,3 +16,5 @@ include::modules/extend_dynamic-plugins-reference/ref-technology-preview-plugins
 include::modules/extend_dynamic-plugins-reference/ref-deprecated-plugins.adoc[leveloffset=+1]
 
 include::modules/extend_dynamic-plugins-reference/ref-other-installable-plugins.adoc[leveloffset=+1]
+include::modules/extend_dynamic-plugins-reference/ref-community-supported-plugins.adoc[leveloffset=+1]
+

--- a/titles/product_product/category-maps/reference/nav-helm-chart-configuration-parameters.adoc
+++ b/titles/product_product/category-maps/reference/nav-helm-chart-configuration-parameters.adoc
@@ -21,3 +21,5 @@ include::modules/configure_helm-chart-config-reference/ref-test-namespace-values
 include::modules/configure_helm-chart-config-reference/ref-upstream-namespace-values.adoc[leveloffset=+1]
 
 include::modules/configure_helm-chart-config-reference/ref-additional-upstream-chart-values.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/ref-resource-limits-for-installing-rhdh-with-the-orchestrator-plugin-when-using-helm.adoc[leveloffset=+1]
+

--- a/titles/product_product/category-maps/secure/nav-define-authorization-policies-to-restrict-access-based-on-user-roles.adoc
+++ b/titles/product_product/category-maps/secure/nav-define-authorization-policies-to-restrict-access-based-on-user-roles.adoc
@@ -28,4 +28,8 @@ include::modules/shared/con-conditional-policies-in-rhdh.adoc[leveloffset=+1]
 
 include::modules/shared/proc-download-active-users-list-in-rhdh.adoc[leveloffset=+1]
 
+include::modules/extend_orchestrator-in-rhdh/proc-manage-orchestrator-plugin-permissions-using-rbac-policies.adoc[leveloffset=+1]
+
+include::modules/extend_orchestrator-in-rhdh/ref-orchestrator-plugin-permissions.adoc[leveloffset=+1]
+
 include::nav-delegate-rbac-management-to-decentralize-administration.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automation.adoc
+++ b/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automation.adoc
@@ -10,4 +10,8 @@ include::modules/extend_orchestrator-in-rhdh/proc-resolve-pod-startup-failure-wh
 
 include::modules/shared/proc-troubleshoot-a-pod-startup-failure-after-enabling-a-plugin.adoc[leveloffset=+1]
 
+include::modules/extend_orchestrator-in-rhdh/proc-restore-workflow-visibility-by-removing-duplicate-entries.adoc[leveloffset=+1]
+
+include::modules/extend_orchestrator-in-rhdh/ref-troubleshooting-workflow-deployments.adoc[leveloffset=+1]
+
 include::nav-diagnose-serverless-workflow-issues.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/upgrade/nav-upgrade-rhdh-to-apply-the-latest-features-and-security-patches.adoc
+++ b/titles/product_product/category-maps/upgrade/nav-upgrade-rhdh-to-apply-the-latest-features-and-security-patches.adoc
@@ -19,3 +19,7 @@ include::modules/upgrade_upgrade-rhdh/proc-update-custom-helm-configurations.ado
 include::modules/shared/proc-enable-quicklinks-and-starred-items-after-an-upgrade.adoc[leveloffset=+1]
 
 include::modules/upgrade_upgrade-rhdh/proc-upgrade-rhdh-from-1-8-to-using-the-helm-chart.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-openshift-serverless-logic-operator-for-rhdh-1-9.adoc[leveloffset=+1]
+
+include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-orchestrator-plugins-for-1-9-operator-backed-instances.adoc[leveloffset=+1]
+


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** main
**Issue:** https://redhat.atlassian.net/browse/RHDHPLAN-1559
**Preview:** N/A

## Summary

Wire the remaining 13 orphan modules from `modules/extend_orchestrator-in-rhdh/` and `modules/extend_dynamic-plugins-reference/` into their destination JTBD categories. These modules live in `extend_*` directories but their content belongs in other categories.

## Modules placed (13)

| Category | Module | Content |
|----------|--------|---------|
| **Develop** | `con-benefits-of-workflow-images` | Workflow image concept |
| **Develop** | `proc-build-workflow-images-locally` | Build workflow images procedure |
| **Develop** | `proc-install-rhdh-on-ocp-with-the-orchestrator-using-the-helm-cli` | Helm CLI install with Orchestrator |
| **Develop** | `proc-install-rhdh-using-helm-from-the-ocp-web-console` | OCP console install with Orchestrator |
| **Upgrade** | `proc-upgrade-the-openshift-serverless-logic-operator-for-rhdh-1-9` | OSL Operator upgrade |
| **Upgrade** | `proc-upgrade-the-orchestrator-plugins-for-1-9-operator-backed-instances` | Plugin upgrade for 1.9 |
| **Secure** | `proc-manage-orchestrator-plugin-permissions-using-rbac-policies` | RBAC policy configuration |
| **Secure** | `ref-orchestrator-plugin-permissions` | Permission strings reference |
| **Observe** | `proc-integrate-loki-logs-for-orchestrator-workflows` | Loki log integration |
| **Troubleshoot** | `proc-restore-workflow-visibility-by-removing-duplicate-entries` | Duplicate workflow fix |
| **Troubleshoot** | `ref-troubleshooting-workflow-deployments` | Deployment troubleshooting guide |
| **Reference** | `ref-community-supported-plugins` | Community plugin catalog |
| **Reference** | `ref-resource-limits-for-installing-rhdh-with-the-orchestrator-plugin-when-using-helm` | Helm resource limits |

## xref fix

The Helm CLI install procedure contains `xref:configure-orchestrator-to-connect-to-existing-postgresql-infrastructure-using-helm_{context}[...]` which targets a module in the Extend category. Applied temporary `:context:` override per jtbd-map skill Step 6 to resolve the cross-category xref.

## Validation

- ccutil build: 36/36 passed, 0 failed
- No duplicate IDs
- All module file paths verified via symlink


Made with [Cursor](https://cursor.com)