### PR TITLE
[RHIDP#14276]: Document new standalone Helm chart values reference

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -137,7 +137,7 @@
 :control-access-category-link: {product-docs-link}/#Control access
 :customizing-book-link: {product-docs-link}/html-single/customizing_red_hat_developer_hub/index
 :customizing-book-title: Customizing {product}
-:default-helm-chart-values-link: link:https://github.com/redhat-developer/rhdh-chart/blob/release-{product-version}/charts/rhdh/values.yaml
+:default-helm-chart-values-link: link:https://github.com/redhat-developer/rhdh-chart/blob/release-{product-version}/charts/backstage/values.yaml
 :develop-and-deploy-dynamic-plugins-book-link: {product-docs-link}/html-single/develop_and_deploy_dynamic_plugins_in_red_hat_developer_hub/index
 :develop-and-deploy-dynamic-plugins-book-title: Develop and deploy dynamic plugins in {product}
 :developer-lightspeed-book-link: {product-docs-link}/html-single/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/index

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -137,7 +137,7 @@
 :control-access-category-link: {product-docs-link}/#Control access
 :customizing-book-link: {product-docs-link}/html-single/customizing_red_hat_developer_hub/index
 :customizing-book-title: Customizing {product}
-:default-helm-chart-values-link: link:https://github.com/redhat-developer/rhdh-chart/blob/release-{product-version}/charts/backstage/values.yaml
+:default-helm-chart-values-link: link:https://github.com/redhat-developer/rhdh-chart/blob/release-{product-version}/charts/rhdh/values.yaml
 :develop-and-deploy-dynamic-plugins-book-link: {product-docs-link}/html-single/develop_and_deploy_dynamic_plugins_in_red_hat_developer_hub/index
 :develop-and-deploy-dynamic-plugins-book-title: Develop and deploy dynamic plugins in {product}
 :developer-lightspeed-book-link: {product-docs-link}/html-single/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/index

--- a/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
+++ b/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
@@ -22,7 +22,7 @@ The values are organized into the following categories:
 * OpenShift
 * Database
 * Metrics
-* Lightspeed
+* {ls-brand-name}
 * Orchestrator
 * Test
 

--- a/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
+++ b/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
@@ -8,25 +8,39 @@ ifdef::context[:parent-context: {context}]
 :context: helm-chart-configuration-reference
 
 [role="_abstract"]
-Use the overview of default Helm Chart values to configure and customize your {product-very-short} deployment.
+Use the overview of default Helm chart values to configure and customize your {product-very-short} deployment.
 
-The values are organized into five main categories, which cover the key namespaces that organize the chart's hierarchical configuration structure:
+The values are organized into the following categories:
 
-* Global
+* Global and chart configuration
+* Container image
+* Application configuration
+* Environment and command overrides
+* Dynamic plugins
+* Deployment and pod
+* Networking
+* OpenShift
+* Database
+* Metrics
+* Lightspeed
 * Orchestrator
-* Route
 * Test
-* Upstream
 
 
 include::../../modules/configure_helm-chart-config-reference/proc-display-a-complete-list-of-helm-chart-values-with-helm-cli.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-root-namespace-value.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-global-namespace-values.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-orchestrator-namespace-values.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-route-namespace-values.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-test-namespace-values.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-upstream-namespace-values.adoc[leveloffset=+1]
-include::../../modules/configure_helm-chart-config-reference/ref-additional-upstream-chart-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-global-and-chart-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-image-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-application-config-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-environment-and-command-override-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-dynamic-plugins-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-networking-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-openshift-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-database-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-metrics-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-orchestrator-values.adoc[leveloffset=+1]
+include::../../modules/configure_helm-chart-config-reference/ref-test-values.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
+++ b/assemblies/configure_helm-chart-config-reference/assembly-helm-chart-configuration-reference.adoc
@@ -22,7 +22,7 @@ The values are organized into the following categories:
 * OpenShift
 * Database
 * Metrics
-* {ls-brand-name}
+* Lightspeed
 * Orchestrator
 * Test
 

--- a/modules/configure_helm-chart-config-reference/proc-display-a-complete-list-of-helm-chart-values-with-helm-cli.adoc
+++ b/modules/configure_helm-chart-config-reference/proc-display-a-complete-list-of-helm-chart-values-with-helm-cli.adoc
@@ -8,42 +8,30 @@ Use the available options to configure {product} with Helm Charts: the Helm depl
 
 .Procedure
 
-. Pull the released {product-very-short} Helm Chart, including all its dependencies:
+. Pull the released {product-very-short} Helm chart, including all its dependencies:
 +
 [,console,subs="+attributes,+quotes"]
 ----
-$ helm pull redhat-developer-hub \
+$ helm pull rhdh \
   --repo https://charts.openshift.io \
   --version {product-chart-version} \
   --untar
 ----
-. View default values:
-+
-.. View default values of the {product-very-short} Chart.
+. View default values of the {product-very-short} Chart:
 +
 [,console]
 ----
-$ helm show values redhat-developer-hub
+$ helm show values rhdh
 ----
 +
-.. View default values of the upstream {backstage} Chart. The fields can be set under the `upstream` scope when deploying the {product-very-short} Chart.
-+
-[,console]
-----
-$ helm show values redhat-developer-hub/charts/backstage
-----
-+
-.. Optional: View default values of the upstream PostgreSQL Chart, which is a dependency of the upstream {backstage} Chart.
+. Optional: View default values of the built-in PostgreSQL Chart, which is a dependency of the {product-very-short} Chart:
 +
 [IMPORTANT]
 ====
-Using the local PostgreSQL database is **not recommended for production**, as you should be using your own external database. However, it allows for visibility into the local database. For more information, see {configuring-book-link}#proc-configuring-postgresql-instance-using-helm_configuring-external-postgresql-databases[Configuring an external PostgreSQL instance using the Helm Chart].
+Using the local PostgreSQL database is **not recommended for production**, as you should be using your own external database. However, it allows for visibility into the local database. For more information, see {configuring-book-link}#proc-configuring-postgresql-instance-using-helm_configuring-external-postgresql-databases[Configuring an external PostgreSQL instance using the Helm chart].
 ====
-... The fields can be set under the `upstream.postgresql` scope when deploying the {product-very-short} Chart.
 +
 [,console]
 ----
-$ helm show values redhat-developer-hub/charts/backstage/charts/postgresql
+$ helm show values rhdh/charts/postgresql
 ----
-
-

--- a/modules/configure_helm-chart-config-reference/ref-application-config-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-application-config-values.adoc
@@ -1,0 +1,97 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="application-config-values_{context}"]
+= Application configuration values
+
+[role="_abstract"]
+You can configure the {backstage} application settings and backend service-to-service authentication for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|appConfig
+|Inline {backstage} app-config YAML. Rendered into a ConfigMap and mounted as `app-config-from-configmap.yaml`.
+|object
+e|See child keys
+
+|appConfig.auth
+|Authentication providers configuration.
+|object
+e|See child keys
+
+|appConfig.auth.providers
+|Authentication provider settings.
+|object
+|{}
+
+|appConfig.app.baseUrl
+|Base URL for the {backstage} front-end application.
+|string
+e|Go template
+
+|appConfig.backend.baseUrl
+|Base URL for the {backstage} backend.
+|string
+e|Go template
+
+|appConfig.backend.cors.origin
+|Allowed CORS origin for the backend.
+|string
+e|Go template
+
+|appConfig.backend.database.connection.host
+|Database connection host. Resolved from environment variables.
+|string
+|${POSTGRES_HOST}
+
+|appConfig.backend.database.connection.port
+|Database connection port.
+|string
+|${POSTGRES_PORT}
+
+|appConfig.backend.database.connection.user
+|Database connection user.
+|string
+|${POSTGRES_USER}
+
+|appConfig.backend.database.connection.password
+|Database connection password.
+|string
+|${POSTGRES_PASSWORD}
+
+|appConfig.backend.auth.externalAccess
+|External access configuration for backend authentication.
+|list
+e|See child keys
+
+|extraAppConfig
+a|Additional app-config files from existing ConfigMaps. Each item requires `filename` and `configMapRef` fields.
+|list
+|[]
+
+|auth
+|Backend service-to-service authentication configuration.
+|object
+e|See child keys
+
+|auth.backend.enabled
+a|Enable backend service-to-service authentication. Generates a random secret unless `existingSecretRef` is set or `value` is provided.
+|boolean
+|true
+
+|auth.backend.existingSecretRef.name
+|Name of an existing Secret containing the backend auth token. When empty, the chart generates one.
+|string
+|""
+
+|auth.backend.existingSecretRef.key
+|Key within the Secret that holds the backend auth token.
+|string
+|"backend-secret"
+
+|auth.backend.value
+|Use a specific value for the backend auth token instead of generating one.
+|string
+|""
+|===

