### PR TITLE
RHDHBUGS-3408: Remove mentions of fixed tresholds (#2449)

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
@@ -50,11 +50,6 @@ where:
 
 `myDatasource`:: represents your specific scorecard data source, such as `jira` 
 `myMetric`:: represents the metric identifier, such as `open_issues`
-+
-[NOTE]
-====
-Custom severity thresholds and color configurations are only functional for scorecard plugin modules that support custom rules. At this time, the `filecheck`, `openssf`, and `dependabot` modules do not support custom thresholds.
-====
 
 . Save the changes to the configuration file.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -101,8 +101,8 @@ This annotation is usually added automatically during catalog ingestion. If your
 ====
 Filecheck metrics use the following default thresholds:
 
-* *exist*: File is present (success).
-* *missing*: File is absent (error).
+. *exist*: File is present (success).
+. *missing*: File is absent (error).
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc
@@ -96,11 +96,14 @@ where:
 ====
 This annotation is usually added automatically during catalog ingestion. If your entities are already registered in the catalog, this annotation is likely already present.
 ====
-+
-[IMPORTANT]
-====
-Filecheck metrics use fixed boolean thresholds. Unlike GitHub and Jira metrics, you cannot customize these thresholds.
 
-exist:: File is present (success).
-missing:: File is absent (error).
+[NOTE]
 ====
+Filecheck metrics use the following default thresholds:
+
+* *exist*: File is present (success).
+* *missing*: File is absent (error).
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -155,3 +155,15 @@ scorecard:
 where:
 
 `scorecard:plugins:github:open_prs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
+
+[NOTE]
+====
+GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.open_prs`) metric:
+
+* *Error*: More than 50 open pull requests.
+* *Warning*: Between 10 and 50 open pull requests.
+* *Success*: Fewer than 10 open pull requests.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -151,11 +151,11 @@ scorecard:
         thresholds:
           rules:
             - key: success
-              expression: '<10'
+              expression: '<=50'
             - key: warning
-              expression: '10-50'
-            - key: error
               expression: '>50'
+            - key: error
+              expression: '>100'
 ----
 +
 where:
@@ -179,6 +179,15 @@ where:
 
 `mandatoryFilter`:: Optional: Replaces the default filter (`type = Bug and resolution = Unresolved`).
 `customFilter`:: Optional: Specifies a global custom filter. The entity annotation `jira/custom-filter` overrides this value.
