### PR TITLE
RHDHBUGS-3408: Remove mentions of fixed tresholds

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
@@ -50,11 +50,6 @@ where:
 
 `myDatasource`:: represents your specific scorecard data source, such as `jira` 
 `myMetric`:: represents the metric identifier, such as `open_issues`
-+
-[NOTE]
-====
-Custom severity thresholds and color configurations are only functional for scorecard plugin modules that support custom rules. At this time, the `filecheck`, `openssf`, and `dependabot` modules do not support custom thresholds.
-====
 
 . Save the changes to the configuration file.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -101,8 +101,10 @@ This annotation is usually added automatically during catalog ingestion. If your
 +
 [IMPORTANT]
 ====
-Filecheck metrics use fixed boolean thresholds. Unlike GitHub and Jira metrics, you cannot customize these thresholds.
+Filecheck metrics use the following default thresholds:
 
 exist:: File is present (success).
 missing:: File is absent (error).
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -99,7 +99,7 @@ where:
 This annotation is usually added automatically during catalog ingestion. If your entities are already registered in the catalog, this annotation is likely already present.
 ====
 +
-[IMPORTANT]
+[NOTE]
 ====
 Filecheck metrics use the following default thresholds:
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -108,3 +108,4 @@ missing:: File is absent (error).
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -98,7 +98,7 @@ where:
 ====
 This annotation is usually added automatically during catalog ingestion. If your entities are already registered in the catalog, this annotation is likely already present.
 ====
-+
+
 [NOTE]
 ====
 Filecheck metrics use the following default thresholds:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -106,6 +106,6 @@ Filecheck metrics use the following default thresholds:
 * *exist*: File is present (success).
 * *missing*: File is absent (error).
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -106,6 +106,6 @@ Filecheck metrics use the following default thresholds:
 * *exist*: File is present (success).
 * *missing*: File is absent (error).
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -103,8 +103,8 @@ This annotation is usually added automatically during catalog ingestion. If your
 ====
 Filecheck metrics use the following default thresholds:
 
-exist:: File is present (success).
-missing:: File is absent (error).
+* *exist*: File is present (success).
+* *missing*: File is absent (error).
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -106,6 +106,6 @@ Filecheck metrics use the following default thresholds:
 * *exist*: File is present (success).
 * *missing*: File is absent (error).
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -106,6 +106,6 @@ Filecheck metrics use the following default thresholds:
 * *exist*: File is present (success).
 * *missing*: File is absent (error).
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -155,3 +155,14 @@ scorecard:
 where:
 
 `scorecard:plugins:github:open_prs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
++
+[NOTE]
+====
+GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.open_prs`) metric:
+
+Error:: More than 50 open pull requests.
+Warning:: Between 10 and 50 open pull requests.
+Success:: Fewer than 10 open pull requests.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -160,9 +160,9 @@ where:
 ====
 GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.open_prs`) metric:
 
-Error:: More than 50 open pull requests.
-Warning:: Between 10 and 50 open pull requests.
-Success:: Fewer than 10 open pull requests.
+* *Error*: More than 50 open pull requests.
+* *Warning*: Between 10 and 50 open pull requests.
+* *Success*: Fewer than 10 open pull requests.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -155,7 +155,7 @@ scorecard:
 where:
 
 `scorecard:plugins:github:open_prs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
