### PR TITLE
RHIDP-15491: Update RBAC policy examples to behavior-linked permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ build-report.json
 .lycheecache
 build/.cache/
 opencode.json
+
+# Local development environments — not part of the documentation source
+rhdh-local/
+redhat-docs-agent-tools/

--- a/assemblies/shared/assembly-permission-policies-reference.adoc
+++ b/assemblies/shared/assembly-permission-policies-reference.adoc
@@ -7,7 +7,7 @@ ifdef::context[:parent-context: {context}]
 :context: permission-policies-reference
 
 [role="_abstract"]
-Reference information about permission policy types and available permissions for catalog, scaffolder, RBAC, Kubernetes, Extensions, and plugin resources.
+Reference information about permission policy types and available permissions for catalog, scaffolder, RBAC, Kubernetes, Extensions, AI features, and plugin resources.
 
 {product-short} supports permission policies for controlling access to resources and functionalities.
 The following reference modules describe the available permission types and permissions for each plugin category.
@@ -33,6 +33,8 @@ include::../modules/shared/ref-argocd-permissions.adoc[leveloffset=+1]
 include::../modules/shared/ref-quay-permissions.adoc[leveloffset=+1]
 
 include::../modules/shared/ref-extensions-permissions.adoc[leveloffset=+1]
+
+include::../modules/shared/ref-ai-feature-permissions.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -35,7 +35,7 @@ If the model name is incorrect, an error message appears in the logs and the use
 +
 [source,text]
 ----
-p, role:default/_<your_team_name>_, lightspeed.notebooks.use, update, allow
+p, role:default/_<your_team_name>_, intelligent-assistant.notebooks.use, update, allow
 ----
 .. Assign the role to specific users:
 +

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -27,19 +27,20 @@ lightspeed:
 +
 [NOTE]
 ====
-If the model name is incorrect, an error message appears in the logs and the user interface.
+If the model name is wrong, an error message is displayed in the logs and the user interface.
 ====
 
 . Grant user access through role-based access control (RBAC) policies by defining permissions in your `rbac-policy-csv` file:
-.. Add the permission policy:
+.. Add the permission policies:
 +
-[source,text]
+[source,text,subs="+quotes"]
 ----
-p, role:default/_<your_team_name>_, intelligent-assistant.notebooks.use, update, allow
+p, role:default/_<your_team_name>_, intelligent-assistant.notebooks.use, use, allow
+p, role:default/_<your_team_name>_, intelligent-assistant.notebooks.manage, use, allow
 ----
 .. Assign the role to specific users:
 +
-[source,text]
+[source,text,subs="+quotes"]
 ----
 g, user:default/_<your_user_name>_, role:default/_<your_team_name>_
 ----

--- a/modules/shared/ref-ai-feature-permissions.adoc
+++ b/modules/shared/ref-ai-feature-permissions.adoc
@@ -88,7 +88,7 @@ p, role:default/_<team>_, mcp.tools.manage, use, allow
 p, role:default/_<team>_, intelligent-assistant.saved-prompts.manage, update, allow
 ----
 
-To grant read-only chat access without history management or MCP configuration, grant only `intelligent-assistant.chat.access` and `intelligent-assistant.chat.use`.
+To grant view-only chat access without the ability to send messages, manage history, or configure MCP, grant only `intelligent-assistant.chat.access`.
 
 == Migration from previous permission names
 

--- a/modules/shared/ref-ai-feature-permissions.adoc
+++ b/modules/shared/ref-ai-feature-permissions.adoc
@@ -38,8 +38,12 @@ Each permission uses a behavior-linked name that describes the capability it gra
 | Permission | Action | What it grants
 
 | `intelligent-assistant.notebooks.use`
-| `update`
-| Access the Notebooks feature in {ls-short}. Create, view, and interact with Notebooks.
+| `use`
+| Access the Notebooks feature in {ls-short}. List, read, create, upload, and query Notebooks.
+
+| `intelligent-assistant.notebooks.manage`
+| `use`
+| Update and delete Notebooks.
 |===
 
 == Model Context Protocol (MCP) permissions
@@ -48,12 +52,12 @@ Each permission uses a behavior-linked name that describes the capability it gra
 |===
 | Permission | Action | What it grants
 