--- a/modules/configure_helm-chart-config-reference/ref-database-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-database-values.adoc
@@ -1,0 +1,127 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="database-values_{context}"]
+= Database values
+
+[role="_abstract"]
+You can configure the built-in PostgreSQL database or connect to an external PostgreSQL instance for your {product-very-short} deployment.
+
+[NOTE]
+====
+To use an external PostgreSQL database, set `postgresql.enabled` to `false` and configure the `externalDatabase` values.
+====
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|postgresql
+|Built-in PostgreSQL database configuration (Bitnami subchart). Enabled by default.
+|object
+e|See child keys
+
+|postgresql.enabled
+|Enable the built-in PostgreSQL database.
+|boolean
+|true
+
+|postgresql.postgresqlDataDir
+|PostgreSQL data directory.
+|string
+|"/var/lib/pgsql/data/userdata"
+
+|postgresql.serviceBindings.enabled
+|Enable service bindings for the PostgreSQL instance.
+|boolean
+|true
+
+|postgresql.image.registry
+|PostgreSQL image registry.
+|string
+|"quay.io"
+
+|postgresql.image.repository
+|PostgreSQL image repository.
+|string
+|"fedora/postgresql-15"
+
+|postgresql.image.tag
+|PostgreSQL image tag.
+|string
+|"latest"
+
+|postgresql.image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|postgresql.auth.secretKeys.adminPasswordKey
+|Key in the Secret for the PostgreSQL admin password.
+|string
+|"postgres-password"
+
+|postgresql.auth.secretKeys.userPasswordKey
+|Key in the Secret for the PostgreSQL user password.
+|string
+|"password"
+
+|postgresql.primary.podSecurityContext.enabled
+|Enable pod security context for the PostgreSQL primary.
+|boolean
+|false
+
+|postgresql.primary.containerSecurityContext.enabled
+|Enable container security context for the PostgreSQL primary.
+|boolean
+|false
+
+|postgresql.primary.resources
+a|Resource requests and limits. Defaults: requests `cpu=250m`, `memory=256Mi`; limits `cpu=250m`, `memory=1024Mi`, `ephemeral-storage=20Mi`.
+|object
+e|See description
+
+|postgresql.primary.persistence.enabled
+|Enable persistence for the PostgreSQL primary.
+|boolean
+|true
+
+|postgresql.primary.persistence.size
+|Size of the persistent volume.
+|string
+|"1Gi"
+
+|postgresql.primary.persistence.mountPath
+|Mount path for the persistent volume.
+|string
+|"/var/lib/pgsql/data"
+
+|externalDatabase
+a|External database connection configuration. Used when `postgresql.enabled` is `false`.
+|object
+e|See child keys
+
+|externalDatabase.host
+|External database hostname.
+|string
+|""
+
+|externalDatabase.port
+|External database port.
+|integer
+|5432
+
+|externalDatabase.user
+|External database user.
+|string
+|"postgres"
+
+|externalDatabase.existingSecretRef.name
+|Name of an existing Secret containing the database password.
+|string
+|""
+
+|externalDatabase.existingSecretRef.key
+|Key within the Secret that holds the database password.
+|string
+|"password"
+|===

--- a/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
@@ -71,7 +71,7 @@ a|The name of the service account to use. If not set and `create` is `true`, a n
 |{}
 
 |containerSecurityContext
-|Security context for the main {product-very-short} container (not the Lightspeed sidecar or init containers).
+|Security context for the main {product-very-short} container (not the {ls-brand-name} sidecar or init containers).
 |object
 e|See child keys
 

--- a/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
@@ -71,7 +71,7 @@ a|The name of the service account to use. If not set and `create` is `true`, a n
 |{}
 
 |containerSecurityContext
