### PR TITLE
Fix AWS CloudWatch link text to match updated page title

### DIFF
--- a/modules/observability_monitoring-and-logging/proc-retrieve-logs-from-amazon-cloudwatch.adoc
+++ b/modules/observability_monitoring-and-logging/proc-retrieve-logs-from-amazon-cloudwatch.adoc
@@ -8,7 +8,7 @@ Retrieve and query logs from your {product-short} instance by using Amazon Cloud
 
 .Prerequisites
 * CloudWatch Container Insights is used to capture logs and metrics for {eks-brand-name}.
-For more information, see https://docs.aws.amazon.com/prescriptive-guidance/latest/implementing-logging-monitoring-cloudwatch/logging-and-monitoring-on-amazon-eks.html[Logging for {eks-brand-name}] documentation.
+For more information, see https://docs.aws.amazon.com/prescriptive-guidance/latest/implementing-logging-monitoring-cloudwatch/logging-and-monitoring-on-amazon-eks.html[Logging and monitoring on {eks-brand-name}] documentation.
 
 * To capture the logs and metrics, link:https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-{eks-short}-addon.html[install the Amazon CloudWatch Observability {eks-short} add-on] in your cluster.
 Following the setup of Container Insights, you can access container logs using Logs Insights or Live Tail views.


### PR DESCRIPTION
> [!IMPORTANT]
> **IMPORTANT: Do Not Merge**
> This PR requires review and approval before merging.

## Summary

- Update the AWS CloudWatch documentation link text from "Logging for" to "Logging and monitoring on" to match the actual AWS page title after URL migration

## Details

The URL for the AWS EKS logging documentation was previously updated from `kubernetes-eks-logging.html` to `logging-and-monitoring-on-amazon-eks.html`, but the link text was not updated to match the new page title.

**Version(s):** main

**Issue:** Related to PR #2497 (release-1.10 cherry-pick that fixed both URL and link text)

**Preview:** N/A