### PR TITLE
RHIDP-15235: Update product documentation for NFS hard cut-over (legacy OFS removed in 2.1)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -17,3 +17,9 @@ file://.*titles-generated/index\.html$
 
 # operatorhub.io returns 503 errors intermittently
 ^https://operatorhub\.io/how-to-install-an-operator
+
+# vllm.ai rate-limits automated requests (429)
+^https://docs\.vllm\.ai
+
+# Docker Hub returns 504 gateway timeouts for automated requests
+^https://hub\.docker\.com

--- a/assemblies/configure_configuring-rhdh/assembly-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
+++ b/assemblies/configure_configuring-rhdh/assembly-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
@@ -10,7 +10,8 @@ ifdef::context[:parent-context: {context}]
 [role="_abstract"]
 Migrate your {product} environment to the extension-based front-end system to use blueprint-based dynamic routing for improved extensibility and performance.
 
-include::{docdir}/artifacts/snip-developer-preview.adoc[]
+// What changed in the front-end system
+include::../modules/shared/con-new-frontend-system-changes-in-rhdh-2-1.adoc[leveloffset=+1]
 
 // Customize the interface theme
 include::../modules/shared/proc-customize-platform-appearance-to-reflect-your-brand-identity.adoc[leveloffset=+1]
@@ -37,7 +38,13 @@ include::../modules/shared/proc-migrate-the-homepage-to-function-as-a-dynamic-pl
 include::../modules/shared/proc-enable-guided-tutorials-to-learn-platform-features.adoc[leveloffset=+1]
 
 // Preserve custom integrations when migrating to the front-end system
-include::../modules/shared/proc-preserve-custom-integrations-when-migrating-to-the-front-end-system.adoc[leveloffset=+1]
+include::../modules/shared/proc-preserve-custom-integrations-to-maintain-functionality-after-upgrade.adoc[leveloffset=+1]
+
+// Migrate custom plugins to the new front-end system
+include::../modules/shared/proc-migrate-custom-plugins-to-the-new-frontend-system.adoc[leveloffset=+1]
+
+// Application configuration changes reference
+include::../modules/shared/ref-app-config-changes-for-the-new-frontend-system.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/modules/shared/con-dynamic-front-end-plugins-for-application-use.adoc
+++ b/modules/shared/con-dynamic-front-end-plugins-for-application-use.adoc
@@ -1,86 +1,53 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="dynamic-front-end-plugins-for-application-use_{context}"]
-= Dynamic front-end plugins for application integration
+= Dynamic front-end plugins for controlled UI extensibility
 
 [role="_abstract"]
-A dynamic front-end plugin requires front-end wiring when it exports a feature for integration into the main {product-custom-resource-type} application UI. The following scenarios require wiring:
+You can choose which dynamic front-end plugin features are active in your {product-short} application by configuring extension blueprints.
+
+Each plugin exports its UI contributions through the `/alpha` entry point, and you control availability and behavior through the `app.extensions` section of your `{my-app-config-file}` file.
 
 [cols="1,1,2"]
 |===
-|Scenario|Wiring configuration|Description
+|Scenario|Extension blueprint|Description
 
-|{installing-and-viewing-plugins-book-link}#proc-customizing-and-extending-entity-tabs.adoc_assembly-front-end-plugin-wiring[Extending entity tabs]
-|`entityTabs`
+|Adding entity page content
+|`EntityContentBlueprint`
 |Add or customize a tab on the *Catalog entity* view.
 
-|{installing-and-viewing-plugins-book-link}#proc-binding-to-existing-plugins.adoc_assembly-front-end-plugin-wiring[Binding routes]
-|`routeBindings`
-|Link a route in one plugin to an external route defined by another plugin.
+|Adding entity page cards
+|`EntityCardBlueprint`
+|Add a card to an entity page section.
 
-|{installing-and-viewing-plugins-book-link}#proc-provide-additional-utility-apis.adoc_assembly-front-end-plugin-wiring[Integrating custom APIs]
-|`apiFactories`
+|Adding new pages
+|`PageBlueprint`
+|Add a new page and route to the application. For example, `/my-plugin`. Sidebar navigation entries are inferred automatically from page extensions.
+
+|Registering icons
+|`IconBundleBlueprint`
+|Add custom icons to the application catalog.
+
+|Providing APIs
+|`ApiBlueprint`
 |Supply a custom utility API implementation or override an existing one.
 