-+
+
 [NOTE]
 ====
 GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.open_prs`) metric:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -164,6 +164,6 @@ GitHub metrics use the following default thresholds for the *GitHub Open Pull Re
 * *Warning*: Between 10 and 50 open pull requests.
 * *Success*: Fewer than 10 open pull requests.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -164,6 +164,6 @@ GitHub metrics use the following default thresholds for the *GitHub Open Pull Re
 * *Warning*: Between 10 and 50 open pull requests.
 * *Success*: Fewer than 10 open pull requests.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -164,6 +164,6 @@ GitHub metrics use the following default thresholds for the *GitHub Open Pull Re
 * *Warning*: Between 10 and 50 open pull requests.
 * *Success*: Fewer than 10 open pull requests.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -164,6 +164,6 @@ GitHub metrics use the following default thresholds for the *GitHub Open Pull Re
 * *Warning*: Between 10 and 50 open pull requests.
 * *Success*: Fewer than 10 open pull requests.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -166,3 +166,4 @@ Success:: Fewer than 10 open pull requests.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -151,11 +151,11 @@ scorecard:
         thresholds:
           rules:
             - key: success
-              expression: '<10'
+              expression: '<=50'
             - key: warning
-              expression: '10-50'
-            - key: error
               expression: '>50'
+            - key: error
+              expression: '>100'
 ----
 +
 where:
@@ -180,5 +180,14 @@ where:
 `mandatoryFilter`:: Optional: Replaces the default filter (`type = Bug and resolution = Unresolved`).
 `customFilter`:: Optional: Specifies a global custom filter. The entity annotation `jira/custom-filter` overrides this value.
 +
-For more information about how to customize the threshold values, see {scorecard-plugin-book-link}#con-manage-metric-thresholds-in-scorecard-plugin[Thresholds in Scorecard plugins].
+[NOTE]
+====
+Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.open_issues`) metric:
+
+Error:: More than 100 open issues.
+Warning:: More than 50 open issues.
+Success:: 50 or fewer open issues.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -188,6 +188,6 @@ Jira metrics use the following default thresholds for the *Jira Open Issues* (`j
 * *Warning*: More than 50 open issues.
 * *Success*: 50 or fewer open issues.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -179,7 +179,7 @@ where:
 
 `mandatoryFilter`:: Optional: Replaces the default filter (`type = Bug and resolution = Unresolved`).
 `customFilter`:: Optional: Specifies a global custom filter. The entity annotation `jira/custom-filter` overrides this value.
-+
+
 [NOTE]
 ====
 Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.open_issues`) metric:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -188,6 +188,6 @@ Jira metrics use the following default thresholds for the *Jira Open Issues* (`j
 * *Warning*: More than 50 open issues.
 * *Success*: 50 or fewer open issues.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -184,9 +184,9 @@ where:
 ====
 Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.open_issues`) metric:
 
