### PR TITLE
[RHIDP#RHDHBUGS-3326]: Add Scorecard Dependabot integration documentation

### DIFF
--- a/assemblies/observability_evaluate-project-health-using-scorecards/assembly-install-and-configure-scorecards-to-view-metrics.adoc
+++ b/assemblies/observability_evaluate-project-health-using-scorecards/assembly-install-and-configure-scorecards-to-view-metrics.adoc
@@ -6,13 +6,15 @@ ifdef::context[:parent-context: {context}]
 :context: install-and-configure-scorecards-to-view-metrics
 
 [role="_abstract"]
-You can install and configure GitHub, Jira, and OpenSSF Scorecards to display metrics and visual health status for software components in the {product-very-short} catalog.
+You can install and configure GitHub, Jira, OpenSSF, and Dependabot Scorecards to display metrics and visual health status for software components in the {product-very-short} catalog.
 
 include::../modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc[leveloffset=+1]
 
 include::../modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc[leveloffset=+1]
 
 include::../modules/observability_evaluate-project-health-using-scorecards/proc-integrate-openssf-security-metrics-by-using-scorecards.adoc[leveloffset=+1]
+
+include::../modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc[leveloffset=+1]
 
 include::../modules/observability_evaluate-project-health-using-scorecards/proc-configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation.adoc[leveloffset=+1]
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
@@ -17,7 +17,7 @@ You can configure the Dependabot Scorecard module to display GitHub Dependabot a
 
 .Procedure
 
-. Enable the Dependabot Scorecard module: Add the following configuration to your {product-very-short} `dynamic-plugins-config.yaml` file:
+. Add the following configuration to your {product-very-short} `dynamic-plugins-config.yaml` file to enable the Dependabot Scorecard module:
 +
 [source,yaml]
 ----
@@ -28,7 +28,7 @@ plugins:
 +
 include::{docdir}/artifacts/snip-tag-for-OCI-package-paths.adoc[]
 
-. Annotate catalog entities: Link a component to the Dependabot data source by editing the `catalog-info.yaml` file for your {product-very-short} entity and adding the required annotations as shown in the following code:
+. Edit the `catalog-info.yaml` file for your {product-very-short} entity to link a component to the Dependabot data source by adding the required annotations as shown in the following code:
 +
 [source,yaml,subs="+quotes"]
 ----
@@ -53,7 +53,7 @@ where:
 `annotations:github.com/dependabot`:: Enables Dependabot alert collection for the entity. The value must be the exact string `'true'`.
 `spec:owner`:: Specifies your team name.
 
-. Ingest the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file:
+. Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file to ingest the catalog entity:
 +
 [source,yaml,subs="+quotes"]
 ----
@@ -63,7 +63,7 @@ catalog:
       target: https://github.com/_<owner>_/_<repository>_/catalog-info.yaml
 ----
 
-. Optional: Customize thresholds: Define custom threshold rules for the Dependabot alert metrics in your {product-very-short} `{my-app-config-file}` file:
+. Optional: Define custom threshold rules for the Dependabot alert metrics in your {product-very-short} `{my-app-config-file}` file:
 +
 [source,yaml]
 ----

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
@@ -51,7 +51,7 @@ where:
 `_<repository>_`:: Specifies the name of the GitHub repository.
 `annotations:github.com/project-slug`:: Specifies the GitHub repository in `owner/repository` format.
 `annotations:github.com/dependabot`:: Enables Dependabot alert collection for the entity. The value must be the exact string `'true'`.
-`spec:owner`:: Specifies your team or user name.
+`spec:owner`:: Specifies your team name or username.
 
 . Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file to ingest the catalog entity:
 +

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
@@ -1,0 +1,98 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="integrate-dependabot-alert-metrics-by-using-scorecards_{context}"]
+= Integrate Dependabot alert metrics by using Scorecards
+
+include::{docdir}/artifacts/snip-developer-preview-scorecard.adoc[]
+
+[role="_abstract"]
+You can configure the Dependabot Scorecard module to display GitHub Dependabot alert metrics in your {product-very-short} catalog. The module provides four severity-based metrics (critical, high, medium, and low) that score entities based on open Dependabot alerts.
+
+.Prerequisites
+
+* You have {install-category-link}[installed your {product-very-short} instance].
+* You have {scorecard-plugin-book-link}#set-up-scorecards-to-monitor-your-project-health_{context}[set up the Scorecard plugin].
+* You have {configuring-book-link}[added a custom {product-short} application configuration].
+* You have configured a GitHub integration with a token or GitHub App that has the `security_events` permission (or Dependabot read scope).
+
+.Procedure
+
+. Enable the Dependabot Scorecard module: Add the following configuration to your {product-very-short} `dynamic-plugins-config.yaml` file:
++
+[source,yaml]
+----
+plugins:
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-dependabot:<tag>
+    disabled: false
+----
++
+include::{docdir}/artifacts/snip-tag-for-OCI-package-paths.adoc[]
+
+. Annotate catalog entities: Link a component to the Dependabot data source by editing the `catalog-info.yaml` file for your {product-very-short} entity and adding the required annotations as shown in the following code:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: my-service
+  annotations:
+    github.com/project-slug: _<owner>_/_<repository>_
+    github.com/dependabot: 'true'
+spec:
+  type: service
+  lifecycle: production
+  owner: _<your_team_name>_
+----
++
+where:
+
+`_<owner>_`:: Specifies the GitHub organization or user account that owns the repository.
+`_<repository>_`:: Specifies the name of the GitHub repository.
+`annotations:github.com/project-slug`:: Specifies the GitHub repository in `owner/repository` format.
+`annotations:github.com/dependabot`:: Enables Dependabot alert collection for the entity. The value must be the exact string `'true'`.
+`spec:owner`:: Specifies your team name.
+
+. Ingest the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file:
++
+[source,yaml,subs="+quotes"]
+----
+catalog:
+  locations:
+    - type: url
+      target: https://github.com/_<owner>_/_<repository>_/catalog-info.yaml
+----
+
+. Optional: Customize thresholds: Define custom threshold rules for the Dependabot alert metrics in your {product-very-short} `{my-app-config-file}` file:
++
+[source,yaml]
+----
+scorecard:
+  plugins:
+    dependabot:
+      alerts_critical:
+        thresholds:
+          rules:
+            - key: success
+              expression: '<1'
+            - key: warning
+              expression: '1-7'
+            - key: error
+              expression: '>7'
+----
++
+where:
+
+`scorecard:plugins:dependabot:alerts_critical:thresholds`:: Specifies the threshold values for the critical-severity Dependabot alert metric. Replace `alerts_critical` with `alerts_high`, `alerts_medium`, or `alerts_low` to customize thresholds for the other severity levels.
+
++
+[NOTE]
+====
+Dependabot metrics use the following default thresholds for all four severity levels:
+
+* *Error*: More than 7 open alerts.
+* *Warning*: Between 1 and 7 open alerts.
+* *Success*: Fewer than 1 open alert.
+
+You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
+====

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
@@ -90,9 +90,13 @@ where:
 ====
 Dependabot metrics use the following default thresholds for all four severity levels:
 
