### PR TITLE
Accept 202 status code in lychee link validation

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -12,8 +12,9 @@ cache = true
 timeout = 60
 
 # Accept these status codes as valid
+# 202 included for Atlassian URLs that return Accepted status
 # 403 included because many doc sites (developers.redhat.com, entra.microsoft.com) block crawlers
-accept = [200, 204, 301, 302, 403]
+accept = [200, 202, 204, 301, 302, 403]
 
 # Skip SSL certificate verification (matches htmltest IgnoreSSLVerify)
 insecure = true


### PR DESCRIPTION
Atlassian API token management URLs return HTTP 202 (Accepted) status, which is a valid success response but was not in the accepted list.

This was causing link validation failures for:
- https://id.atlassian.com/manage-profile/security/api-tokens

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:**
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