-+
-For more information about how to customize the threshold values, see {scorecard-plugin-book-link}#con-manage-metric-thresholds-in-scorecard-plugin[Thresholds in Scorecard plugins].
+
+[NOTE]
+====
+Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.open_issues`) metric:
+
+* *Error*: More than 100 open issues.
+* *Warning*: More than 50 open issues.
+* *Success*: 50 or fewer open issues.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -68,9 +68,9 @@ catalog:
 ====
 OpenSSF metrics use the following default thresholds:
 
-* *Error*: Score below 2.
-* *Warning*: Score between 2 and 7.
-* *Success*: Score above 7.
+. *Error*: Score below 2.
+. *Warning*: Score between 2 and 7.
+. *Success*: Score above 7.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -64,12 +64,14 @@ catalog:
       target: https://github.com/<owner>/<repository>/catalog-info.yaml
 ----
 
-+
-[IMPORTANT]
+[NOTE]
 ====
-OpenSSF metrics use fixed, non-configurable thresholds. Unlike GitHub and Jira metrics, you cannot customize these thresholds.
+OpenSSF metrics use the following default thresholds:
 
-Error:: Score below 2.
-Warning:: Score between 2 and 7.
-Success:: Score above 7.
+* *Error*: Score below 2.
+* *Warning*: Score between 2 and 7.
+* *Success*: Score above 7.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
+

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -8,156 +8,136 @@ The Scorecard plugin gathers data from third-party systems through metric provid
 
 The following metric providers are supported:
 
-[cols="1,1,2,3,1,1", options="header"]
+[cols="1,1,2,3,1", options="header"]
 |===
-| Provider | Metric ID | Title | Description | Type | Thresholds
+| Provider | Metric ID | Title | Description | Type
 
 | GitHub
 | `github.open_prs`
 | GitHub open PRs
 | Number of open pull requests in GitHub.
 | number
-| Configurable
 
 | Jira
 | `jira.open_issues`
 | Jira open issues
 | Number of open issues in Jira.
 | number
-| Configurable
 
 | OpenSSF
 | `openssf.binary_artifacts`
 | Binary Artifacts
 | Determines if the project has generated executable (binary) artifacts in the source repository.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.branch_protection`
 | Branch Protection
 | Determines if the default and release branches are protected with branch protection settings.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.cii_best_practices`
 | CII Best Practices
 | Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.ci_tests`
 | CI Tests
 | Determines if the project runs tests before pull requests are merged.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.code_review`
 | Code Review
 | Determines if the project requires human code review before pull requests are merged.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.contributors`
 | Contributors
 | Determines if the project has a set of contributors from multiple organizations.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.dangerous_workflow`
 | Dangerous Workflow
 | Determines if the project's GitHub Action workflows avoid dangerous patterns.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.dependency_update_tool`
 | Dependency Update Tool
 | Determines if the project uses a dependency update tool.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.fuzzing`
 | Fuzzing
 | Determines if the project uses fuzzing.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.license`
 | License
 | Determines if the project has defined a license.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.maintained`
 | Maintained
 | Determines if the project is actively maintained.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.packaging`
 | Packaging
 | Determines if the project is published as a package.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.pinned_dependencies`
 | Pinned Dependencies
 | Determines if the project has declared and pinned the dependencies of its build process.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.sast`
 | SAST (Static Analysis Security Testing)
 | Determines if the project uses static code analysis.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.security_policy`
 | Security Policy
 | Determines if the project has published a security policy.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.signed_releases`
 | Signed Releases
 | Determines if the project cryptographically signs release artifacts.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.token_permissions`
 | Token Permissions
 | Determines if the project's workflows follow the principle of least privilege.
 | score (0-10)
-| Fixed
 
 | OpenSSF
 | `openssf.vulnerabilities`
 | Vulnerabilities
 | Determines if the project has open, known unfixed vulnerabilities.
 | score (0-10)
-| Fixed
 
 | Filecheck
 | `filecheck._<key>_`
 | _<key>_
 | Verifies that the configured file exists in the repository. The metric ID suffix and title are derived from the key you define in `scorecard.plugins.filecheck.files`. For more information, see {scorecard-plugin-book-link}#configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation_install-and-configure-scorecards-to-view-metrics[Configure file-level checks to verify repositories contain required compliance documentation].
 | boolean
-| Fixed
 |===
 
-For OpenSSF metrics, the fixed thresholds are: Error (score below 2), Warning (score between 2 and 7), Success (score above 7). For Filecheck metrics, the fixed thresholds are: exist (file present, success) and missing (file absent, error). For GitHub and Jira metrics, you can customize thresholds. For more information, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].
+

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
@@ -43,9 +43,9 @@ kind: Component
 metadata:
   name: critical-production-service
   annotations:
-    # Changes global 'warning' from '10-50' to '10-15'
+    # Changes global 'warning' from '>50' to '10-15'
     scorecard.io/jira.open_issues.thresholds.rules.warning: '10-15'
-    # Changes global 'error' from '>50' to '>15'
+    # Changes global 'error' from '>100' to '>15'
     scorecard.io/jira.open_issues.thresholds.rules.error: '>15'
 spec:
   type: service


### PR DESCRIPTION
* doc: remove mentions of fixed tresholds



* ref: add default tresholds, replace importants



* ref: simplify threshold information in metrics reference

Remove the detailed threshold values paragraph and replace with a simple pointer to the threshold customization documentation.

This fixes the build validation issue and follows Dominika's review feedback. The detailed threshold information is already present in each metric provider's procedure file.



* fix: Set context for backward-compatible scorecard-metric-thresholds ID

Temporarily set context to evaluate-project-health-using-scorecards before including nav-manage-metric-thresholds.adoc to ensure the anchor ID matches hardcoded xrefs.

* fix: Add trailing blank line to scorecard nav file

AsciiDoc files should end with a blank line for proper XML validation.

* Fix backward-compatible anchor implementation

Use hardcoded anchor before include instead of context manipulation. This follows the established pattern in the codebase and avoids XML validation issues caused by dual ID attributes on section titles.

* Add trailing blank lines to module files

Ensure all AsciiDoc files end with a blank line per convention.

* Create both backward-compatible IDs as standalone anchors

Instead of dual section IDs, create two standalone anchor IDs to support both xref patterns without context manipulation.

* Fix: Replace definition lists with bulleted lists in NOTE blocks

Nested definition lists inside NOTE blocks cause DocBook XML validation errors. Changed Error::, Warning::, Success:: to bulleted lists with bold labels to fix the document structure validation failure.

* Revert to main's dual-ID pattern and use context variables in xrefs

- Restore nav-manage-metric-thresholds.adoc to main's structure with dual IDs on section title
- Change all hardcoded xrefs to use {context} variable instead
- This ensures xrefs resolve correctly in both product_product and standalone titles

* Remove invalid list continuation markers before NOTE blocks

List continuation (+) should not be used before standalone NOTE blocks as it creates invalid DocBook structure. Removed orphaned + markers.

* Use scorecard-ref-context variable for xrefs to threshold section

The {context} variable changes based on where modules are included. Use {scorecard-ref-context} which is explicitly set in both titles to point to the correct scorecard-metric-thresholds section.

* Revert xrefs back to {context} variable

Main branch uses {context} in xrefs and it works correctly. The dual-ID pattern on nav-manage-metric-thresholds section title ensures both contexts resolve to valid IDs.

* FINAL FIX: Use hardcoded xrefs and create backward-compatible anchor

Original PR used hardcoded xrefs to scorecard-metric-thresholds_evaluate-project-health-using-scorecards. Create this ID as a standalone anchor in nav-manage-metric-thresholds.adoc. Keep dual IDs on section title for {context}-based xrefs. Use bulleted lists in NOTE blocks (not definition lists). No list continuation markers before NOTE blocks.

---------

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:**
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