-|{installing-and-viewing-plugins-book-link}#proc-defining-dynamic-routes-for-new-plugin-pages.adoc_assembly-front-end-plugin-wiring[Enabling new pages/Routes]
-|`dynamicRoutes`
-|Add a new page and route to the application  (for example, `/my-plugin`).
-
-|{installing-and-viewing-plugins-book-link}#proc-using-mount-points.adoc_assembly-front-end-plugin-wiring[Extending existing pages/UI]
-|`mountPoints`
-|Inject custom widgets, cards, listeners, or providers into existing pages (for example, the *Catalog entity* page).
-
-|{installing-and-viewing-plugins-book-link}#proc-defining-dynamic-routes-for-new-plugin-pages.adoc_assembly-front-end-plugin-wiring[Customizing sidebar navigation]
-|`dynamicRoutes.menuItem`, `menuItems`
-|Add a new entry to the main sidebar or customize its order and nesting.
-
-|{installing-and-viewing-plugins-book-link}#proc-extending-internal-icon-catalog.adoc_assembly-front-end-plugin-wiring[Adding icons/Theming]
-|`appIcons`, `themes`
-|Add custom icons to the application catalog or define a new {product-custom-resource-type} theme.
-
-|{installing-and-viewing-plugins-book-link}#con-providing-custom-scaffolder-field-extensions.adoc_assembly-front-end-plugin-wiring[Scaffolder/TechDocs extensions]
-|`scaffolderFieldExtensions`, `techdocsAddons`
-|Expose custom field extensions for the Scaffolder or new add-ons for TechDocs.
-
-|{installing-and-viewing-plugins-book-link}#proc-extensions-enabling-plugins-installation_rhdh-extensions-plugins[Translation resources]
-|`translationResources`
-|Offer new translation files or override default plugin translations.
+|Adding translation resources
+|`TranslationBlueprint`
+|Provide translation files or override default plugin translations.
 |===
 
-== Example of Front-end wiring workflow
+[id="operator-configuration-for-extensions_{context}"]
+== Operator configuration for extensions
 
-Front-end wiring configuration occurs in the `{my-app-config-file}` or a dedicated `dynamic-plugins-config.yaml` file. The dynamic plugin exposes components, routes, or APIs. For example, a module exports a plugin component.
+Plugins declare their extension defaults in code. Extensions from an installed plugin are auto-discovered and loaded by default. As an operator, you use the `app.extensions` section in your `{my-app-config-file}` file to disable, reorder, or override extension configuration:
 
-The application administrator defines the wiring in the configuration file, using the plugin package name to register the exports, such as adding a new page with a sidebar link.
-
-[source,yaml,subs="+quotes"]
+[source,yaml]
 ----
-# dynamic-plugins-config.yaml
-plugins:
-  - plugin: __<plugin_path_or_url>__
-    disabled: false
-    pluginConfig:
-      dynamicPlugins:
-        frontend:
-          my-plugin-package-name: # The plugin's unique package name
-            dynamicRoutes: # Wiring for a new page/route
-              - path: /my-new-page # The desired URL path
-                importName: __<my-plugin>__PluginPage # The exported component name
-                menuItem: # Wiring for the sidebar entry
-                  icon: favorite # A registered icon name
-                  text: My Custom Page
+app:
+  extensions:
+    - entity-card:my-plugin/my-component:
+        config:
+          filter: kind:Component
+    - entity-card:my-plugin/unused-component: false
 ----
-
-When the application loads, it performs the following steps:
-
-. It parses the `dynamic-plugins-config.yaml`.
-. It uses the `_<plugin_path_or_url>_` to download the plugin bundle using the dynamic loading mechanism.
-. If the package exports the plugin object, the application adds it to the list provided to the {product-custom-resource-type} `createApp` API, registering the plugin properly with the front-end application.
-. It uses the configuration block (`dynamicRoutes`, `menuItem`) to:
-* Add an entry to the internal router mapping `/my-new-page` to the `__<my-plugin>__PluginPage` component.
-* Construct and render a new sidebar item labeled _My Custom Page_, pointing to the `/my-new-page` route.
-
-[NOTE]
-====
-If the configuration is missing, steps 1 and 2 might still occur, but the application skips the final registration in step 3 and the wiring/rendering in step 4, and no UI changes occur.
-====