-|Security context for the main {product-very-short} container (not the {ls-brand-name} sidecar or init containers).
+|Security context for the main {product-very-short} container (not the Lightspeed sidecar or init containers).
 |object
 e|See child keys
 

--- a/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-deployment-and-pod-values.adoc
@@ -1,0 +1,247 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="deployment-and-pod-values_{context}"]
+= Deployment and pod values
+
+[role="_abstract"]
+You can configure deployment settings, pod scheduling, security contexts, resource limits, health probes, extra volumes, and autoscaling for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|replicaCount
+|Number of required pods.
+|integer
+|1
+
+|revisionHistoryLimit
+|Number of old ReplicaSets to retain.
+|integer
+|10
+
+|strategy
+|Deployment update strategy.
+|object
+|{}
+
+|serviceAccount
+|ServiceAccount configuration.
+|object
+e|See child keys
+
+|serviceAccount.create
+|Create a ServiceAccount.
+|boolean
+|false
+
+|serviceAccount.automount
+|Automount the ServiceAccount token.
+|boolean
+|true
+
+|serviceAccount.labels
+|Additional labels for the ServiceAccount.
+|object
+|{}
+
+|serviceAccount.annotations
+|Annotations for the ServiceAccount.
+|object
+|{}
+
+|serviceAccount.name
+a|The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template.
+|string
+|""
+
+|podAnnotations
+|Annotations to add to the pod.
+|object
+|{}
+
+|podLabels
+|Labels to add to the pod.
+|object
+|{}
+
+|podSecurityContext
+|Pod-level security context.
+|object
+|{}
+
+|containerSecurityContext
+|Security context for the main {product-very-short} container (not the Lightspeed sidecar or init containers).
+|object
+e|See child keys
+
+|containerSecurityContext.readOnlyRootFilesystem
+|Mount the container root filesystem as read-only.
+|boolean
+|true
+
+|containerSecurityContext.allowPrivilegeEscalation
+|Prevent privilege escalation.
+|boolean
+|false
+
+|containerSecurityContext.capabilities.drop
+|Linux capabilities to drop.
+|list
+|["ALL"]
+
+|containerSecurityContext.runAsNonRoot
+|Run the container as a non-root user.
+|boolean
+|true
+
+|containerSecurityContext.seccompProfile.type
+|Seccomp profile type.
+|string
+|"RuntimeDefault"
+
+|resources
+|Resource requests and limits for the main {product-very-short} container.
+|object
+e|See child keys
+
+|resources.requests.cpu
+|CPU request.
+|string
+|"250m"
+
+|resources.requests.memory
+|Memory request.
+|string
+|"1Gi"
+
+|resources.limits.cpu
+|CPU limit.
+|string
+|"1000m"
+
+|resources.limits.memory
+|Memory limit.
+|string
+|"2.5Gi"
+
+|resources.limits.ephemeral-storage
+|Ephemeral storage limit.
+|string
+|"5Gi"
+
+|startupProbe
+a|Startup probe configuration. Uses HTTP GET on `/.backstage/health/v1/liveness` port `backend`. Default timing: `initialDelaySeconds=30`, `timeoutSeconds=4`, `periodSeconds=20`, `successThreshold=1`, `failureThreshold=3`.
+|object
+e|See description
+
+|readinessProbe
+a|Readiness probe configuration. Uses HTTP GET on `/.backstage/health/v1/readiness` port `backend`. Default timing: `periodSeconds=10`, `successThreshold=2`, `failureThreshold=3`, `timeoutSeconds=4`.
+|object
+e|See description
+
+|livenessProbe
+a|Liveness probe configuration. Uses HTTP GET on `/.backstage/health/v1/liveness` port `backend`. Default timing: `periodSeconds=10`, `successThreshold=1`, `failureThreshold=3`, `timeoutSeconds=4`.
+|object
+e|See description
+
+|extraVolumes
+|Additional volumes to add to the pod. These are appended to the system volumes.
+|list
+|[]
+
+|extraVolumeMounts
+|Additional volume mounts to add to the main container. These are appended to the system mounts.
+|list
+|[]
+
+|extraContainers
+|Additional sidecar containers.
+|list
+|[]
+
+|preInitContainers
+|Init containers to run before the system init containers.
+|list
+|[]
+
+|extraInitContainers
+|Additional init containers. These are added after system init containers.
+|list
+|[]
+
+|nodeSelector
+|Node labels for pod assignment.
+|object
+|{}
+
+|tolerations
+|Tolerations for pod assignment.
+|list
+|[]
+
+|affinity
+|Affinity rules for pod assignment.
+|object
+|{}
+
+|topologySpreadConstraints
+|Topology spread constraints for pod scheduling.
+|list
+|[]
+
+|hostAliases
+|Host aliases for `/etc/hosts` entries.
+|list
+|[]
+
+|deploymentAnnotations
+|Annotations for the Deployment resource (not the pod).
+|object
+|{}
+
+|autoscaling
+|Horizontal Pod Autoscaler configuration.
+|object
+e|See child keys
+
+|autoscaling.enabled
+|Enable autoscaling.
+|boolean
+|false
+
+|autoscaling.minReplicas
+|Minimum number of replicas.
+|integer
+|1
+
+|autoscaling.maxReplicas
+|Maximum number of replicas.
+|integer
+|3
+
+|autoscaling.targetCPUUtilizationPercentage
+|Target CPU use percentage.
+|integer
+|80
+
+|podDisruptionBudget
+|Pod disruption budget configuration.
+|object
+e|See child keys
+
+|podDisruptionBudget.create
+|Create a PodDisruptionBudget.
+|boolean
+|false
+
+|podDisruptionBudget.minAvailable
+|Minimum number of pods that must be available.
+|string
+|""
+
+|podDisruptionBudget.maxUnavailable
+|Maximum number of pods that can be unavailable.
+|integer
+|1
+|===

