### PR TITLE
[RHIDP-14962]: Add external TLS certificate module to Configure nav map

### DIFF
--- a/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
+++ b/titles/product_product/category-maps/configure/nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc
@@ -28,6 +28,8 @@ include::modules/configure_configuring-rhdh/ref-configure-rhdh-deployment-when-u
 
 include::modules/configure_configuring-rhdh/proc-configure-an-rhdh-instance-with-a-tls-connection-in-kubernetes.adoc[leveloffset=+1]
 
+include::modules/configure_configuring-rhdh/proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc[leveloffset=+1,navtitle="Secure a route with an external TLS certificate"]
+
 include::modules/configure_configuring-rhdh/proc-configure-http-server-timeouts.adoc[leveloffset=+1]
 
 include::modules/configure_configuring-rhdh/proc-configure-the-dynamic-plugins-cache.adoc[leveloffset=+1]


### PR DESCRIPTION
> [!IMPORTANT]
> **Do Not Merge:** This PR is part of a documentation restructuring effort and requires review before merging.

## Summary

- Places the unused `proc-configure-a-route-with-an-external-tls-certificate-by-using-the-operator.adoc` module into the Configure category nav map (`nav-configure-core-parameters-to-meet-infrastructure-requirements.adoc`)
- Groups it with existing TLS/route infrastructure content, after the Kubernetes TLS connection module
- Uses navtitle override "Secure a route with an external TLS certificate" to accurately describe the content (the module's internal title duplicates another module's navtitle)

**Version(s):** 1.5

**Issue:** https://redhat.atlassian.net/browse/RHIDP-14962

**Preview:** N/A

## Test plan

- [x] ccutil build passes (36/36 topics, 0 errors)
- [x] CQA checks pass (22/22)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)