### PR TITLE
RHIDP-15242: Add troubleshooting content for common upgrade issues

### DIFF
--- a/assemblies/shared/assembly-troubleshoot-common-upgrade-issues.adoc
+++ b/assemblies/shared/assembly-troubleshoot-common-upgrade-issues.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+ifdef::context[:parent-context: {context}]
+
+[id="troubleshoot-common-upgrade-issues_{context}"]
+= Troubleshoot common upgrade issues
+
+:context: troubleshoot-common-upgrade-issues
+
+[role="_abstract"]
+Find solutions for common issues that can occur when upgrading {product} to a later version.
+
+include::../modules/shared/ref-common-upgrade-issues-and-solutions.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/modules/shared/ref-common-upgrade-issues-and-solutions.adoc
+++ b/modules/shared/ref-common-upgrade-issues-and-solutions.adoc
@@ -4,7 +4,7 @@
 = Common upgrade issues and solutions
 
 [role="_abstract"]
-The following sections describe common issues that can occur when upgrading {product} and how to resolve them.
+Find solutions for common issues that can occur when upgrading {product} to a later version.
 
 == Custom Helm values lose mandatory defaults after upgrade
 

--- a/modules/shared/ref-common-upgrade-issues-and-solutions.adoc
+++ b/modules/shared/ref-common-upgrade-issues-and-solutions.adoc
@@ -1,0 +1,116 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="common-upgrade-issues-and-solutions_{context}"]
+= Common upgrade issues and solutions
+
+[role="_abstract"]
+The following sections describe common issues that can occur when upgrading {product} and how to resolve them.
+
+== Custom Helm values lose mandatory defaults after upgrade
+
+----
+install-dynamic-plugins: error: volume "extensions-catalog" not found
+----
+
+This issue occurs when custom `values.yaml` overrides replace mandatory default values during an upgrade from version 1.8 or earlier.
+The `install-dynamic-plugins` init container fails because required volume mounts and volumes are missing from the merged configuration.
+
+To resolve this issue:
+
+* Before upgrading, manually merge the new mandatory defaults into your custom `values.yaml` file.
+Compare your custom values with the default values in the target version and add any missing entries for `upstream.backstage.extraVolumeMounts`, `upstream.backstage.extraVolumes`, and `upstream.backstage.initContainers`.
++
+For detailed steps, see {upgrading-book-link}#upgrade-rhdh-from-1-8-to-using-the-helm-chart_upgrade-rhdh[Upgrade {product-short} from 1.8 by using the Helm chart].
+
+== Quicklinks and starred items missing after upgrade
+
+This issue occurs when upgrading from {product-short} version 1.6 or earlier.
+The global header renders without the star icon or the Quicklinks matrix because the global header plugin and its required mount point components are not enabled by default in older configurations.
+
+To resolve this issue:
+
+* Manually enable the global header plugin and add the required mount point components in your configuration.
++
+For detailed steps, see {configuring-book-link}#enable-quicklinks-and-starred-items-after-an-upgrade_customize-the-home-page[Enable quicklinks and starred items after an upgrade].
+
+== Deprecated janus-idp Helm template references
+
+----
+Error: template: rhdh/templates/deployment.yaml: parse error: function "janus-idp" not defined
+----
+
+This issue occurs when Helm templates reference the deprecated `janus-idp` chart names instead of the current `rhdh` equivalents.
+Helm rendering fails or produces silent misconfiguration because the old template references no longer resolve.
+
+To resolve this issue:
+
+* Rename all `janus-idp` Helm template references to their `rhdh` equivalents in your custom templates and values files.
+
+== Front-end system migration from Scalprum to extension blueprints
+
+This issue occurs when upgrading to a version that uses the extension-based front-end system.
+Mount point configuration from the Scalprum-based system is not compatible with the new extension blueprints, causing custom entity page cards, tabs, or header components to stop rendering.
+
+To resolve this issue:
+
+* Convert your YAML-based mount point definitions to extension blueprints.
++
+For the mapping table and conversion steps, see {configuring-book-link}#preserve-custom-integrations-when-migrating-to-the-front-end-system_configuring-rhdh[Preserve custom integrations when migrating to the front-end system].
+
+== OCI plugin image paths change between versions
+
+----
+install-dynamic-plugins: error: failed to pull plugin image: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/...: not found
+----
+
+This issue occurs when plugin OCI image paths, tags, or SHA digests change between {product-short} versions.
+The `install-dynamic-plugins` init container fails to pull plugin images, and pods remain in `Init:Error` state.
+
+To resolve this issue:
+
+* Update the OCI paths and tags in your dynamic plugin configuration to match the target version.
+Check the {dynamic-plugins-reference-book-link}[Dynamic plugins reference] for current package paths.
+
+== Single-database deployments fail with permission errors
+
+----
+backend error: plugin "catalog" startup failed: error: permission denied for CREATE DATABASE
+----
+
+This issue occurs when a single-database deployment uses a restricted database user that does not have `CREATEDB` privileges.
+By default, each backend plugin attempts to create its own database, which fails when the database user lacks the required permissions.
+
+To resolve this issue:
+
+* Set `pluginDivisionMode: schema` in the `backend.database` section of your `{my-app-config-file}` file.
+This mode creates a separate schema for each plugin within the existing database instead of creating new databases.
+The database user needs `CREATE SCHEMA` privileges instead of `CREATEDB`.
++
+For detailed configuration steps, see {configuring-book-link}#configure-schema-based-plugin-isolation-to-simplify-single-database-provisioning_configuring-rhdh[Configure schema-based plugin isolation to simplify single-database provisioning].
+
+== Orchestrator plugin configuration fails after Operator upgrade from 1.7
+
+This issue occurs when upgrading the {product-short} Operator from version 1.7.
+After approving the Operator install plan, the deployment fails because the Orchestrator plugin configuration format changed between versions.
+
+To resolve this issue:
+
+* Manually update the Orchestrator plugin configuration after approving the install plan.
++
+For detailed steps, see the important notice in {upgrading-book-link}#upgrade-the-rhdh-operator_upgrade-rhdh[Upgrade the {product-short} Operator].
+
+== PostgreSQL DateStyle incompatibility with external database
+
+This issue occurs when an external PostgreSQL instance uses a non-ISO `DateStyle` setting.
+Catalog scheduling tasks fail and catalog items do not refresh because the date format is incompatible with the expected ISO format.
+
+To resolve this issue:
+
+* Configure the external PostgreSQL database to use the ISO `DateStyle` by running the following SQL command:
++
+[source,sql]
+----
+ALTER DATABASE <database_name> SET DateStyle = 'ISO, MDY';
+----
++
+For more information about external database configuration, see {configuring-book-link}#migrate-local-databases-to-an-external-database-server-using-the-operator_configuring-rhdh[Migrate local databases to an external database server by using the Operator].