--- a/modules/configure_helm-chart-config-reference/ref-dynamic-plugins-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-dynamic-plugins-values.adoc
@@ -1,0 +1,137 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="dynamic-plugins-values_{context}"]
+= Dynamic plugins values
+
+[role="_abstract"]
+You can configure the dynamic plugins system, including plugin includes, the plugin list, volume settings for the plugins root directory, and the init container that installs plugins at startup. You can also configure the catalog index for plugin discovery in the Extensions UI.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|dynamicPlugins
+|Dynamic plugins system configuration.
+|object
+e|See child keys
+
+|dynamicPlugins.includes
+a|Array of YAML files listing dynamic plugins to include. Relative paths are resolved from the working directory of the init container (`/opt/app-root/src`).
+|list
+|["dynamic-plugins.default.yaml"]
+
+|dynamicPlugins.plugins
+|List of dynamic plugins. Every item defines the plugin `package` as an NPM package spec or OCI reference.
+|list
+|[]
+
+|dynamicPlugins.maxEntrySize
+|Maximum uncompressed size (in bytes) of a single dynamic plugin entry.
+|integer
+|40000000
+
+|dynamicPlugins.volume
+|Volume configuration for the dynamic plugins root directory.
+|object
+e|See child keys
+
+|dynamicPlugins.volume.type
+a|Volume type: `ephemeral` (auto-provisioned PVC per pod), `emptyDir` (scratch space, lost on pod restart), or `pvc` (pre-existing PersistentVolumeClaim).
+|string
+|"ephemeral"
+
+|dynamicPlugins.volume.ephemeral.storageClassName
+|StorageClass for the ephemeral volume. When empty, uses `defaultStorageClass` or the cluster default.
+|string
+|""
+
+|dynamicPlugins.volume.ephemeral.accessModes
+|Access modes for the ephemeral PVC.
+|list
+|["ReadWriteOnce"]
+
+|dynamicPlugins.volume.ephemeral.resources.requests.storage
+|Storage request for the ephemeral PVC.
+|string
+|"5Gi"
+
+|dynamicPlugins.volume.emptyDir
+|Raw Kubernetes emptyDir volume spec. Used when type is `emptyDir`.
+|object
+|{}
+
+|dynamicPlugins.volume.pvc.claimName
+|Name of the PersistentVolumeClaim to use. Used when type is `pvc`.
+|string
+|""
+
+|dynamicPlugins.initContainer
+|Configuration for the `install-dynamic-plugins` init container.
+|object
+e|See child keys
+
+|dynamicPlugins.initContainer.commandOverride
+|Override the default command.
+|list
+|[]
+
+|dynamicPlugins.initContainer.argsOverride
+|Override the default arguments.
+|list
+|[]
+
+|dynamicPlugins.initContainer.extraArgs
+|Extra arguments appended after the default arguments. Ignored when `argsOverride` is set.
+|list
+|[]
+
+|dynamicPlugins.initContainer.extraEnv
+|Extra environment variables appended after the system env vars.
+|list
+|[]
+
+|dynamicPlugins.initContainer.extraVolumeMounts
+|Additional volume mounts appended after the system mounts.
+|list
+|[]
+
+|dynamicPlugins.initContainer.resources
+a|Resource requests and limits. Defaults: requests cpu=250m, memory=256Mi; limits cpu=1000m, memory=2.5Gi, ephemeral-storage=5Gi.
+|object
+e|See description
+
+|dynamicPlugins.initContainer.securityContext
+|Security context for the init container. Defaults to the value of `containerSecurityContext`.
+|object
+|{}
+
+|catalogIndex
+|Plugin catalog index image configuration for plugin discovery in the Extensions UI.
+|object
+e|See child keys
+
+|catalogIndex.image.registry
+|Catalog index image registry.
+|string
+|"quay.io"
+
+|catalogIndex.image.repository
+|Catalog index image repository.
+|string
+|"rhdh/plugin-catalog-index"
+
+|catalogIndex.image.tag
+|Catalog index image tag.
+|string
+|"next"
+
+|catalogIndex.image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|catalogIndex.extraImages
+a|Extra catalog index images for additional plugin discovery. Each item must include `registry`, `repository`, and `tag` fields; `name` and `digest` are optional. Only catalog entities are extracted from extra images.
+|list
+|[]
+|===

--- a/modules/configure_helm-chart-config-reference/ref-environment-and-command-override-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-environment-and-command-override-values.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="environment-and-command-override-values_{context}"]
+= Environment and command override values
+
+[role="_abstract"]
+You can override the default container command, arguments, and environment variables for the main {product-very-short} container. The chart provides both override keys that fully replace system defaults and extra keys that append to them.
+
+[IMPORTANT]
+====
+The `*Override` keys replace system defaults entirely. When you use `envOverride`, system-injected environment variables such as `BACKEND_SECRET` and database credentials are not added automatically. Use the `extra*` keys to add values without replacing the defaults.
+====
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|commandOverride
+|Override the container command.
+|list
+|[]
+
+|argsOverride
+a|Override the container arguments entirely. When set, system config arguments are not added automatically; you must include them yourself.
+|list
+|[]
+
+|extraArgs
+|Extra arguments appended after the system config flags.
+|list
+|[]
+
+|envOverride
+a|Override the container environment variables entirely. When set, system env vars (`BACKEND_SECRET`, database credentials, and so on) are not added automatically.
+|list
+|[]
+
+|extraEnv
+|Extra environment variables appended after the system env vars.
+|list
+|[]
+
+|envFromOverride
+a|Override the container `envFrom` entirely. When set, `extraEnvFrom` is ignored. Accepts raw Kubernetes `envFrom` entries (`configMapRef`, `secretRef`, `prefix`).
+|list
+|[]
+
+|extraEnvFrom
+|Extra `envFrom` entries appended to the container. Accepts raw Kubernetes `envFrom` entries.
+|list
+|[]
+|===

--- a/modules/configure_helm-chart-config-reference/ref-environment-and-command-override-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-environment-and-command-override-values.adoc
@@ -8,7 +8,7 @@ You can override the default container command, arguments, and environment varia
 
 [IMPORTANT]
 ====
-The `*Override` keys replace system defaults entirely. When you use `envOverride`, system-injected environment variables such as `BACKEND_SECRET` and database credentials are not added automatically. Use the `extra*` keys to add values without replacing the defaults.
+The override keys (for example, `commandOverride` and `envOverride`) replace system defaults entirely. When you use an override key, system-injected environment variables such as `BACKEND_SECRET` and database credentials are not added automatically. Use the extra keys (for example, `extraEnv` and `extraArgs`) to add values without replacing the defaults.
 ====
 
 [cols="1m, 1, 1, 1m"]

