### PR TITLE
RHDHBUGS-3376: include dev-preview plugins in community supported

### DIFF
--- a/modules/extend_dynamic-plugins-reference/ref-community-supported-plugins.adoc
+++ b/modules/extend_dynamic-plugins-reference/ref-community-supported-plugins.adoc
@@ -6,7 +6,7 @@
 = {company-name} community supported plugins
 
 [role="_abstract"]
-{company-name} provides community support for the following 45 dynamic plugins in `ghcr.io`.
+{company-name} provides community support for the following 52 dynamic plugins in `ghcr.io`.
 
 
 
@@ -22,11 +22,18 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 |*Path and required variables*
 
 |*3Scale*
-|3.13.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:<tag>`
+|3.15.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-3scale-backend:<tag>`
 
 `THREESCALE_ACCESS_TOKEN`
 
 `THREESCALE_BASE_URL`
+
+`
+
+|*@backstage/plugin-mcp-actions-backend*
+|0.1.11|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-mcp-actions-backend:<tag>`
+
+`MCP_TOKEN`
 
 `
 
@@ -49,7 +56,9 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Azure DevOps Backend*
-|0.27.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-azure-devops-backend:<tag>`
+|0.30.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-azure-devops-backend:<tag>`
+
+`AZURE_HOST`
 
 `AZURE_ORG`
 
@@ -58,7 +67,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Catalog Backend Module Azure DevOps Annotator Processor*
-|0.18.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-azure-devops-annotator-processor:<tag>`
+|0.20.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-azure-devops-annotator-processor:<tag>`
 
 `
 
@@ -82,27 +91,27 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Dynatrace*
-|10.17.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-dynatrace:<tag>`
+|10.21.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-dynatrace:<tag>`
 
 `
 
 |*GitHub Actions*
-|0.22.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:<tag>`
+|1.2.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:<tag>`
 
 `
 
 |*GitHub Deployments*
-|0.18.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-deployments:<tag>`
+|1.2.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-deployments:<tag>`
 
 `
 
 |*GitHub Discussions*
-|0.10.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-discussions:<tag>`
+|1.2.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-discussions:<tag>`
 
 `
 
 |*GitHub Discussions Search Backend Module*
-|0.11.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-search-backend-module-github-discussions:<tag>`
+|0.14.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-search-backend-module-github-discussions:<tag>`
 
 `GITHUB_DISCUSSIONS_REPO_URL`
 
@@ -114,7 +123,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*GitHub Issues*
-|0.21.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:<tag>`
+|1.2.1|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:<tag>`
 
 `
 
@@ -124,7 +133,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*GitHub Pull Requests Board*
-|0.16.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-pull-requests-board:<tag>`
+|1.2.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-pull-requests-board:<tag>`
 
 `
 
@@ -138,12 +147,12 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*JFrog Artifactory*
-|1.28.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-jfrog-artifactory:<tag>`
+|1.30.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-jfrog-artifactory:<tag>`
 
 `
 
 |*Jenkins Backend*
-|0.27.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-jenkins-backend:<tag>`
+|0.29.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-jenkins-backend:<tag>`
 
 `JENKINS_TOKEN`
 
@@ -154,7 +163,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Jenkins Scaffolder Backend Module*
-|0.20.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-jenkins:<tag>`
+|0.22.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-jenkins:<tag>`
 
 `
 
@@ -164,12 +173,12 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Lighthouse Backend*
-|0.21.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-lighthouse-backend:<tag>`
+|0.25.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-lighthouse-backend:<tag>`
 
 `
 
 |*Nexus Repository Manager*
-|1.23.2|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-nexus-repository-manager:<tag>`
+|1.25.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-nexus-repository-manager:<tag>`
 
 `
 
@@ -197,7 +206,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Quay Backend*
-|1.14.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:<tag>`
+|1.17.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:<tag>`
 
 `
 
@@ -242,7 +251,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Scaffolder Backend Module Azure DevOps*
-|0.23.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-azure-devops:<tag>`
+|0.25.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-azure-devops:<tag>`
 
 `
 
@@ -257,7 +266,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Scaffolder Backend Module DotNet*
-|0.13.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-dotnet:<tag>`
+|0.15.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-dotnet:<tag>`
 
 `
 
@@ -267,7 +276,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Scaffolder Backend Module Quay*
-|2.18.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:<tag>`
+|2.21.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:<tag>`
 
 `
 
@@ -283,7 +292,7 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `
 
 |*Scaffolder Backend Module SonarQube*
-|2.15.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-sonarqube:<tag>`
+|2.16.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-sonarqube:<tag>`
 
 `
 
