### PR TITLE
RHDHBUGS-3376: [release-1.10] include dev-preview plugins in community supported

### DIFF
--- a/modules/extend_dynamic-plugins-reference/ref-community-supported-plugins.adoc
+++ b/modules/extend_dynamic-plugins-reference/ref-community-supported-plugins.adoc
@@ -6,7 +6,7 @@
 = {company-name} community supported plugins
 
 [role="_abstract"]
-{company-name} provides community support for the following 44 dynamic plugins in `ghcr.io`.
+{company-name} provides community support for the following 51 dynamic plugins in `ghcr.io`.
 
 
 
@@ -27,6 +27,13 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 `THREESCALE_ACCESS_TOKEN`
 
 `THREESCALE_BASE_URL`
+
+`
+
+|*@backstage/plugin-mcp-actions-backend*
+|0.1.11|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-mcp-actions-backend:<tag>`
+
+`MCP_TOKEN`
 
 `
 
@@ -284,6 +291,42 @@ Replace `<tag>` with the version tag corresponding to your {product-short} versi
 
 |*Scaffolder Backend Module Utils*
 |4.1.2|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-utils:<tag>`
+
+`
+
+|*Scorecard Backend Module for Dependabot*
+|0.2.12|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:<tag>`
+
+`
+
+|*Scorecard Backend Module for Filechecks*
+|0.1.10|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-filecheck:<tag>`
+
+`
+
+|*Scorecard Backend Module for GitHub*
+|2.7.8|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:<tag>`
+
+`
+
+|*Scorecard Backend Module for Jira*
+|2.7.8|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:<tag>`
+
+`JIRA_TOKEN`
+
+`JIRA_URL`
+
+`
+
+|*Scorecard Backend Module for OpenSSF Security Scorecards*
+|0.2.12|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-openssf:<tag>`
+
+`
+
+|*Scorecard Backend Module for SonarQube*
+|0.1.7|`oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-sonarqube:<tag>`
+
+`SONARQUBE_API_KEY`
 
 `
 

--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -295,8 +295,8 @@ generate_community_table() {
     # LC_ALL=C sort the community table by plugin title and format for adoc
     COMMUNITY_TABLE_SORTED="/tmp/community_table_sorted_${BRANCH}.txt"
     if [[ -f "$COMMUNITY_TABLE_FILE" ]]; then
-        LC_ALL=C sort -t '|' -k1,1 "$COMMUNITY_TABLE_FILE" | while IFS='||' read -r key content; do
-            echo -e "$content\n" >> "$COMMUNITY_TABLE_SORTED"
+        LC_ALL=C sort -t '|' -k1,1 "$COMMUNITY_TABLE_FILE" | while read -r line; do
+            echo -e "${line#*||}\n" >> "$COMMUNITY_TABLE_SORTED"
         done
     fi
 

--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -250,7 +250,7 @@ generate_community_table() {
             Required_Variables=$(get_required_variables "$metadata_file")
 
             # Skip if not a community plugin or no dynamic artifact
-            [[ "$support" != "community" ]] && continue
+            [[ "$support" != "community" && "$support" != "dev-preview" ]] && continue
             [[ -z "$dynamic_artifact" || "$dynamic_artifact" == "null" ]] && continue
             [[ "$dynamic_artifact" != "oci://ghcr.io"* ]] && continue
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->
Scorecard is missing from the community support plugins table due to it being labeled as dev-preview and not community. I made the filter accept dev-preview plugins as well since they fit the requirements of the table.

**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
1.10
**Issue:**
[RHDHBUGS-3376](https://redhat.atlassian.net/browse/RHDHBUGS-3376)
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