--- a/modules/configure_helm-chart-config-reference/ref-global-and-chart-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-global-and-chart-values.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="global-and-chart-values_{context}"]
+= Global and chart configuration values
+
+[role="_abstract"]
+You can customize global settings that affect all chart resources, including image registries, storage classes, and resource naming.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|imageRegistry
+|Global container image registry. Overrides per-image registries for all containers.
+|string
+|""
+
+|imagePullSecrets
+|Global container image registry secret names.
+|list
+|[]
+
+|defaultStorageClass
+|Global default StorageClass for PVCs.
+|string
+|""
+
+|nameOverride
+|Override the chart name used in resource naming.
+|string
+|""
+
+|fullnameOverride
+|Override the full resource name.
+|string
+|""
+
+|commonLabels
+|Labels applied to all chart resources.
+|object
+|{}
+
+|commonAnnotations
+|Annotations applied to all chart resources.
+|object
+|{}
+
+|host
+|Custom hostname for the {product-very-short} instance.
+|string
+|""
+|===

--- a/modules/configure_helm-chart-config-reference/ref-image-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-image-values.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="image-values_{context}"]
+= Container image values
+
+[role="_abstract"]
+You can configure the container image used for the main {product-very-short} deployment, including the registry, repository, tag, and pull policy.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|image
+|Container image configuration for the main {product-very-short} container.
+|object
+e|See child keys
+
+|image.registry
+|Image registry.
+|string
+|"quay.io"
+
+|image.repository
+|Image repository.
+|string
+|"rhdh-community/rhdh"
+
+|image.tag
+|Image tag.
+|string
+|"next"
+
+|image.pullPolicy
+|Image pull policy.
+|string
+|"IfNotPresent"
+
+|image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|imagePullSecrets
+|Secrets for pulling images from private registries. Merged with global `imagePullSecrets`.
+|list
+|[]
+|===

--- a/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
@@ -1,0 +1,217 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="lightspeed-values_{context}"]
+= Lightspeed values
+
+[role="_abstract"]
+You can configure {ls-brand-name}, the AI assistant, as a first-class feature of your {product-very-short} instance, including the dynamic plugins, configuration files, Retrieval-Augmented Generation (RAG) init container, and core sidecar.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|lightspeed
+|Lightspeed AI assistant configuration.
+|object
+e|See child keys
+
+|lightspeed.enabled
+|Enable Lightspeed.
+|boolean
+|true
+
+|lightspeed.plugins
+|Dynamic plugin definitions for Lightspeed. Default includes the front-end and back-end plugins from `registry.access.redhat.com`.
+|list
+e|See description
+
+|lightspeed.config
+|Configuration files for Lightspeed.
+|object
+e|See child keys
+
+|lightspeed.config.stack.existingConfigMap.name
+|Name of an existing ConfigMap containing the Lightspeed stack configuration.
+|string
+|""
+
+|lightspeed.config.stack.existingConfigMap.key
+|Key within the ConfigMap.
+|string
+|""
+
+|lightspeed.config.server.existingConfigMap.name
+|Name of an existing ConfigMap containing the Lightspeed server configuration.
+|string
+|""
+
+|lightspeed.config.server.existingConfigMap.key
+|Key within the ConfigMap.
+|string
+|""
+
+|lightspeed.config.profile.existingConfigMap.name
+|Name of an existing ConfigMap containing the Lightspeed profile configuration.
+|string
+|""
+
+|lightspeed.config.profile.existingConfigMap.key
+|Key within the ConfigMap.
+|string
+|""
+
+|lightspeed.existingSecret
+|Name of an existing Secret containing the Lightspeed credentials.
+|string
+|""
+
+|lightspeed.runtimeVolume
+|Volume for the Lightspeed runtime data.
+|object
+e|See child keys
+
+|lightspeed.runtimeVolume.type
+a|Volume type: `emptyDir` or `persistentVolumeClaim`.
+|string
+|"emptyDir"
+
+|lightspeed.runtimeVolume.emptyDir
+|Raw Kubernetes emptyDir volume spec.
+|object
+|{}
+
+|lightspeed.runtimeVolume.persistentVolumeClaim
+|Raw Kubernetes PVC volume spec.
+|object
+|{}
+
+|lightspeed.ragInit
+|RAG (Retrieval-Augmented Generation) init container configuration.
+|object
+e|See child keys
+
+|lightspeed.ragInit.image.registry
+|RAG init container image registry.
+|string
+|"quay.io"
+
+|lightspeed.ragInit.image.repository
+|RAG init container image repository.
+|string
+|"redhat-ai-dev/rag-content"
+
+|lightspeed.ragInit.image.tag
+|RAG init container image tag.
+|string
+e|(version-specific)
+
+|lightspeed.ragInit.image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|lightspeed.ragInit.imagePullPolicy
+|Image pull policy for the RAG init container.
+|string
+|"IfNotPresent"
+
+|lightspeed.ragInit.commandOverride
+|Override the default command.
+|list
+|[]
+
+|lightspeed.ragInit.argsOverride
+|Override the default arguments.
+|list
+|[]
+
+|lightspeed.ragInit.extraArgs
+|Extra arguments appended after the defaults.
+|list
+|[]
+
+|lightspeed.ragInit.extraEnv
+|Extra environment variables.
+|list
+|[]
+
+|lightspeed.ragInit.extraVolumeMounts
+|Additional volume mounts.
+|list
+|[]
+
+|lightspeed.ragInit.resources
+a|Resource requests and limits. Defaults: requests cpu=50m, memory=150Mi; limits cpu=100m, memory=500Mi.
+|object
+e|See description
+
+|lightspeed.ragInit.securityContext
+a|Security context. Default: readOnlyRootFilesystem=true, allowPrivilegeEscalation=false, runAsNonRoot=true, seccompProfile type=RuntimeDefault, drop ALL capabilities.
+|object
+e|See description
+
+|lightspeed.core
+|Lightspeed core sidecar container configuration.
+|object
+e|See child keys
+
+|lightspeed.core.image.registry
+|Core sidecar image registry.
+|string
+|"quay.io"
+
+|lightspeed.core.image.repository
+|Core sidecar image repository.
+|string
+|"lightspeed-core/lightspeed-stack"
+
+|lightspeed.core.image.tag
+|Core sidecar image tag.
+|string
+|"0.5.3"
+
+|lightspeed.core.image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|lightspeed.core.imagePullPolicy
+|Image pull policy for the core sidecar.
+|string
+|"IfNotPresent"
+
+|lightspeed.core.commandOverride
+|Override the default command.
+|list
+|[]
+
+|lightspeed.core.argsOverride
+|Override the default arguments.
+|list
+|[]
+
+|lightspeed.core.extraArgs
+|Extra arguments.
+|list
+|[]
+
+|lightspeed.core.extraEnv
+|Extra environment variables.
+|list
+|[]
+
+|lightspeed.core.extraVolumeMounts
+|Additional volume mounts.
+|list
+|[]
+
+|lightspeed.core.resources
+a|Resource requests and limits. Defaults: requests cpu=100m, memory=512Mi; limits cpu=1000m, memory=2Gi.
+|object
+e|See description
+
+|lightspeed.core.securityContext
+a|Security context. Default: readOnlyRootFilesystem=true, allowPrivilegeEscalation=false, runAsNonRoot=true, seccompProfile type=RuntimeDefault, drop ALL capabilities.
+|object
+e|See description
+|===