--- a/modules/shared/con-front-end-plugin-wiring.adoc
+++ b/modules/shared/con-front-end-plugin-wiring.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="front-end-plugin-wiring_{context}"]
-= Front-end plugin wiring
+= Front-end plugin wiring for extension-based customization
 
 [role="_abstract"]
-Front-end plugin wiring integrates dynamic front-end plugin components, such as new pages, UI extensions, icons, and APIs, into {product}.
+Front-end plugin wiring in {product} {product-version} uses extension blueprints so that you can control how dynamic plugins contribute pages, UI components, icons, and APIs to the application.
 
-Because the dynamic plugins load at runtime, the core application must discover and connect the exported assets of the plugin to the appropriate user interface systems and locations.
+Plugins declare their extensions through the `/alpha` export by using typed blueprints, such as `PageBlueprint`, `EntityCardBlueprint`, and `IconBundleBlueprint`. The {product-short} application discovers and connects these extensions at runtime by using the extension tree, which resolves attachments by matching extension outputs to parent inputs. You control which extensions you enable, disable, or configure through the `app.extensions` section of your `{my-app-config-file}` file.

--- a/modules/shared/con-new-frontend-system-changes-in-rhdh-2-1.adoc
+++ b/modules/shared/con-new-frontend-system-changes-in-rhdh-2-1.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="front-end-system-changes-that-affect-your-upgrade_{context}"]
+= Front-end system changes that affect your {product} upgrade
+
+[role="_abstract"]
+{product} {product-version} uses the new front-end system exclusively. {product-version} removes the old front-end system, and you must migrate all custom plugins and configuration before upgrading. Plugins that have not been migrated are not loaded and do not appear in the application.
+
+The following changes affect your upgrade:
+
+Red Hat plugins:: All Red Hat-provided plugins use extension blueprints. You do not need to take any action for these plugins.
+
+Community plugins:: Community plugins that already use the new front-end system work without changes. Check each community plugin for an `/alpha` export to confirm compatibility.
+
+Custom plugins:: You must migrate custom plugins that use the old front-end system to extension blueprints before upgrading. Plugins without an `/alpha` export do not load in {product} {product-version}.
++
+--
+If an unmigrated plugin remains in the `dynamic-plugins-root` directory, check the backend logs for the missing-manifest error:
+
+* `Could not find manifest for frontend plugin <plugin_name>`
+
+If the plugin loads remotely but still does not appear, check the browser console for the following debug-level message:
+
+* `Skipping dynamic plugin remote module '...' since it doesn't export a new 'FrontendFeature' as default export`
+--
+
+Application configuration:: The `app.extensions` section in your `{my-app-config-file}` file replaces the `dynamicPlugins.frontend` configuration section, including `dynamicRoutes`, `mountPoints`, `entityTabs`, `appIcons`, `menuItems`, and `routeBindings`.
+
+{product} {product-version} removes the following configuration options and environment variables, which have no effect:
+
+* `APP_CONFIG_app_packageName`
+* `ENABLE_STANDARD_MODULE_FEDERATION`
+* `DISABLE_STANDARD_MODULE_FEDERATION`
+* Scalprum-specific fields in `package.json` (`scalprum.name`, `scalprum.exposedModules`)
+* The `dist-scalprum` build output directory
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/migrating-config-to-new-frontend-system.md[{product-short} configuration migration guide]
+* link:https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/migrating-plugins-to-new-frontend-system.md[{product-short} plugin migration guide]
+* link:https://backstage.io/docs/frontend-system/building-plugins/migrating/[Upstream plugin migration guide]
+* link:https://backstage.io/docs/frontend-system/building-apps/migrating/[Upstream application migration guide]

--- a/modules/shared/con-understand-why-front-end-wiring-is-required.adoc
+++ b/modules/shared/con-understand-why-front-end-wiring-is-required.adoc
@@ -1,17 +1,17 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="understand-why-front-end-wiring-is-required_{context}"]
-= Reasons for requiring front-end plugin wiring
+= Extension declarations that enable dynamic plugin discovery
 
 [role="_abstract"]