--- a/titles/product_product/category-maps/troubleshoot.adoc
+++ b/titles/product_product/category-maps/troubleshoot.adoc
@@ -11,3 +11,5 @@ include::troubleshoot/nav-troubleshoot-user-access-and-authentication-issues-to-
 include::troubleshoot/nav-troubleshoot-plugin-and-workflow-deployment-errors-to-resume-automation.adoc[leveloffset=+1]
 
 include::troubleshoot/nav-troubleshoot-ai-and-tool-integrations-to-restore-intelligent-features.adoc[leveloffset=+1]
+
+include::troubleshoot/nav-troubleshoot-common-upgrade-issues.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/troubleshoot/con-troubleshoot-common-upgrade-issues.adoc
+++ b/titles/product_product/category-maps/troubleshoot/con-troubleshoot-common-upgrade-issues.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: CONCEPT
+
+= Troubleshoot common upgrade issues
+
+[role="_abstract"]
+Find solutions for common issues that can occur when upgrading {product} to a later version.

--- a/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-common-upgrade-issues.adoc
+++ b/titles/product_product/category-maps/troubleshoot/nav-troubleshoot-common-upgrade-issues.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: MAP
+
+[id="troubleshoot-common-upgrade-issues_{context}"]
+= Troubleshoot common upgrade issues
+:context: troubleshoot-common-upgrade-issues
+
+include::con-troubleshoot-common-upgrade-issues.adoc[leveloffset=+1]
+
+include::modules/shared/ref-common-upgrade-issues-and-solutions.adoc[leveloffset=+1]

--- a/titles/upgrade_upgrade-rhdh/master.adoc
+++ b/titles/upgrade_upgrade-rhdh/master.adoc
@@ -21,3 +21,5 @@ include::modules/upgrade_upgrade-rhdh/proc-upgrade-the-rhdh-helm-chart.adoc[leve
 include::modules/upgrade_upgrade-rhdh/proc-upgrade-rhdh-from-1-8-to-using-the-helm-chart.adoc[leveloffset=+1]
 
 include::modules/shared/proc-rollback-a-plugin-to-a-previous-version.adoc[leveloffset=+1]
+
+include::assemblies/shared/assembly-troubleshoot-common-upgrade-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1
**Issue:** [RHIDP-15242](https://redhat.atlassian.net/browse/RHIDP-15242)
**Preview:** N/A

## Summary

- Add reference module with 8 known upgrade issues using the H2-per-issue troubleshooting pattern
- Add assembly, category map concept, and nav files to wire content into the troubleshoot section
- Generalized filenames (no version suffix) to support ongoing maintenance across releases

## Known issues documented

1. Custom Helm values lose mandatory defaults after upgrade (from 1.8)
2. Quicklinks and starred items missing after upgrade (from 1.6)
3. Deprecated janus-idp Helm template references
4. Front-end system migration from Scalprum to extension blueprints
5. OCI plugin image paths change between versions
6. Single-database deployments fail with permission errors (pluginDivisionMode)
7. Orchestrator plugin configuration fails after Operator upgrade (from 1.7)
8. PostgreSQL DateStyle incompatibility with external database

## Outstanding items

- **Test day findings** needed to finalize content (Jira explicitly requires these)
- **Front-end system GA status** for 2.1 affects priority of issue 4
- **7 content gap areas** need SME input (Backstage version bump, RBAC changes, auth provider changes, plugin API compatibility, Node.js version, TechDocs builder changes, catalog entity validation)
- **Upgrade guide cross-link** — decision needed on whether to add a cross-reference from the upgrade guide

## Test plan

- [ ] Verify CQA checks pass for `titles/product_product/master.adoc`
- [ ] Verify cross-references to existing docs resolve correctly
- [ ] Verify nav file renders in the troubleshoot category map

🤖 Generated with [Claude Code](https://claude.com/claude-code)