### PR TITLE
RHDHBUGS-769: add homepage card props reference and missing props tables

### DIFF
--- a/modules/shared/proc-arrange-homepage-card-layouts-to-optimize-visual-organization.adoc
+++ b/modules/shared/proc-arrange-homepage-card-layouts-to-optimize-visual-organization.adoc
@@ -258,6 +258,24 @@ dynamicPlugins:
                 * [{product-very-short} Plugins](https://github.com/redhat-developer/rhdh-plugins)
                 * [{product-very-short} Hub](https://github.com/redhat-developer/rhdh)
 ----
+
+|===
+| Prop | Default | Description
+
+| `title`
+| none
+| Title displayed above the Markdown content
+
+| `content`
+| none
+| Markdown content to render, supporting standard Markdown syntax such as headings, lists, links, and text formatting
+|===
+
+[NOTE]
+====
+`MarkdownCard` renders Markdown content inside a bordered card with a title header.
+`Markdown` renders the same content directly on the page without a card border or wrapper.
+====
 --
 
 Placeholder::
@@ -285,6 +303,18 @@ dynamicPlugins:
               showBorder: true
               debugContent: '1'
 ----
+
+|===
+| Prop | Default | Description
+
+| `showBorder`
+| `false`
+| Whether to display a visible border around the placeholder area
+
+| `debugContent`
+| none
+| Text content to display inside the placeholder for layout debugging
+|===
 --
 
 Catalog starred entities::

--- a/modules/shared/ref-available-homepage-cards.adoc
+++ b/modules/shared/ref-available-homepage-cards.adoc
@@ -4,20 +4,179 @@
 = Available homepage cards
 
 [role="_abstract"]
-Integrate custom features from installed plugins into your Home page by using available cards.
-Configure card visibility by attaching cards to RBAC groups using visibility rules.
+Use the available homepage cards to integrate custom features from installed plugins into your {product} Home page.
 
-The following is a list of the available homepage cards:
+Each card is configured as a mount point under `home.page/cards` in the `{my-app-config-file}` file.
+Cards support a `layouts` definition for responsive grid placement, `props` for component-specific configuration, and optional `visibilityRules` to control which users can see the card.
 
-** Search bar
-** Quick access
-** Headline
-** Markdown
-** Placeholder
-** Catalog starred entities
-** Featured docs
+The following table lists all available homepage cards:
 
-[NOTE]
-====
-Each card can have a `layouts` definition, `props` that depend on the component you use, and optional `visibilityRules` to control which users can see the card.
-====
+[cols="25%,25%,50%", frame="all", options="header"]
+|===
+|Card
+|`importName`
+|Description
+
+|Search bar
+|`SearchBar`
+|Provides search functionality directly on the Home page.
+
+|Quick access
+|`QuickAccessCard`
+|Functions as a customizable shortcut panel with configurable links.
+
+|Headline
+|`Headline`
+|Displays a text headline for important announcements or section headers.
+
+|Markdown card
+|`MarkdownCard`
+|Renders Markdown content inside a bordered card with a title header.
+
+|Markdown
+|`Markdown`
+|Renders Markdown content directly without a card border or wrapper.
+
+|Placeholder
+|`Placeholder`
+|Reserves space on the grid or assists with layout testing during development.
+
+|Catalog starred entities
+|`CatalogStarredEntitiesCard`
+|Displays catalog entities that the user has marked as starred.
+
+|Featured docs
+|`FeaturedDocsCard`
+|Highlights specific documentation within {product}.
+
+|Entity section
+|`EntitySection`
+|Highlights catalog entities of various kinds, such as `Component`, `API`, `Resource`, and `System`.
+
+|Onboarding section
+|`OnboardingSection`
+|Provides discovery of learning resources within {product-very-short}.
+
+|Template section
+|`TemplateSection`
+|Enables users to explore and initiate software templates.
+
+|Recently visited
+|`RecentlyVisitedCard`
+|Displays a list of catalog entities that the user recently visited.
+
+|Top visited
+|`TopVisitedCard`
+|Displays a list of catalog entities that the user visits most frequently.
+|===
+
+== SearchBar props
+
+[cols="20%,15%,15%,50%", frame="all", options="header"]
+|===
+|Prop
+|Type
+|Default
+|Description
+
+|`path`
+|string
+|`/search`
+|The search results page path that the search bar links to.
+
+|`queryParam`
+|string
+|`query`
+|The query parameter name appended to the search URL.
+|===
+
+== QuickAccessCard props
+
+[cols="20%,15%,15%,50%", frame="all", options="header"]
+|===
+|Prop
+|Type
+|Default
+|Description
+
+|`title`
+|string
+|`Quick Access`
+|The title displayed on the card header.
+
+|`path`
+|string
+|None
+|An optional path to a custom quick access data endpoint.
+|===
+
+== Headline props
+
+[cols="20%,15%,15%,50%", frame="all", options="header"]
+|===
+|Prop
+|Type
+|Default
+|Description
+
+|`title`
+|string
+|None
+|The headline text to display.
+|===
+
+== MarkdownCard and Markdown props
+
+The `MarkdownCard` and `Markdown` cards share the same props.
+`MarkdownCard` renders content inside a bordered card with a title header.
+`Markdown` renders content directly on the page without a card border or wrapper.
+
+[cols="20%,15%,15%,50%", frame="all", options="header"]
+|===
+|Prop
+|Type
+|Default
+|Description
+
+|`title`
+|string
+|None
+|The title displayed above the Markdown content.
+
+|`content`
+|string
+|None
+|The Markdown content to render. Supports standard Markdown syntax including headings, lists, links, bold, italic, and code blocks.
+|===
+
+== Placeholder props
+
+[cols="20%,15%,15%,50%", frame="all", options="header"]
+|===
+|Prop
+|Type
+|Default
+|Description
+
+|`showBorder`
+|boolean
+|`false`
+|Whether to display a visible border around the placeholder area.
+
+|`debugContent`
+|string
+|None
+|Text content to display inside the placeholder for layout debugging purposes.
+|===
+
+== Cards with no configurable props
+
+The following cards do not accept custom props and are configured by using `layouts` only:
+
+* `CatalogStarredEntitiesCard`
+* `FeaturedDocsCard`
+* `EntitySection`
+* `OnboardingSection`
+* `TemplateSection`
+* `RecentlyVisitedCard`
+* `TopVisitedCard`


### PR DESCRIPTION
Expand ref-available-homepage-cards.adoc from a bullet list into a comprehensive reference listing all 13 cards with importName, description, and props tables. Add missing props tables for MarkdownCard/Markdown and Placeholder to proc-arrange-homepage-card-layouts.adoc.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
release-1.10
**Issue:**
[RHDHBUGS-769](https://redhat.atlassian.net/browse/RHDHBUGS-769)
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