-* *Error*: More than 7 open alerts.
-* *Warning*: Between 1 and 7 open alerts.
 * *Success*: Fewer than 1 open alert.
+* *Warning*: Between 1 and 7 open alerts.
+* *Error*: More than 7 open alerts.
 
 You can customize these thresholds in your {product-very-short} `{my-app-config-file}` file. For more information, see xref:scorecard-metric-thresholds_evaluate-project-health-using-scorecards[Scorecard metric thresholds].
 ====
+
+.Verification
+
+* In your {product-very-short} application, navigate to the catalog page for your component and confirm that the Dependabot metrics are displayed in the Scorecard view.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc
@@ -51,7 +51,7 @@ where:
 `_<repository>_`:: Specifies the name of the GitHub repository.
 `annotations:github.com/project-slug`:: Specifies the GitHub repository in `owner/repository` format.
 `annotations:github.com/dependabot`:: Enables Dependabot alert collection for the entity. The value must be the exact string `'true'`.
-`spec:owner`:: Specifies your team name.
+`spec:owner`:: Specifies your team or user name.
 
 . Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file to ingest the catalog entity:
 +

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -136,25 +136,25 @@ The following metric providers are supported:
 | `dependabot.alerts_critical`
 | Critical Dependabot alerts
 | Number of open critical-severity Dependabot alerts.
-| number (0-9)
+| number
 
 | Dependabot
 | `dependabot.alerts_high`
 | High Dependabot alerts
 | Number of open high-severity Dependabot alerts.
-| number (0-9)
+| number
 
 | Dependabot
 | `dependabot.alerts_medium`
 | Medium Dependabot alerts
 | Number of open medium-severity Dependabot alerts.
-| number (0-9)
+| number
 
 | Dependabot
 | `dependabot.alerts_low`
 | Low Dependabot alerts
 | Number of open low-severity Dependabot alerts.
