### PR TITLE
RHDHBUGS-3547: Fix broken cross-book references to Common icons module

### DIFF
--- a/modules/shared/proc-configure-the-logo-in-the-global-header.adoc
+++ b/modules/shared/proc-configure-the-logo-in-the-global-header.adoc
@@ -8,7 +8,7 @@ You can configure a company logo in the global header of the {product} ({product
 
 When you define menu items or links in the global header, you must specify an icon identifier. 
 
-For the full list of available icon identifiers, see {customizing-book-link}#ref-common-icons[Common icons for customization].
+For the full list of available icon identifiers, see {customizing-book-link}#common-icons-for-customization_configure-the-global-header-in-rhdh[Common icons for customization].
 
 This component supports the following props, which are provided through configuration:
 

--- a/modules/shared/proc-customize-your-rhdh-quick-start.adoc
+++ b/modules/shared/proc-customize-your-rhdh-quick-start.adoc
@@ -45,4 +45,4 @@ where:
 `description`:: Enter the brief description of what the step covers.
 `icon`:: (Optional) Enter the icon identifier. You can use a full image URL, a valid SVG path, or one of the following common keys:
 +
-For a list of supported icons you can use in your quick start definitions, see {customizing-book-link}#ref-common-icons[Common icons for customization].
+For a list of supported icons you can use in your quick start definitions, see {customizing-book-link}#common-icons-for-customization_configure-the-global-header-in-rhdh[Common icons for customization].

--- a/modules/shared/proc-use-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc
+++ b/modules/shared/proc-use-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc
@@ -33,4 +33,4 @@ proxy:
 	<HEADER_KEY>: <HEADER_VALUE> # optional and can be passed as needed i.e Authorization can be passed for private GitHub repo and PRIVATE-TOKEN can be passed for private GitLab repo
 ----
 +
-The icon field uses predefined system icons. Select the correct key for your service from the {customizing-book-link}#ref-common-icons[Common icons for customization] table.
+The icon field uses predefined system icons. Select the correct key for your service from the {customizing-book-link}#common-icons-for-customization_configure-the-global-header-in-rhdh[Common icons for customization] table.


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** Merge to release-1.10 Cherry pick to release-1.9
**Issue:** [RHDHBUGS-3547](https://redhat.atlassian.net/browse/RHDHBUGS-3547)
**Preview:** N/A

## Summary

- Fix stale `#ref-common-icons` cross-book anchors in three modules to use the correct `#common-icons-for-customization_configure-the-global-header-in-rhdh` anchor

## Files changed

- `modules/shared/proc-configure-the-logo-in-the-global-header.adoc`
- `modules/shared/proc-customize-your-rhdh-quick-start.adoc`
- `modules/shared/proc-use-hosted-json-files-to-provide-data-to-the-quick-access-card.adoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)