-| `intelligent-assistant.mcp.read`
-| `read`
+| `mcp.tools.use`
+| `use`
 | List configured MCP servers and view their status.
 
-| `intelligent-assistant.mcp.manage`
-| `update`
+| `mcp.tools.manage`
+| `use`
 | Add, edit, delete, and validate MCP server configurations.
 |===
 
@@ -77,9 +81,10 @@ The following example grants a team full access to all AI features:
 p, role:default/_<team>_, intelligent-assistant.chat.access, use, allow
 p, role:default/_<team>_, intelligent-assistant.chat.use, use, allow
 p, role:default/_<team>_, intelligent-assistant.chat.manage, use, allow
-p, role:default/_<team>_, intelligent-assistant.mcp.read, read, allow
-p, role:default/_<team>_, intelligent-assistant.mcp.manage, update, allow
-p, role:default/_<team>_, intelligent-assistant.notebooks.use, update, allow
+p, role:default/_<team>_, intelligent-assistant.notebooks.use, use, allow
+p, role:default/_<team>_, intelligent-assistant.notebooks.manage, use, allow
+p, role:default/_<team>_, mcp.tools.use, use, allow
+p, role:default/_<team>_, mcp.tools.manage, use, allow
 p, role:default/_<team>_, intelligent-assistant.saved-prompts.manage, update, allow
 ----
 
@@ -87,7 +92,7 @@ To grant read-only chat access without history management or MCP configuration, 
 
 == Migration from previous permission names
 
-If you are upgrading from {product-short} 1.x, update your RBAC policies to use the new permission identifiers. The old CRUD-based permission names are removed in version 2.1.
+If you are upgrading from {product-short} 1.x, update your RBAC policies to use the new permission identifiers. {product-short} version 2.1 removes the previous permission names that used create, read, update, and delete action verbs.
 
 [cols="2,2,1",options="header"]
 |===
@@ -110,16 +115,20 @@ If you are upgrading from {product-short} 1.x, update your RBAC policies to use 
 | Merged into `manage`
 
 | `lightspeed.notebooks.use, update`
-| `intelligent-assistant.notebooks.use, update`
+| `intelligent-assistant.notebooks.use, use`
 | Renamed
+
+| _(none)_
+| `intelligent-assistant.notebooks.manage, use`
+| New
 
 | `lightspeed.mcp.read, read`
-| `intelligent-assistant.mcp.read, read`
-| Renamed
+| `mcp.tools.use, use`
+| Changed
 
 | `lightspeed.mcp.manage, update`
-| `intelligent-assistant.mcp.manage, update`
-| Renamed
+| `mcp.tools.manage, use`
+| Changed
 |===
 
 [IMPORTANT]

--- a/modules/shared/ref-ai-feature-permissions.adoc
+++ b/modules/shared/ref-ai-feature-permissions.adoc
@@ -12,6 +12,7 @@ Each permission uses a behavior-linked name that describes the capability it gra
 `use`:: Actively interact with the feature, such as sending a chat message.
 `manage`:: Administer resources within the feature, such as deleting chat history.
 
+[discrete]
 == {ls-short} chat permissions
 
 [cols="2,1,3",options="header"]
@@ -31,6 +32,7 @@ Each permission uses a behavior-linked name that describes the capability it gra
 | Edit and delete chat history entries.
 |===
 
+[discrete]
 == {ls-short} Notebooks permissions
 
 [cols="2,1,3",options="header"]
@@ -46,6 +48,7 @@ Each permission uses a behavior-linked name that describes the capability it gra
 | Update and delete Notebooks.
 |===
 
+[discrete]
 == Model Context Protocol (MCP) permissions
 
 [cols="2,1,3",options="header"]
@@ -61,6 +64,7 @@ Each permission uses a behavior-linked name that describes the capability it gra
 | Add, edit, delete, and validate MCP server configurations.
 |===
 
+[discrete]
 == Saved prompts permissions
 
 [cols="2,1,3",options="header"]
@@ -72,6 +76,7 @@ Each permission uses a behavior-linked name that describes the capability it gra
 | List, create, and delete saved prompts. Read saved prompts configuration.
 |===
 
+[discrete]
 == Example RBAC policy
 
 The following example grants a team full access to all AI features:
