### PR TITLE
Exclude operatorhub.io URL from link validation

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,6 @@ file://.*titles-generated/index\.html$
 
 # Site exists but refuses the crawler
 ^https://scorecard.dev
+
+# operatorhub.io returns 503 errors intermittently
+^https://operatorhub\.io/how-to-install-an-operator


### PR DESCRIPTION
The operatorhub.io site returns 503 errors intermittently during automated link validation, causing CI failures.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:**
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