-| number (0-9)
+| number
 
 | Filecheck
 | `filecheck._<key>_`

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -132,6 +132,30 @@ The following metric providers are supported:
 | Determines if the project has open, known unfixed vulnerabilities.
 | score (0-10)
 
+| Dependabot
+| `dependabot.alerts_critical`
+| Critical Dependabot alerts
+| Number of open critical-severity Dependabot alerts.
+| number (0-9)
+
+| Dependabot
+| `dependabot.alerts_high`
+| High Dependabot alerts
+| Number of open high-severity Dependabot alerts.
+| number (0-9)
+
+| Dependabot
+| `dependabot.alerts_medium`
+| Medium Dependabot alerts
+| Number of open medium-severity Dependabot alerts.
+| number (0-9)
+
+| Dependabot
+| `dependabot.alerts_low`
+| Low Dependabot alerts
+| Number of open low-severity Dependabot alerts.
+| number (0-9)
+
 | Filecheck
 | `filecheck._<key>_`
 | _<key>_

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -12,6 +12,36 @@ The following metric providers are supported:
 |===
 | Provider | Metric ID | Title | Description | Type
 
+| Dependabot
+| `dependabot.alerts_critical`
+| Critical Dependabot alerts
+| Number of open critical-severity Dependabot alerts.
+| number
+
+| Dependabot
+| `dependabot.alerts_high`
+| High Dependabot alerts
+| Number of open high-severity Dependabot alerts.
+| number
+
+| Dependabot
+| `dependabot.alerts_medium`
+| Medium Dependabot alerts
+| Number of open medium-severity Dependabot alerts.
+| number
+
+| Dependabot
+| `dependabot.alerts_low`
+| Low Dependabot alerts
+| Number of open low-severity Dependabot alerts.
+| number
+
+| Filecheck
+| `filecheck._<key>_`
+| _<key>_
+| Verifies that the configured file exists in the repository. The metric ID suffix and title are derived from the key you define in `scorecard.plugins.filecheck.files`. For more information, see {scorecard-plugin-book-link}#configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation_install-and-configure-scorecards-to-view-metrics[Configure file-level checks to verify repositories contain required compliance documentation].
+| boolean
+
 | GitHub
 | `github.open_prs`
 | GitHub open PRs
@@ -131,36 +161,6 @@ The following metric providers are supported:
 | Vulnerabilities
 | Determines if the project has open, known unfixed vulnerabilities.
 | score (0-10)
-
-| Dependabot
-| `dependabot.alerts_critical`
-| Critical Dependabot alerts
-| Number of open critical-severity Dependabot alerts.
-| number
-
-| Dependabot
-| `dependabot.alerts_high`
-| High Dependabot alerts
-| Number of open high-severity Dependabot alerts.
-| number
-
-| Dependabot
-| `dependabot.alerts_medium`
-| Medium Dependabot alerts
-| Number of open medium-severity Dependabot alerts.
-| number
-
-| Dependabot
-| `dependabot.alerts_low`
-| Low Dependabot alerts
-| Number of open low-severity Dependabot alerts.
-| number
-
-| Filecheck
-| `filecheck._<key>_`
-| _<key>_
-| Verifies that the configured file exists in the repository. The metric ID suffix and title are derived from the key you define in `scorecard.plugins.filecheck.files`. For more information, see {scorecard-plugin-book-link}#configure-file-level-checks-to-verify-repositories-contain-required-compliance-documentation_install-and-configure-scorecards-to-view-metrics[Configure file-level checks to verify repositories contain required compliance documentation].
-| boolean
 |===
 
 For information about customizing metric thresholds, see xref:scorecard-metric-thresholds_{context}[Scorecard metric thresholds].


### PR DESCRIPTION
> [!CAUTION]
> **IMPORTANT: Do Not Merge**
> This PR should not be merged until it has been reviewed and approved.

## Version(s)

- release-1.10

## Issue

https://issues.redhat.com/browse/RHDHBUGS-3326

## Preview

N/A

## Summary

- Add new procedure module (`proc-integrate-dependabot-alert-metrics-by-using-scorecards.adoc`) documenting how to enable and configure the Dependabot Scorecard backend module
- Update the "Install and configure Scorecards" assembly to include the new Dependabot procedure and mention Dependabot in the abstract
- Add four Dependabot severity metrics (`alerts_critical`, `alerts_high`, `alerts_medium`, `alerts_low`) to the metric providers reference table

🤖 Generated with [Claude Code](https://claude.com/claude-code)