-Error:: More than 100 open issues.
-Warning:: More than 50 open issues.
-Success:: 50 or fewer open issues.
+* *Error*: More than 100 open issues.
+* *Warning*: More than 50 open issues.
+* *Success*: 50 or fewer open issues.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -188,6 +188,6 @@ Jira metrics use the following default thresholds for the *Jira Open Issues* (`j
 * *Warning*: More than 50 open issues.
 * *Success*: 50 or fewer open issues.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -188,6 +188,6 @@ Jira metrics use the following default thresholds for the *Jira Open Issues* (`j
 * *Warning*: More than 50 open issues.
 * *Success*: 50 or fewer open issues.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -67,7 +67,7 @@ catalog:
 ----
 
 +
-[IMPORTANT]
+[NOTE]
 ====
 OpenSSF metrics use the following default thresholds:
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -69,9 +69,11 @@ catalog:
 +
 [IMPORTANT]
 ====
-OpenSSF metrics use fixed, non-configurable thresholds. Unlike GitHub and Jira metrics, you cannot customize these thresholds.
+OpenSSF metrics use the following default thresholds:
 
 Error:: Score below 2.
 Warning:: Score between 2 and 7.
 Success:: Score above 7.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -74,6 +74,6 @@ OpenSSF metrics use the following default thresholds:
 * *Warning*: Score between 2 and 7.
 * *Success*: Score above 7.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -77,3 +77,4 @@ Success:: Score above 7.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -66,7 +66,6 @@ catalog:
       target: https://github.com/<owner>/<repository>/catalog-info.yaml
 ----
 
-+
 [NOTE]
 ====
 OpenSSF metrics use the following default thresholds:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -74,6 +74,6 @@ OpenSSF metrics use the following default thresholds:
 * *Warning*: Score between 2 and 7.
 * *Success*: Score above 7.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -71,9 +71,9 @@ catalog:
 ====
 OpenSSF metrics use the following default thresholds:
 
-Error:: Score below 2.
-Warning:: Score between 2 and 7.
-Success:: Score above 7.
+* *Error*: Score below 2.
+* *Warning*: Score between 2 and 7.
+* *Success*: Score above 7.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -74,6 +74,6 @@ OpenSSF metrics use the following default thresholds:
 * *Warning*: Score between 2 and 7.
 * *Success*: Score above 7.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -75,6 +75,6 @@ OpenSSF metrics use the following default thresholds:
 * *Warning*: Score between 2 and 7.
 * *Success*: Score above 7.
 
-You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 ====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -8,156 +8,135 @@ The Scorecard plugin gathers data from third-party systems through metric provid
 
 The following metric providers are supported:
 
-[cols="1,1,2,3,1,1", options="header"]
+[cols="1,1,2,3,1", options="header"]
 |===
-| Provider | Metric ID | Title | Description | Type | Thresholds
+| Provider | Metric ID | Title | Description | Type
 
 | GitHub
 | `github.open_prs`
 | GitHub open PRs
 | Number of open pull requests in GitHub.
 | number
-| Configurable
 
 | Jira
 | `jira.open_issues`
 | Jira open issues
 | Number of open issues in Jira.
 | number
-| Configurable
 
 | OpenSSF
 | `openssf.binary_artifacts`
 | Binary Artifacts
 | Determines if the project has generated executable (binary) artifacts in the source repository.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.branch_protection`
 | Branch Protection
 | Determines if the default and release branches are protected with branch protection settings.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.cii_best_practices`
 | CII Best Practices
 | Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.ci_tests`
 | CI Tests
 | Determines if the project runs tests before pull requests are merged.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.code_review`
 | Code Review
 | Determines if the project requires human code review before pull requests are merged.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.contributors`
 | Contributors
 | Determines if the project has a set of contributors from multiple organizations.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.dangerous_workflow`
 | Dangerous Workflow
 | Determines if the project's GitHub Action workflows avoid dangerous patterns.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.dependency_update_tool`
 | Dependency Update Tool
 | Determines if the project uses a dependency update tool.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.fuzzing`
 | Fuzzing
 | Determines if the project uses fuzzing.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.license`
 | License
 | Determines if the project has defined a license.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.maintained`
 | Maintained
 | Determines if the project is actively maintained.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.packaging`
 | Packaging
 | Determines if the project is published as a package.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.pinned_dependencies`
 | Pinned Dependencies
 | Determines if the project has declared and pinned the dependencies of its build process.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.sast`
 | SAST (Static Analysis Security Testing)
 | Determines if the project uses static code analysis.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.security_policy`
 | Security Policy
 | Determines if the project has published a security policy.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.signed_releases`
 | Signed Releases
 | Determines if the project cryptographically signs release artifacts.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.token_permissions`
 | Token Permissions
 | Determines if the project's workflows follow the principle of least privilege.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.vulnerabilities`
 | Vulnerabilities
 | Determines if the project has open, known unfixed vulnerabilities.
 | score (0-10)
-| Fixed
 
 | Filecheck
 | `filecheck._<key>_`
 | _<key>_
 | Verifies that the configured file exists in the repository. The metric ID suffix and title are derived from the key you define in `scorecard.plugins.filecheck.files`. For more information, see {scorecard-plugin-book-link}#configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation_install-and-configure-scorecards-to-view-metrics[Configure file-level checks to verify repositories contain required compliance documentation].
 | boolean
-| Fixed
 |===
 
-For OpenSSF metrics, the fixed thresholds are: Error (score below 2), Warning (score between 2 and 7), Success (score above 7). For Filecheck metrics, the fixed thresholds are: exist (file present, success) and missing (file absent, error). For GitHub and Jira metrics, you can customize thresholds. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+For OpenSSF metrics, the default thresholds are: Error (score below 2), Warning (score between 2 and 7), Success (score above 7). For Filecheck metrics, the default thresholds are: exist (file present, success) and missing (file absent, error). You can customize thresholds for all metrics in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -139,4 +139,4 @@ The following metric providers are supported:
 | boolean
 |===
 
-For OpenSSF metrics, the default thresholds are: Error (score below 2), Warning (score between 2 and 7), Success (score above 7). For Filecheck metrics, the default thresholds are: exist (file present, success) and missing (file absent, error). You can customize thresholds for all metrics in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -139,4 +139,5 @@ The following metric providers are supported:
 | boolean
 |===
 
-For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -139,5 +139,5 @@ The following metric providers are supported:
 | boolean
 |===
 
-For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{scorecard-ref-context}[Scorecard metric thresholds].
+For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
 

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
@@ -43,9 +43,9 @@ kind: Component
 metadata:
   name: critical-production-service
   annotations:
-    # Changes global 'warning' from '10-50' to '10-15'
+    # Changes global 'warning' from '>50' to '10-15'
     scorecard.io/jira.open_issues.thresholds.rules.warning: '10-15'
-    # Changes global 'error' from '>50' to '>15'
+    # Changes global 'error' from '>100' to '>15'
     scorecard.io/jira.open_issues.thresholds.rules.error: '>15'
 spec:
   type: service

--- a/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
@@ -14,6 +14,8 @@ include::nav-set-up-scorecards.adoc[leveloffset=+1]
 include::nav-install-and-configure-scorecards.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 
+// Temporarily set old context for backward-compatible scorecard-metric-thresholds ID
+:context: evaluate-project-health-using-scorecards
 include::nav-manage-metric-thresholds.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 

--- a/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
@@ -14,8 +14,6 @@ include::nav-set-up-scorecards.adoc[leveloffset=+1]
 include::nav-install-and-configure-scorecards.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 
-// Temporarily set old context for backward-compatible scorecard-metric-thresholds ID
-:context: evaluate-project-health-using-scorecards
 include::nav-manage-metric-thresholds.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 

--- a/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
+++ b/titles/product_product/category-maps/administer/nav-evaluate-component-compliance-using-scorecards.adoc
@@ -20,3 +20,4 @@ include::nav-manage-metric-thresholds.adoc[leveloffset=+1]
 :context: evaluate-component-compliance-using-scorecards
 
 include::modules/observability_evaluate-project-health-using-scorecards/proc-monitor-component-health-and-readiness-with-scorecard-metrics.adoc[leveloffset=+1]
+

--- a/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
+++ b/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
@@ -5,6 +5,7 @@
 = Manage metric thresholds
 :context: manage-metric-thresholds
 
+[id="scorecard-metric-thresholds_evaluate-project-health-using-scorecards"]
 include::con-manage-metric-thresholds.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
+++ b/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
@@ -4,7 +4,8 @@
 = Manage metric thresholds
 :context: manage-metric-thresholds
 
-// Backward-compatible anchor for xrefs using the old assembly context
+// Backward-compatible anchors for xrefs
+[id="scorecard-metric-thresholds_evaluate-component-compliance-using-scorecards"]
 [id="scorecard-metric-thresholds_evaluate-project-health-using-scorecards"]
 include::con-manage-metric-thresholds.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
+++ b/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
@@ -1,10 +1,11 @@
 :_mod-docs-content-type: MAP
 
 [id="manage-metric-thresholds_{context}"]
-[id="scorecard-metric-thresholds_{context}"]
 = Manage metric thresholds
 :context: manage-metric-thresholds
 
+// Backward-compatible anchor for xrefs using the old assembly context
+[id="scorecard-metric-thresholds_evaluate-project-health-using-scorecards"]
 include::con-manage-metric-thresholds.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
+++ b/titles/product_product/category-maps/administer/nav-manage-metric-thresholds.adoc
@@ -1,12 +1,10 @@
 :_mod-docs-content-type: MAP
 
 [id="manage-metric-thresholds_{context}"]
+[id="scorecard-metric-thresholds_{context}"]
 = Manage metric thresholds
 :context: manage-metric-thresholds
 
-// Backward-compatible anchors for xrefs
-[id="scorecard-metric-thresholds_evaluate-component-compliance-using-scorecards"]
-[id="scorecard-metric-thresholds_evaluate-project-health-using-scorecards"]
 include::con-manage-metric-thresholds.adoc[leveloffset=+1]
 
 include::modules/observability_evaluate-project-health-using-scorecards/con-scorecard-metric-threshold-categorization-rules.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10.2
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-3408
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->

Thresholds are now by default configurable by app-config for all plugins. Removed all mentions of fixed thresholds from documentation.