-Because dynamic front-end plugins load their code at runtime, the {product-short} application requires explicit instructions to integrate the plugin components in the user interface (UI).
+Each dynamic front-end plugin must declare its UI contributions through extension blueprints so that {product-short} can discover, connect, and render them at runtime.
 
-Front-end wiring provides the metadata and instructions necessary to bridge this gap, informing the applications on how to:
+Extension blueprints enable plugins to:
 
-* {installing-and-viewing-plugins-book-link}#proc-defining-dynamic-routes-for-new-plugin-pages.adoc_assembly-front-end-plugin-wiring[Add new pages and routes to the main application]. (using `dynamicRoutes`)
-* {installing-and-viewing-plugins-book-link}#proc-using-mount-points.adoc_assembly-front-end-plugin-wiring[Inject custom components into existing UI pages]. (using `mountPoints`)
-* {installing-and-viewing-plugins-book-link}#proc-extending-internal-icon-catalog.adoc_assembly-front-end-plugin-wiring[Configure application-wide customizations, such as new icons or themes]. (using `appIcons`)
-* {installing-and-viewing-plugins-book-link}#proc-customizing-sidebar-menu-items.adoc_assembly-front-end-plugin-wiring[Add new menu items]. (using `menuItems`)
-* {installing-and-viewing-plugins-book-link}#proc-binding-to-existing-plugins.adoc_assembly-front-end-plugin-wiring[Bind to existing plugins]. (using `routeBindings`)
+* Add new pages and routes by using `PageBlueprint`
+* Inject custom components into entity pages by using `EntityCardBlueprint` or `EntityContentBlueprint`
+* Register application-wide icons by using `IconBundleBlueprint`
+* Add navigation items automatically by using `PageBlueprint` (sidebar entries are inferred from page extensions)
+* Provide or replace utility APIs by using `ApiBlueprint`
 
-The wiring configuration, typically located in `{my-app-config-file}` or `dynamic-plugins-config.yaml`, gives the application the necessary metadata (including the component names, paths, and integration points) to render and use the plugin features.
+Each plugin exports its extensions through the `/alpha` entry point. You control which extensions to enable and how to configure them through the `app.extensions` section of your `{my-app-config-file}` file.

--- a/modules/shared/proc-migrate-custom-plugins-to-the-new-frontend-system.adoc
+++ b/modules/shared/proc-migrate-custom-plugins-to-the-new-frontend-system.adoc
@@ -1,0 +1,95 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="migrate-custom-plugins-to-ensure-compatibility-after-upgrade_{context}"]
+= Migrate custom plugins to ensure compatibility after upgrade
+
+[role="_abstract"]
+Migrate your custom front-end plugins to the new front-end system by adding an `/alpha` export with extension blueprints before upgrading to {product} {product-version}. Plugins without an `/alpha` export do not load in {product} {product-version}.
+
+.Prerequisites
+
+* You have a custom front-end plugin that uses the old front-end system.
+* You have access to the plugin source code.
+* You have installed the required {product} CLI (`@red-hat-developer-hub/cli`).
+
+.Procedure
+
+. Identify the plugin features that require migration by reviewing your `dynamicPlugins.frontend` configuration for the plugin. Note which wiring types the plugin uses, such as `dynamicRoutes`, `mountPoints`, `entityTabs`, or `appIcons`.
+
+. Add the required blueprint dependencies to your plugin's `package.json` file:
++
+[source,bash]
+----
+yarn add @backstage/frontend-plugin-api
+----
++
+If your plugin adds entity page content, also add:
++
+[source,bash]
+----
+yarn add @backstage/plugin-catalog-react
+----
+
+. Create an `/alpha` export file in your plugin's `src` directory (for example, `src/alpha.ts` or `src/alpha/index.ts`). Define your extensions by using the appropriate blueprint for each feature:
++
+[source,typescript]
+----
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+
+const myEntityCard = EntityCardBlueprint.make({
+  name: 'my-component',
+  params: {
+    filter: entity => entity.kind === 'Component',
+    loader: () => import('./components/MyComponent').then(m => <m.MyComponent />),
+  },
+});
+
+export default createFrontendPlugin({
+  pluginId: 'my-plugin',
+  extensions: [myEntityCard],
+});
+----
+
+. Add the `/alpha` export to your plugin's `package.json` file:
++
+[source,json]
+----
+{
+  "name": "@my-org/backstage-plugin-my-plugin",
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts"
+  }
+}
+----
+
+. Export the plugin as a dynamic plugin by using the {product-very-short} CLI:
++
+[source,bash]
+----
+npx @red-hat-developer-hub/cli plugin export
+----
+
+. Remove the old `dynamicPlugins.frontend` wiring configuration for this plugin from your `{my-app-config-file}` file.
+
+. Verify that the plugin extensions load. Extensions from an installed plugin are auto-discovered and loaded by default. If you need to disable, reorder, or override extension configuration, use the `app.extensions` section of your `{my-app-config-file}` file:
++
+[source,yaml]
+----
+app:
+  extensions:
+    - entity-card:my-plugin/my-component:
+        config:
+          filter: kind:Component
+----
+
+.Verification
+
+. Start your {product} instance with the migrated plugin.
+. Verify that the plugin features appear in the expected locations.
+. Confirm that conditional rendering, such as entity kind filtering, works as expected.
+
+.Troubleshooting
+
+If a plugin does not load after migration, check the browser console for extension resolution errors. Verify the `/alpha` export and that extension IDs in `app.extensions` use the same `pluginId` declared in `createFrontendPlugin`. The `pluginId` is the short frontend-system identifier (for example, `my-plugin`), not the npm package name (for example, `@my-org/backstage-plugin-my-plugin`).