@@ -292,8 +301,44 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 
 `
 
+|*Scorecard Backend Module for Dependabot*
+|0.2.12|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:<tag>`
+
+`
+
+|*Scorecard Backend Module for Filechecks*
+|0.1.10|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck:<tag>`
+
+`
+
+|*Scorecard Backend Module for GitHub*
+|2.7.8|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:<tag>`
+
+`
+
+|*Scorecard Backend Module for Jira*
+|2.7.8|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:<tag>`
+
+`JIRA_TOKEN`
+
+`JIRA_URL`
+
+`
+
+|*Scorecard Backend Module for OpenSSF Security Scorecards*
+|0.2.12|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:<tag>`
+
+`
+
+|*Scorecard Backend Module for SonarQube*
+|0.1.7|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube:<tag>`
+
+`SONARQUBE_API_KEY`
+
+`
+
 |*Search Backend Module Azure DevOps*
-|0.5.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-search-backend-module-azure-devops:<tag>`
+|0.7.0|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-search-backend-module-azure-devops:<tag>`
 
 `AZURE_DEVOPS_BASE_URL`
 

--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -253,7 +253,7 @@ generate_community_table() {
             Required_Variables=$(get_required_variables "$metadata_file")
 
             # Skip if not a community plugin or no dynamic artifact
-            [[ "$support" != "community" ]] && continue
+            [[ "$support" != "community" && "$support" != "dev-preview" ]] && continue
             [[ -z "$dynamic_artifact" || "$dynamic_artifact" == "null" ]] && continue
             [[ "$dynamic_artifact" != "oci://ghcr.io"* ]] && continue
 

--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -22,7 +22,6 @@ BRANCH=main
 SKIP_TABLES=0
 SKIP_COMMUNITY_TABLE=0
 
-rhdhRepo="https://github.com/redhat-developer/rhdh"
 overlaysRepo="https://github.com/redhat-developer/rhdh-plugin-export-overlays"
 
 CATALOG_INDEX_REGISTRY="${CATALOG_INDEX_REGISTRY:-quay.io/rhdh}"

--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -17,7 +17,6 @@ red="\033[1;31m"
 orange="\033[1;35m"
 
 QUIET=1; # suppress debug output
-DO_CLEAN=0
 
 BRANCH=main
 SKIP_TABLES=0
@@ -64,7 +63,6 @@ Options:
   -b, --ref-branch          : Branch against which plugin versions should be incremented, like release-1.y; default: main
   --skip-tables             : Skip re-generating dynamic plugin tables and .csv
   --skip-community-table    : Skip re-generating the community plugins table
-  --clean                   : Force a clean GH checkout (do not reuse files on disk)
   -v                        : more verbose output
   -h, --help                : Show this help
 
@@ -82,7 +80,6 @@ if [[ "$#" -lt 1 ]]; then usage; exit 1; fi
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    '--clean') DO_CLEAN=1;;
     '-b'|'--ref-branch') BRANCH="$2"; shift 1;;        # reference branch, eg., 1.1.x
     '--skip-tables') SKIP_TABLES=1;;
     '--skip-community-table') SKIP_COMMUNITY_TABLE=1;;
@@ -147,7 +144,7 @@ generate_dynamic_plugins_table() {
     ref-technology-preview-plugins.adoc
     rhdh-supported-plugins.csv
   )
-  ls ${catalogindextmpdir}
+  ls "${catalogindextmpdir}"
   if [[ ! -d "$src" ]]; then
     echo -e "${red}[ERROR] Missing directory in catalog index image: $src${norm}" >&2
     exit 1
@@ -298,8 +295,8 @@ generate_community_table() {
     # LC_ALL=C sort the community table by plugin title and format for adoc
     COMMUNITY_TABLE_SORTED="/tmp/community_table_sorted_${BRANCH}.txt"
     if [[ -f "$COMMUNITY_TABLE_FILE" ]]; then
-        LC_ALL=C sort -t '|' -k1,1 "$COMMUNITY_TABLE_FILE" | while IFS='||' read -r key content; do
-            echo -e "$content\n" >> "$COMMUNITY_TABLE_SORTED"
+        LC_ALL=C sort -t '|' -k1,1 "$COMMUNITY_TABLE_FILE" | while read -r line; do
+            echo -e "${line#*||}\n" >> "$COMMUNITY_TABLE_SORTED"
         done
     fi
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->
Scorecard is missing from the community support plugins table due to it being labeled as dev-preview and not community. I made the filter accept dev-preview plugins as well since they fit the requirements of the table.

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.10
**Issue:**
[RHDHBUGS-3376](https://redhat.atlassian.net/browse/RHDHBUGS-3376)
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