@@ -90,6 +95,7 @@ p, role:default/_<team>_, intelligent-assistant.saved-prompts.manage, update, al
 
 To grant view-only chat access without the ability to send messages, manage history, or configure MCP, grant only `intelligent-assistant.chat.access`.
 
+[discrete]
 == Migration from previous permission names
 
 If you are upgrading from {product-short} 1.x, update your RBAC policies to use the new permission identifiers. {product-short} version 2.1 removes the previous permission names that used create, read, update, and delete action verbs.

--- a/modules/shared/ref-ai-feature-permissions.adoc
+++ b/modules/shared/ref-ai-feature-permissions.adoc
@@ -1,0 +1,128 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="ai-feature-permissions_{context}"]
+= AI feature permissions
+
+[role="_abstract"]
+Configure role-based access control (RBAC) policies for AI features in {product} by using the permission identifiers in the following tables.
+
+Each permission uses a behavior-linked name that describes the capability it grants. Permissions follow the pattern `_<feature>_._<resource>_._<verb>_`, where the verb is one of the following:
+
+`access`:: View or open the feature interface.
+`use`:: Actively interact with the feature, such as sending a chat message.
+`manage`:: Administer resources within the feature, such as deleting chat history.
+
+== {ls-short} chat permissions
+
+[cols="2,1,3",options="header"]
+|===
+| Permission | Action | What it grants
+
+| `intelligent-assistant.chat.access`
+| `use`
+| Access to the {ls-short} chat interface. Required to open the chat window.
+
+| `intelligent-assistant.chat.use`
+| `use`
+| Send messages to {ls-short} and start chat conversations.
+
+| `intelligent-assistant.chat.manage`
+| `use`
+| Edit and delete chat history entries.
+|===
+
+== {ls-short} Notebooks permissions
+
+[cols="2,1,3",options="header"]
+|===
+| Permission | Action | What it grants
+
+| `intelligent-assistant.notebooks.use`
+| `update`
+| Access the Notebooks feature in {ls-short}. Create, view, and interact with Notebooks.
+|===
+
+== Model Context Protocol (MCP) permissions
+
+[cols="2,1,3",options="header"]
+|===
+| Permission | Action | What it grants
+
+| `intelligent-assistant.mcp.read`
+| `read`
+| List configured MCP servers and view their status.
+
+| `intelligent-assistant.mcp.manage`
+| `update`
+| Add, edit, delete, and validate MCP server configurations.
+|===
+
+== Saved prompts permissions
+
+[cols="2,1,3",options="header"]
+|===
+| Permission | Action | What it grants
+
+| `intelligent-assistant.saved-prompts.manage`
+| `update`
+| List, create, and delete saved prompts. Read saved prompts configuration.
+|===
+
+== Example RBAC policy
+
+The following example grants a team full access to all AI features:
+
+[source,text,subs="+quotes"]
+----
+p, role:default/_<team>_, intelligent-assistant.chat.access, use, allow
+p, role:default/_<team>_, intelligent-assistant.chat.use, use, allow
+p, role:default/_<team>_, intelligent-assistant.chat.manage, use, allow
+p, role:default/_<team>_, intelligent-assistant.mcp.read, read, allow
+p, role:default/_<team>_, intelligent-assistant.mcp.manage, update, allow
+p, role:default/_<team>_, intelligent-assistant.notebooks.use, update, allow
+p, role:default/_<team>_, intelligent-assistant.saved-prompts.manage, update, allow
+----
+
+To grant read-only chat access without history management or MCP configuration, grant only `intelligent-assistant.chat.access` and `intelligent-assistant.chat.use`.
+
+== Migration from previous permission names
+
+If you are upgrading from {product-short} 1.x, update your RBAC policies to use the new permission identifiers. The old CRUD-based permission names are removed in version 2.1.
+
+[cols="2,2,1",options="header"]
+|===
+| Old permission (1.x) | New permission (2.1) | Action
+
+| `lightspeed.chat.read, read`
+| `intelligent-assistant.chat.access, use`
+| Changed
+
+| `lightspeed.chat.create, create`
+| `intelligent-assistant.chat.use, use`
+| Changed
+
+| `lightspeed.chat.delete, delete`
+| `intelligent-assistant.chat.manage, use`
+| Changed
+
+| `lightspeed.chat.update, update`
+| `intelligent-assistant.chat.manage, use`
+| Merged into `manage`
+
+| `lightspeed.notebooks.use, update`
+| `intelligent-assistant.notebooks.use, update`
+| Renamed
+
+| `lightspeed.mcp.read, read`
+| `intelligent-assistant.mcp.read, read`
+| Renamed
+
+| `lightspeed.mcp.manage, update`
+| `intelligent-assistant.mcp.manage, update`
+| Renamed
+|===
+
+[IMPORTANT]
+====
+This is a breaking change. The old permission names are not supported in {product-short} 2.1. Update all RBAC policies, conditional rules, and automation scripts that reference the old `lightspeed.*` permission identifiers before upgrading.
+====