--- a/modules/shared/proc-preserve-custom-integrations-to-maintain-functionality-after-upgrade.adoc
+++ b/modules/shared/proc-preserve-custom-integrations-to-maintain-functionality-after-upgrade.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="preserve-custom-integrations-when-migrating-to-the-front-end-system_{context}"]
-= Preserve custom integrations when migrating to the front-end system
+[id="preserve-custom-integrations-to-maintain-functionality-after-upgrade_{context}"]
+= Preserve custom integrations to maintain functionality after upgrade
 
 [role="_abstract"]
-Migrate your mount points and custom components from the Scalprum-based system to {product} extension-based front-end system by converting YAML-based mount points to extension blueprints.
+Convert your YAML-based mount points to extension blueprints before upgrading to {product} {product-version}. {product-version} removes the old front-end system, and all custom integrations must use the extension-based front-end system.
 
-Your existing mount points for entity pages, application headers, search filters, and admin pages map to specific extension attachment points in the front-end system. The extension tree resolves attachments by matching extension outputs to parent inputs. Blueprints provide typed patterns for common extension types including pages, navigation items, and entity content.
+Your existing mount points for entity pages, application headers, search filters, and admin pages map to specific extension attachment points. The extension tree resolves attachments by matching extension outputs to parent inputs. Blueprints provide typed patterns for common extension types including pages, navigation items, and entity content.
 
 Available entity page mount points:
 
@@ -27,9 +27,8 @@ Available entity page mount points:
 
 .Prerequisites
 
-* You have access to the `packages/app/src/App.tsx` file.
 * You have access to your `{my-app-config-file}` file.
-* You understand your current mount point configuration in the `dynamicPlugins.frontend` section.
+* You have identified your current mount point configuration in the `dynamicPlugins.frontend` section.
 
 .Procedure
 
@@ -57,12 +56,12 @@ dynamicPlugins:
 | Previous mount point | Current extension attachment | Blueprint to use
 
 | `entity.page.overview/cards`
-| `page:catalog/entity` with input `contents`
-| `EntityContentBlueprint` or `EntityCardBlueprint`
+| `entity-content:catalog/overview` with input `cards`
+| `EntityCardBlueprint`
 
 | `entity.page.*/cards`
-| `page:catalog/entity` with input `contents`
-| `EntityContentBlueprint`
+| `entity-content:catalog/<tab>` with input `cards`
+| `EntityCardBlueprint`
 
 | `application/header`
 | `app/root` with custom attachment
@@ -124,20 +123,14 @@ const myTab = EntityContentBlueprint.make({
 });
 ----
 
-. To activate the migrated plugin, update your `packages/app/src/App.tsx` file to import it:
+. Export the migrated plugin as a dynamic plugin by using the {product-very-short} CLI:
 +
-[source,typescript]
+[source,bash]
 ----
