### PR TITLE
JTBD: Fix TOC nesting in Optimize and Upgrade nav maps

### DIFF
--- a/titles/product_product/category-maps/optimize/nav-scale-system-performance-for-growing-traffic.adoc
+++ b/titles/product_product/category-maps/optimize/nav-scale-system-performance-for-growing-traffic.adoc
@@ -8,7 +8,7 @@ include::con-scale-system-performance-for-growing-traffic.adoc[leveloffset=+1]
 
 include::con-plan-production-scaling-using-high-availability-architecture.adoc[leveloffset=+1]
 
-include::modules/discover_about-rhdh/con-high-availability-with-database-and-cache-layers.adoc[leveloffset=+1]
+include::modules/discover_about-rhdh/con-high-availability-with-database-and-cache-layers.adoc[leveloffset=+2]
 
 include::con-configure-high-availability-to-maintain-performance.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/upgrade/nav-upgrade-rhdh-to-apply-the-latest-features-and-security-patches.adoc
+++ b/titles/product_product/category-maps/upgrade/nav-upgrade-rhdh-to-apply-the-latest-features-and-security-patches.adoc
@@ -8,18 +8,18 @@ include::con-upgrade-rhdh-to-apply-the-latest-features-and-security-patches.adoc
 
 include::modules/upgrade_upgrade-rhdh/proc-upgrade-the-rhdh-operator.adoc[leveloffset=+1]
 
-include::modules/upgrade_upgrade-rhdh/proc-approve-the-operator-installplan.adoc[leveloffset=+1]
+include::modules/upgrade_upgrade-rhdh/proc-approve-the-operator-installplan.adoc[leveloffset=+2]
 
 include::modules/upgrade_upgrade-rhdh/proc-upgrade-the-rhdh-helm-chart.adoc[leveloffset=+1]
 
-include::modules/upgrade_upgrade-rhdh/proc-apply-the-new-helm-chart-version.adoc[leveloffset=+1]
+include::modules/upgrade_upgrade-rhdh/proc-apply-the-new-helm-chart-version.adoc[leveloffset=+2]
 
-include::modules/upgrade_upgrade-rhdh/proc-update-custom-helm-configurations.adoc[leveloffset=+1]
+include::modules/upgrade_upgrade-rhdh/proc-update-custom-helm-configurations.adoc[leveloffset=+2]
 
-include::modules/shared/proc-enable-quicklinks-and-starred-items-after-an-upgrade.adoc[leveloffset=+1]
+include::modules/shared/proc-enable-quicklinks-and-starred-items-after-an-upgrade.adoc[leveloffset=+2]
 
-include::modules/upgrade_upgrade-rhdh/proc-upgrade-rhdh-from-1-8-to-using-the-helm-chart.adoc[leveloffset=+1]
-include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-openshift-serverless-logic-operator-for-rhdh-1-9.adoc[leveloffset=+1]
+include::modules/upgrade_upgrade-rhdh/proc-upgrade-rhdh-from-1-8-to-using-the-helm-chart.adoc[leveloffset=+2]
+include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-openshift-serverless-logic-operator-for-rhdh-1-9.adoc[leveloffset=+2]
 
-include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-orchestrator-plugins-for-1-9-operator-backed-instances.adoc[leveloffset=+1]
+include::modules/extend_orchestrator-in-rhdh/proc-upgrade-the-orchestrator-plugins-for-1-9-operator-backed-instances.adoc[leveloffset=+2]
 


### PR DESCRIPTION
> **IMPORTANT: Do Not Merge** — until reviewed and approved.

## Version(s)

All

## Issue

N/A — JTBD sanity check pass

## Summary

- **Optimize**: Nests "Deploy multiple stateless instances" under "Plan production scaling using high availability architecture" (leveloffset +1 → +2)
- **Upgrade**: Nests sub-steps under their parent sections ("Upgrade the RHDH Operator" and "Upgrade the RHDH Helm chart") by adjusting leveloffset from +1 to +2

## Preview

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)