### PR TITLE
RHDHBUGS-3433: Add missing ScorecardPage dynamicRoutes configuration

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
@@ -38,6 +38,9 @@ plugins:
             dynamicRoutes:
               - path: /scorecard/aggregations/:aggregationId/metrics/:metricId
                 importName: ScorecardPage
+            translationResources:
+              - importName: scorecardTranslations
+                ref: scorecardTranslationRef
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:<tag>
     disabled: false
 ----

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-enable-scorecards.adoc
@@ -35,6 +35,9 @@ plugins:
                   if:
                     allOf:
                       - isKind: component
+            dynamicRoutes:
+              - path: /scorecard/aggregations/:aggregationId/metrics/:metricId
+                importName: ScorecardPage
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:<tag>
     disabled: false
 ----


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 1.10
**Issue:** https://redhat.atlassian.net/browse/RHDHBUGS-3433
**Preview:** N/A

## Summary
- Add the missing `dynamicRoutes` entry for `ScorecardPage` to the Scorecard plugin enable procedure
- Without this route, clicking homepage KPI aggregation cards results in a 404 because no route is registered at `/scorecard/aggregations/:aggregationId/metrics/:metricId`

## Test plan
- [ ] Enable the Scorecard plugin with the updated configuration
- [ ] Configure homepage KPI aggregation cards per existing docs
- [ ] Verify clicking an aggregation card navigates to the Scorecard page instead of a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)