--- a/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="lightspeed-values_{context}"]
-= Lightspeed values
+= {ls-brand-name} values
 
 [role="_abstract"]
 You can configure {ls-brand-name}, the AI assistant, as a first-class feature of your {product-very-short} instance, including the dynamic plugins, configuration files, Retrieval-Augmented Generation (RAG) init container, and core sidecar.
@@ -11,27 +11,27 @@ You can configure {ls-brand-name}, the AI assistant, as a first-class feature of
 d|*Key* |*Description* |*Type* d|*Default*
 
 |lightspeed
-|Lightspeed AI assistant configuration.
+|{ls-brand-name} AI assistant configuration.
 |object
 e|See child keys
 
 |lightspeed.enabled
-|Enable Lightspeed.
+|Enable {ls-brand-name}.
 |boolean
 |true
 
 |lightspeed.plugins
-|Dynamic plugin definitions for Lightspeed. Default includes the front-end and back-end plugins from `registry.access.redhat.com`.
+|Dynamic plugin definitions for {ls-brand-name}. Default includes the front-end and back-end plugins from `registry.access.redhat.com`.
 |list
 e|See description
 
 |lightspeed.config
-|Configuration files for Lightspeed.
+|Configuration files for {ls-brand-name}.
 |object
 e|See child keys
 
 |lightspeed.config.stack.existingConfigMap.name
-|Name of an existing ConfigMap containing the Lightspeed stack configuration.
+|Name of an existing ConfigMap containing the {ls-brand-name} stack configuration.
 |string
 |""
 
@@ -41,7 +41,7 @@ e|See child keys
 |""
 
 |lightspeed.config.server.existingConfigMap.name
-|Name of an existing ConfigMap containing the Lightspeed server configuration.
+|Name of an existing ConfigMap containing the {ls-brand-name} server configuration.
 |string
 |""
 
@@ -51,7 +51,7 @@ e|See child keys
 |""
 
 |lightspeed.config.profile.existingConfigMap.name
-|Name of an existing ConfigMap containing the Lightspeed profile configuration.
+|Name of an existing ConfigMap containing the {ls-brand-name} profile configuration.
 |string
 |""
 
@@ -61,12 +61,12 @@ e|See child keys
 |""
 
 |lightspeed.existingSecret
-|Name of an existing Secret containing the Lightspeed credentials.
+|Name of an existing Secret containing the {ls-brand-name} credentials.
 |string
 |""
 
 |lightspeed.runtimeVolume
-|Volume for the Lightspeed runtime data.
+|Volume for the {ls-brand-name} runtime data.
 |object
 e|See child keys
 
@@ -151,7 +151,7 @@ a|Security context. Default: readOnlyRootFilesystem=true, allowPrivilegeEscalati
 e|See description
 
 |lightspeed.core
-|Lightspeed core sidecar container configuration.
+|{ls-brand-name} core sidecar container configuration.
 |object
 e|See child keys
 

--- a/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-lightspeed-values.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="lightspeed-values_{context}"]
-= {ls-brand-name} values
+= Lightspeed values
 
 [role="_abstract"]
 You can configure {ls-brand-name}, the AI assistant, as a first-class feature of your {product-very-short} instance, including the dynamic plugins, configuration files, Retrieval-Augmented Generation (RAG) init container, and core sidecar.
@@ -11,27 +11,27 @@ You can configure {ls-brand-name}, the AI assistant, as a first-class feature of
 d|*Key* |*Description* |*Type* d|*Default*
 
 |lightspeed
-|{ls-brand-name} AI assistant configuration.
+|Lightspeed AI assistant configuration.
 |object
 e|See child keys
 
 |lightspeed.enabled
-|Enable {ls-brand-name}.
+|Enable Lightspeed.
 |boolean
 |true
 
 |lightspeed.plugins
-|Dynamic plugin definitions for {ls-brand-name}. Default includes the front-end and back-end plugins from `registry.access.redhat.com`.
+|Dynamic plugin definitions for Lightspeed. Default includes the front-end and back-end plugins from `registry.access.redhat.com`.
 |list
 e|See description
 
 |lightspeed.config
-|Configuration files for {ls-brand-name}.
+|Configuration files for Lightspeed.
 |object
 e|See child keys
 
 |lightspeed.config.stack.existingConfigMap.name
-|Name of an existing ConfigMap containing the {ls-brand-name} stack configuration.
+|Name of an existing ConfigMap containing the Lightspeed stack configuration.
 |string
 |""
 
@@ -41,7 +41,7 @@ e|See child keys
 |""
 
 |lightspeed.config.server.existingConfigMap.name
-|Name of an existing ConfigMap containing the {ls-brand-name} server configuration.
+|Name of an existing ConfigMap containing the Lightspeed server configuration.
 |string
 |""
 
@@ -51,7 +51,7 @@ e|See child keys
 |""
 
 |lightspeed.config.profile.existingConfigMap.name
-|Name of an existing ConfigMap containing the {ls-brand-name} profile configuration.
+|Name of an existing ConfigMap containing the Lightspeed profile configuration.
 |string
 |""
 
