### PR TITLE
RHDHBUGS-3446: ensure script pulls only relevant tag for plugin index

### DIFF
--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -26,13 +26,7 @@ SKIP_COMMUNITY_TABLE=0
 rhdhRepo="https://github.com/redhat-developer/rhdh"
 overlaysRepo="https://github.com/redhat-developer/rhdh-plugin-export-overlays"
 
-INDEX_TAG="${BRANCH#release-}"
-if [[ $INDEX_TAG == "main" ]]; then
-  INDEX_TAG="next"
-fi
 CATALOG_INDEX_REGISTRY="${CATALOG_INDEX_REGISTRY:-quay.io/rhdh}"
-
-catalogindextmpdir="/tmp/plugin-catalog-index_${BRANCH}"
 
 debug() {
   if [[ $QUIET -eq 0 ]]; then
@@ -100,6 +94,13 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 if [[ ! $BRANCH ]]; then usage; exit 1; fi
+
+catalogindextmpdir="/tmp/plugin-catalog-index_${BRANCH}"
+
+INDEX_TAG="${BRANCH#release-}"
+if [[ $INDEX_TAG == "main" ]]; then
+  INDEX_TAG="next"
+fi
 
 # Set temp directory paths based on BRANCH
 overlaystmpdir="/tmp/rhdh-plugin-export-overlays_$BRANCH" # for catalog metadata


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->
Although it does not affect main, the rhdh-supported-plugins.sh script always pulls in the next tag for branch release-1.10. This quick change fixes it so that the tag is decided only after the branch is decided.

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.10
**Issue:**
[RHDHBUGS-3446](https://redhat.atlassian.net/browse/RHDHBUGS-3446)
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
