### PR TITLE
RHDHBUGS-3283: Clarify OpenSSF Scorecard repository field

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -46,8 +46,8 @@ spec:
 +
 where:
 
-`_<owner>_`:: The GitHub organization or user account that owns the repository, for example, `ossf` or `kubernetes`.
-`_<repository>_`:: The name of the GitHub repository, for example, `scorecard` or `kubernetes`.
+`_<owner>_`:: Specifies the GitHub organization or user account that owns the repository, for example, `ossf` or `kubernetes`.
+`_<repository>_`:: Specifies the name of the GitHub repository, for example, `scorecard` or `kubernetes`.
 `annotations:openssf/scorecard-location`:: Specifies the full URL to the OpenSSF Scorecard API endpoint for the repository. The URL must start with `https://`. For example, `\https://api.securityscorecards.dev/projects/github.com/ossf/scorecard`.
 `spec:owner`:: Specifies your team name.
 +
@@ -58,7 +58,7 @@ For organizations running a self-hosted OpenSSF Scorecard instance, replace `api
 
 . Ingest the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file:
 +
-[source,yaml]
+[source,yaml,subs="+quotes"]
 ----
 catalog:
   locations:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc
@@ -46,7 +46,9 @@ spec:
 +
 where:
 
-`annotations:openssf/scorecard-location`:: Specifies the full URL to the OpenSSF Scorecard API endpoint for the repository. The URL must start with `https://`.
+`_<owner>_`:: The GitHub organization or user account that owns the repository, for example, `ossf` or `kubernetes`.
+`_<repository>_`:: The name of the GitHub repository, for example, `scorecard` or `kubernetes`.
+`annotations:openssf/scorecard-location`:: Specifies the full URL to the OpenSSF Scorecard API endpoint for the repository. The URL must start with `https://`. For example, `\https://api.securityscorecards.dev/projects/github.com/ossf/scorecard`.
 `spec:owner`:: Specifies your team name.
 +
 [NOTE]
@@ -61,7 +63,7 @@ For organizations running a self-hosted OpenSSF Scorecard instance, replace `api
 catalog:
   locations:
     - type: url
-      target: https://github.com/<owner>/<repository>/catalog-info.yaml
+      target: https://github.com/_<owner>_/_<repository>_/catalog-info.yaml
 ----
 
 [NOTE]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-3283
**Preview:** N/A

## Summary
- Define the `<owner>` and `<repository>` placeholders in the OpenSSF Scorecard integration procedure
- Add a concrete example URL (`ossf/scorecard`) so users can verify their configuration
- Fix italic markup on placeholders in the catalog ingest step for consistency

## Test plan
- [ ] Verify the placeholder definitions are clear and match the annotation URL format
- [ ] Verify the example URL (`https://api.securityscorecards.dev/projects/github.com/ossf/scorecard`) returns valid data
- [ ] Verify CQA checks pass with no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)