-import { createApp } from '@backstage/frontend-defaults';
-import myPlugin from '@my-org/backstage-plugin-my-plugin/alpha';
-
-export default createApp({
-  features: [
-    myPlugin,
-    // Additional plugins
-  ],
-});
+npx @red-hat-developer-hub/cli plugin export
 ----
++
+Extensions from the installed plugin are auto-discovered and loaded by default. If you need to disable, reorder, or override extension configuration, use the `app.extensions` section of your `{my-app-config-file}` file.
 
 . To complete the migration, remove the previous mount point configuration from your `{my-app-config-file}` file after verifying the migration works.
 

--- a/modules/shared/ref-app-config-changes-for-the-new-frontend-system.adoc
+++ b/modules/shared/ref-app-config-changes-for-the-new-frontend-system.adoc
@@ -1,0 +1,179 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="configuration-key-mapping-from-old-to-new-front-end-system_{context}"]
+= Configuration key mapping from old to new front-end system
+
+[role="_abstract"]
+{product} {product-version} replaces the `dynamicPlugins.frontend` configuration with the `app.extensions` section. Use the old-to-new mapping to convert your existing plugin configuration during an upgrade.
+
+[id="page-route-configuration_{context}"]
+== Page route configuration
+
+Old `dynamicRoutes` configuration (removed in {product-version}):
+
+[source,yaml,subs="+quotes"]
+----
+dynamicPlugins:
+  frontend:
+    my-plugin-package:
+      dynamicRoutes:
+        - path: /my-page
+          importName: MyPluginPage
+          menuItem:
+            icon: dashboard
+            text: My Page
+----
+
+Page extensions are auto-discovered and loaded by default. Sidebar navigation entries are inferred automatically from `page:*` extensions. Use `app.extensions` to disable or override configuration if needed:
+
+[source,yaml]
+----
+app:
+  extensions:
+    - page:my-plugin/my-page:
+        config:
+          path: /my-page
+          title: My Page
+----
+
+[id="entity-page-card-configuration_{context}"]
+== Entity page card configuration
+
+Old `mountPoints` configuration (removed in {product-version}):
+
+[source,yaml,subs="+quotes"]
+----
+dynamicPlugins:
+  frontend:
+    my-plugin-package:
+      mountPoints:
+        - mountPoint: entity.page.overview/cards
+          importName: MyComponent
+          config:
+            if:
+              isKind: component
+            layout:
+              xs: { w: 12, h: 4 }
+----
+
+Entity card extensions are auto-discovered and loaded by default. Use `app.extensions` to disable or override configuration if needed. The legacy `config.if` filter maps to `config.filter` in the new system. The `config.layout` grid positioning is not available in `app.extensions`; card layout is determined by the card type (`info` for sidebar, `content` for main area) or by the plugin component.
+
+[source,yaml]
+----
+app:
+  extensions:
+    - entity-card:my-plugin/my-component:
+        config:
+          filter: kind:Component
+----
+
+[id="entity-page-tab-configuration_{context}"]
+== Entity page tab configuration
+
+Old `entityTabs` configuration (removed in {product-version}):
+
+[source,yaml,subs="+quotes"]
+----
+dynamicPlugins:
+  frontend:
+    my-plugin-package:
+      entityTabs:
+        - path: /my-tab
+          title: My Tab
+          mountPoint: entity.page.my-tab
+----
+
+Entity content extensions are auto-discovered and loaded by default. Use `app.extensions` to disable or override configuration if needed:
+
+[source,yaml]
+----
+app:
+  extensions:
+    - entity-content:my-plugin/my-tab:
+        config:
+          path: /my-tab
+          title: My Tab
+----
+
+[id="route-binding-configuration_{context}"]
+== Route binding configuration
+
+Old `routeBindings` configuration (removed in {product-version}):
+
+[source,yaml,subs="+quotes"]
+----
+dynamicPlugins:
+  frontend:
+    my-plugin-package:
+      routeBindings:
+        targets:
+          - importName: catalogPlugin
+        bindings:
+          - bindTarget: catalogPlugin.externalRoutes
+            bindMap:
+              viewTechDoc: techdocsPlugin.routes.docRoot
+----
+
+Equivalent `app.routes.bindings` configuration:
+
+[source,yaml]
+----
+app:
+  routes:
+    bindings:
+      catalog.viewTechDoc: techdocs.docRoot
+----
+
+Most plugins resolve route bindings automatically through the extension tree. Use `app.routes.bindings` only when you need to override a default binding.
+
+[id="icon-registration_{context}"]
+== Icon registration
+
+Old `appIcons` configuration (removed in {product-version}):
+
+[source,yaml,subs="+quotes"]
+----
+dynamicPlugins:
+  frontend:
+    my-plugin-package:
+      appIcons:
+        - name: myIcon
+          importName: MyIcon
+----
+
+Plugins register icons by using `IconBundleBlueprint` in their `/alpha` export. You do not need to add any `{my-app-config-file}` configuration.
+
+[id="summary-of-removed-configuration-keys_{context}"]
+== Summary of removed configuration keys
+
+[cols="1,1"]
+|===
+|Removed key|Replacement
+
+|`dynamicPlugins.frontend.<plugin>.dynamicRoutes`
+|`app.extensions` with `page:` entries (sidebar navigation is inferred automatically)
+
+|`dynamicPlugins.frontend.<plugin>.mountPoints`
+|`app.extensions` with `entity-card:` or `entity-content:` entries
+
+|`dynamicPlugins.frontend.<plugin>.entityTabs`
+|`app.extensions` with `entity-content:` entries
+
+|`dynamicPlugins.frontend.<plugin>.appIcons`
+|`IconBundleBlueprint` in plugin `/alpha` export
+
+|`dynamicPlugins.frontend.<plugin>.menuItems`
+|Sidebar entries are inferred from `page:*` extensions; use `app.extensions` ordering to control priority
+
+|`dynamicPlugins.frontend.<plugin>.routeBindings`
+|`app.routes.bindings` (most resolve automatically)
+
+|`dynamicPlugins.frontend.<plugin>.apiFactories`
+|`ApiBlueprint` in plugin `/alpha` export
+
+|`dynamicPlugins.frontend.<plugin>.scaffolderFieldExtensions`
+|`ScaffolderFieldExtensionBlueprint` in plugin `/alpha` export
+
+|`dynamicPlugins.frontend.<plugin>.translationResources`
+|`TranslationBlueprint` in plugin `/alpha` export
+|===