@@ -61,12 +61,12 @@ e|See child keys
 |""
 
 |lightspeed.existingSecret
-|Name of an existing Secret containing the {ls-brand-name} credentials.
+|Name of an existing Secret containing the Lightspeed credentials.
 |string
 |""
 
 |lightspeed.runtimeVolume
-|Volume for the {ls-brand-name} runtime data.
+|Volume for the Lightspeed runtime data.
 |object
 e|See child keys
 
@@ -151,7 +151,7 @@ a|Security context. Default: readOnlyRootFilesystem=true, allowPrivilegeEscalati
 e|See description
 
 |lightspeed.core
-|{ls-brand-name} core sidecar container configuration.
+|Lightspeed core sidecar container configuration.
 |object
 e|See child keys
 

--- a/modules/configure_helm-chart-config-reference/ref-metrics-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-metrics-values.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="metrics-values_{context}"]
+= Metrics values
+
+[role="_abstract"]
+You can configure Prometheus metrics collection and the `ServiceMonitor` resource for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|metrics
+|Metrics and monitoring configuration.
+|object
+e|See child keys
+
+|metrics.serviceMonitor
+|Prometheus ServiceMonitor configuration.
+|object
+e|See child keys
+
+|metrics.serviceMonitor.enabled
+|Enable the ServiceMonitor resource.
+|boolean
+|false
+
+|metrics.serviceMonitor.path
+|Metrics endpoint path.
+|string
+|"/metrics"
+
+|metrics.serviceMonitor.port
+|Name of the Service port to scrape.
+|string
+|"http-metrics"
+
+|metrics.serviceMonitor.interval
+|Scrape interval. When empty, uses the Prometheus default.
+|string
+|""
+
+|metrics.serviceMonitor.labels
+|Labels for the ServiceMonitor. Use these to match the Prometheus operator's `serviceMonitorSelector`.
+|object
+|{}
+
+|metrics.serviceMonitor.annotations
+|Annotations for the ServiceMonitor.
+|object
+|{}
+|===

--- a/modules/configure_helm-chart-config-reference/ref-networking-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-networking-values.adoc
@@ -1,0 +1,142 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="networking-values_{context}"]
+= Networking values
+
+[role="_abstract"]
+You can configure the Kubernetes Service, Ingress, and Gateway API `HTTPRoute` for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|service
+|Kubernetes Service configuration.
+|object
+e|See child keys
+
+|service.type
+|Service type.
+|string
+|"ClusterIP"
+
+|service.port
+|Service port.
+|integer
+|7007
+
+|service.extraPorts
+a|Additional service ports. Default includes `http-metrics` on port 9464.
+|list
+e|See description
+
+|service.annotations
+|Service annotations.
+|object
+|{}
+
+|service.nodePort
+a|NodePort value. Only used when `service.type` is `NodePort`.
+|string
+|""
+
+|service.sessionAffinity
+|Session affinity.
+|string
+|""
+
+|service.clusterIP
+a|Static ClusterIP. Set to `"None"` for a headless service.
+|string
+|""
+
+|service.loadBalancerIP
+|LoadBalancer IP address.
+|string
+|""
+
+|service.loadBalancerSourceRanges
+|Allowed source ranges for LoadBalancer.
+|list
+|[]
+
+|service.externalTrafficPolicy
+|External traffic policy.
+|string
+|""
+
+|service.ipFamilyPolicy
+|IP family policy for dual-stack support.
+|string
+|""
+
+|service.ipFamilies
+|IP families for dual-stack support.
+|list
+|[]
+
+|ingress
+|Kubernetes Ingress configuration.
+|object
+e|See child keys
+
+|ingress.enabled
+|Enable Ingress.
+|boolean
+|false
+
+|ingress.className
+|Ingress class name.
+|string
+|""
+
+|ingress.annotations
+|Ingress annotations.
+|object
+|{}
+
+|ingress.hosts
+a|Ingress host rules. Default: one host entry using `{{ .Values.host }}` with path `/` and `pathType: ImplementationSpecific`.
+|list
+e|See description
+
+|ingress.tls
+|TLS configuration for Ingress.
+|list
+|[]
+
+|httpRoute
+|Gateway API HTTPRoute configuration.
+|object
+e|See child keys
+
+|httpRoute.enabled
+|Enable HTTPRoute.
+|boolean
+|false
+
+|httpRoute.labels
+|Labels for the HTTPRoute.
+|object
+|{}
+
+|httpRoute.annotations
+|Annotations for the HTTPRoute.
+|object
+|{}
+
+|httpRoute.parentRefs
+|Parent references for the HTTPRoute.
+|list
+|[]
+
+|httpRoute.hostnames
+|Hostnames for the HTTPRoute.
+|list
+|[]
+
+|httpRoute.rules
+|Routing rules for the HTTPRoute.
+|list
+|[]
+|===

--- a/modules/configure_helm-chart-config-reference/ref-openshift-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-openshift-values.adoc
@@ -1,0 +1,92 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="openshift-values_{context}"]
+= OpenShift values
+
+[role="_abstract"]
+You can configure {ocp-short}-specific settings, including the cluster router base URL and the Route resource for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|openshift
+|{ocp-short}-specific configuration.
+|object
+e|See child keys
+
+|openshift.clusterRouterBase
+|Base domain for the {ocp-short} cluster router. Used to construct the default hostname for your {product-very-short} instance.
+|string
+|"apps.example.com"
+
+|openshift.route
+|{ocp-short} Route configuration.
+|object
+e|See child keys
+
+|openshift.route.annotations
+|Annotations for the Route.
+|object
+|{}
+
+|openshift.route.enabled
+|Enable the {ocp-short} Route.
+|boolean
+|true
+
+|openshift.route.host
+a|Hostname for the Route. Defaults to the value of the `host` key.
+|string
+e|"{{ .Values.host }}"
+
+|openshift.route.path
+|Path for the Route.
+|string
+|"/"
+
+|openshift.route.wildcardPolicy
+|Wildcard policy for the Route.
+|string
+|"None"
+
+|openshift.route.tls
+|TLS configuration for the Route.
+|object
+e|See child keys
+
+|openshift.route.tls.enabled
+|Enable TLS on the Route.
+|boolean
+|true
+
+|openshift.route.tls.termination
+|TLS termination type.
+|string
+|"edge"
+
+|openshift.route.tls.certificate
+|TLS certificate.
+|string
+|""
+
+|openshift.route.tls.key
+|TLS private key.
+|string
+|""
+
+|openshift.route.tls.caCertificate
+|CA certificate.
+|string
+|""
+
+|openshift.route.tls.destinationCACertificate
+|Destination CA certificate for re-encrypt termination.
+|string
+|""
+
+|openshift.route.tls.insecureEdgeTerminationPolicy
+|Insecure edge termination policy.
+|string
+|"Redirect"
+|===

