### PR TITLE
RHDHBUGS-2883 fix: missing plugins from community table due to substring filter [release-1.10]

### DIFF
--- a/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
+++ b/modules/extend_dynamic-plugins-reference/rhdh-supported-plugins.sh
@@ -255,7 +255,7 @@ generate_community_table() {
             [[ "$dynamic_artifact" != "oci://ghcr.io"* ]] && continue
 
             # Skip if already processed (avoid duplicates)
-            if grep -qF "$plugin_name" "$PROCESSED_PLUGINS_FILE" 2>/dev/null; then
+            if grep -qxF "$plugin_name" "$PROCESSED_PLUGINS_FILE" 2>/dev/null; then
                 continue
             fi
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->

The grep -qF used to deduplicate plugins in generate_community_table() does substring matching, which causes plugins to be silently dropped when their name is a prefix of an already-processed plugin. For example, backstage-community-plugin-quay is skipped because backstage-community-plugin-quay-backend is already in the processed list and contains it as a substring. The same issue affects pagerduty-backstage-plugin (matched by pagerduty-backstage-plugin-backend).

Under LC_ALL=C, glob expansion sorts - before ., so the longer -backend variant is always processed first, making the false positive consistent and silent.

Fix: change grep -qF to grep -qxF so the dedup check requires an exact full-line match.
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:**
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
