### PR TITLE
fix(cqa): skip .template.adoc files in JTBD-02 orphan check

### DIFF
--- a/build/scripts/cqa/checks/jtbd-02-orphans.js
+++ b/build/scripts/cqa/checks/jtbd-02-orphans.js
@@ -82,6 +82,7 @@ function findOrphansInSubdir(subdirPath, includedFiles) {
   for (const file of walkAdocFiles(subdirPath)) {
     const bn = basename(file);
     if (!MODULE_PREFIXES.some(p => bn.startsWith(p))) continue;
+    if (bn.endsWith('.template.adoc')) continue;
 
     const relPath = repoRelative(file);
     if (!includedFiles.has(relPath)) {


### PR DESCRIPTION
The JTBD-02 informational report listed `.template.adoc` files as orphaned modules. These files are templates, not includable content. `cqa-00a` already skips them; this applies the same exclusion to JTBD-02.

**Change:** add `if (bn.endsWith('.template.adoc')) continue;` in `findOrphansInSubdir()` (`build/scripts/cqa/checks/jtbd-02-orphans.js:85`).