--- a/modules/shared/snip-rbac-policies.adoc
+++ b/modules/shared/snip-rbac-policies.adoc
@@ -11,4 +11,4 @@ p, role:default/_<team>_, intelligent-assistant.chat.manage, use, allow <3>
 <2> Grants the ability to send messages and start conversations.
 <3> Grants the ability to edit and delete chat history.
 +
-For the complete list of AI feature permissions, including Notebooks, MCP, and saved prompts, see xref:ai-feature-permissions_{context}[AI feature permissions].
+For the complete list of AI feature permissions, including Notebooks, MCP, and saved prompts, see {developer-lightspeed-book-link}#ai-feature-permissions_interacting-with-developer-lightspeed-for-rhdh[AI feature permissions].

--- a/modules/shared/snip-rbac-policies.adoc
+++ b/modules/shared/snip-rbac-policies.adoc
@@ -1,9 +1,14 @@
 :_mod-docs-content-type: SNIPPET
 To grant non-administrator teams access to the virtual assistant, append permission lines to the `rbac-policies.csv` section, replacing `<team>` with your target team name:
 +
-[source,text]
+[source,text,subs="+quotes"]
 ----
-p, role:default/<team>, intelligent-assistant.chat.access, use, allow
-p, role:default/<team>, intelligent-assistant.chat.use, use, allow
-p, role:default/<team>, intelligent-assistant.chat.manage, use, allow
+p, role:default/_<team>_, intelligent-assistant.chat.access, use, allow <1>
+p, role:default/_<team>_, intelligent-assistant.chat.use, use, allow <2>
+p, role:default/_<team>_, intelligent-assistant.chat.manage, use, allow <3>
 ----
+<1> Grants access to the {ls-short} chat interface.
+<2> Grants the ability to send messages and start conversations.
+<3> Grants the ability to edit and delete chat history.
++
+For the complete list of AI feature permissions, including Notebooks, MCP, and saved prompts, see xref:ai-feature-permissions_{context}[AI feature permissions].

--- a/modules/shared/snip-rbac-policies.adoc
+++ b/modules/shared/snip-rbac-policies.adoc
@@ -3,6 +3,7 @@ To grant non-administrator teams access to the virtual assistant, append permiss
 +
 [source,text]
 ----
-p, role:default/<team>, lightspeed.chat.read, read, allow
-p, role:default/<team>, lightspeed.chat.create, create, allow
+p, role:default/<team>, intelligent-assistant.chat.access, use, allow
+p, role:default/<team>, intelligent-assistant.chat.use, use, allow
+p, role:default/<team>, intelligent-assistant.chat.manage, use, allow
 ----

--- a/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
+++ b/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
@@ -24,6 +24,8 @@ include::modules/shared/con-retrieval-augmented-generation-rag-embeddings-for-gr
 
 include::assemblies/shared/assembly-configure-to-initialize-the-ai-assistant.adoc[leveloffset=+1]
 
+include::modules/shared/ref-ai-feature-permissions.adoc[leveloffset=+1]
+
 include::assemblies/shared/assembly-customize-ai-responses.adoc[leveloffset=+1]
 
 include::assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc[leveloffset=+1]


### PR DESCRIPTION
Replace CRUD-based permission identifiers with the new behavior-linked naming convention per rhdh-plugins PR #3733:
- lightspeed.chat.read/create → intelligent-assistant.chat.access/use/manage
- lightspeed.notebooks.use → intelligent-assistant.notebooks.use

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
2.1
**Issue:**
https://redhat.atlassian.net/browse/RHIDP-15491
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