--- a/titles/product_product/category-maps/migrate/nav-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
+++ b/titles/product_product/category-maps/migrate/nav-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc
@@ -6,6 +6,8 @@
 
 include::con-migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing.adoc[leveloffset=+1]
 
+include::modules/shared/con-new-frontend-system-changes-in-rhdh-2-1.adoc[leveloffset=+1]
+
 include::modules/shared/proc-customize-platform-appearance-to-reflect-your-brand-identity.adoc[leveloffset=+1]
 
 include::modules/shared/proc-update-global-header-mount-points-to-integrate-securely-with-the-new-blueprint-architecture.adoc[leveloffset=+1]
@@ -22,4 +24,8 @@ include::modules/shared/proc-migrate-the-homepage-to-function-as-a-dynamic-plugi
 
 include::modules/shared/proc-enable-guided-tutorials-to-learn-platform-features.adoc[leveloffset=+1]
 
-include::modules/shared/proc-preserve-custom-integrations-when-migrating-to-the-front-end-system.adoc[leveloffset=+1]
+include::modules/shared/proc-preserve-custom-integrations-to-maintain-functionality-after-upgrade.adoc[leveloffset=+1]
+
+include::modules/shared/proc-migrate-custom-plugins-to-the-new-frontend-system.adoc[leveloffset=+1]
+
+include::modules/shared/ref-app-config-changes-for-the-new-frontend-system.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1, main
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHIDP-15235](https://redhat.atlassian.net/browse/RHIDP-15235)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[4.1. Front-end system changes that affect your Red Hat Developer Hub upgrade](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2499/configure_configuring-rhdh/#front-end-system-changes-that-affect-your-upgrade_migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing)
[4.11. Migrate custom plugins to ensure compatibility after upgrade](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2499/configure_configuring-rhdh/#migrate-custom-plugins-to-ensure-compatibility-after-upgrade_migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing)
[4.12. Configuration key mapping from old to new front-end system](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2499/configure_configuring-rhdh/#configuration-key-mapping-from-old-to-new-front-end-system_migrate-to-the-front-end-system-to-use-blueprint-based-dynamic-routing)