--- a/modules/configure_helm-chart-config-reference/ref-orchestrator-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-orchestrator-values.adoc
@@ -1,0 +1,117 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="orchestrator-values_{context}"]
+= Orchestrator values
+
+[role="_abstract"]
+You can configure the Orchestrator serverless workflow feature, including the SonataFlow platform, eventing, external database connections, and dynamic plugins for your {product-very-short} instance.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|orchestrator
+|Orchestrator serverless workflow configuration.
+|object
+e|See child keys
+
+|orchestrator.enabled
+|Enable the Orchestrator feature.
+|boolean
+|false
+
+|orchestrator.serverlessLogicOperator.enabled
+|Enable the Serverless Logic Operator.
+|boolean
+|true
+
+|orchestrator.serverlessOperator.enabled
+|Enable the Serverless Operator.
+|boolean
+|true
+
+|orchestrator.sonataflowPlatform
+|SonataFlow platform configuration.
+|object
+e|See child keys
+
+|orchestrator.sonataflowPlatform.monitoring.enabled
+|Enable monitoring for the SonataFlow platform.
+|boolean
+|true
+
+|orchestrator.sonataflowPlatform.eventing.broker.name
+|Name of the eventing broker.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.eventing.broker.namespace
+|Namespace of the eventing broker.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.resources
+a|Resource requests and limits. Defaults: requests memory=64Mi, cpu=250m; limits memory=1Gi, cpu=500m.
+|object
+e|See description
+
+|orchestrator.sonataflowPlatform.externalDB.existingSecret
+|Name of an existing Secret for the external database credentials.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.externalDB.name
+|External database name.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.externalDB.host
+|External database host.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.externalDB.port
+|External database port.
+|string
+|""
+
+|orchestrator.sonataflowPlatform.dbCreationJob
+|Database creation job configuration.
+|object
+e|See child keys
+
+|orchestrator.sonataflowPlatform.dbCreationJob.backoffLimit
+|Number of retries before the job is considered failed.
+|integer
+|2
+
+|orchestrator.sonataflowPlatform.dbCreationJob.ttlSecondsAfterFinished
+|Time-to-live after job completion.
+|string
+e|(not set)
+
+|orchestrator.sonataflowPlatform.dbCreationJob.activeDeadlineSeconds
+|Maximum time (seconds) for the job to run.
+|integer
+|120
+
+|orchestrator.sonataflowPlatform.dbCreationJob.image
+|Image for the database creation job. Defaults to the PostgreSQL image values.
+|object
+e|See description
+
+|orchestrator.sonataflowPlatform.dataIndex.image
+|Data Index service image. Registry, repository, tag, and digest all default to empty strings.
+|object
+e|See description
+
+|orchestrator.sonataflowPlatform.jobService.image
+|Job Service image. Registry, repository, tag, and digest all default to empty strings.
+|object
+e|See description
+
+|orchestrator.plugins
+|Dynamic plugin definitions for the Orchestrator. Default includes the back-end, form widgets, front-end, and scaffolder back-end module plugins from `registry.access.redhat.com`.
+|list
+e|See description
+|===

--- a/modules/configure_helm-chart-config-reference/ref-test-values.adoc
+++ b/modules/configure_helm-chart-config-reference/ref-test-values.adoc
@@ -1,0 +1,57 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="test-values_{context}"]
+= Test values
+
+[role="_abstract"]
+You can configure the Helm test pod used to verify that your {product-very-short} instance is running correctly.
+
+[cols="1m, 1, 1, 1m"]
+|===
+d|*Key* |*Description* |*Type* d|*Default*
+
+|test
+|Helm test pod configuration.
+|object
+e|See child keys
+
+|test.enabled
+|Enable the Helm test pod.
+|boolean
+|true
+
+|test.image
+|Image for the test pod.
+|object
+e|See child keys
+
+|test.image.registry
+|Test image registry.
+|string
+|"quay.io"
+
+|test.image.repository
+|Test image repository.
+|string
+|"curl/curl"
+
+|test.image.tag
+|Test image tag.
+|string
+|"8.9.1"
+
+|test.image.digest
+|Overrides the image tag with an image digest.
+|string
+|""
+
+|test.image.pullPolicy
+|Image pull policy.
+|string
+|"IfNotPresent"
+
+|test.securityContext
+a|Security context for the test pod. Default: allowPrivilegeEscalation=false, readOnlyRootFilesystem=true, drop ALL capabilities.
+|object
+e|See description
+|===


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1

**Issue:** https://redhat.atlassian.net/browse/RHIDP-14276

**Preview:** N/A (draft — pending chart PR merge)

## Summary

- Add 13 new reference modules documenting the standalone RHDH Helm chart values (replaces the old upstream Backstage subchart-based reference)
- Update assembly to include new modules and remove old upstream namespace references
- Update `helm show values` procedure for new chart name (`rhdh`)
- Update `{default-helm-chart-values-link}` attribute to point to `charts/rhdh/values.yaml`

## Notes

This is a **draft** based on the current state of the developer's branch ([rhdh-chart PR 438](https://github.com/redhat-developer/rhdh-chart/pull/438)). The values schema may change after the developer returns from PTO. The old reference modules (upstream namespace, additional upstream values) are left on disk for release-1.x branches but removed from the assembly includes.

Related dev feature: [RHDHPLAN-1058](https://redhat.atlassian.net/browse/RHDHPLAN-1058)

## Test plan

- [ ] Verify all 13 new reference modules render correctly in HTML preview
- [ ] Cross-check values against final `charts/rhdh/values.yaml` when chart PR merges
- [ ] Confirm no broken cross-references in the Helm chart config reference title
- [ ] Run CQA checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)