### PR TITLE
[RHIDP#14328]: Update scorecard metric IDs to lowerCamelCase

### DIFF
--- a/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
@@ -8,14 +8,14 @@ You can define global thresholds in your `{product-very-short} {my-app-config-fi
 
 If you omit a threshold category, such as `success`, the Scorecard plugin does not assign that category to the metric.
 
-The following example defines thresholds for the `jira.open_issues` metric. These settings apply to all components using this metric unless an entity annotation overrides them.
+The following example defines thresholds for the `jira.openIssues` metric. These settings apply to all components using this metric unless an entity annotation overrides them.
 
 [source,yaml]
 ----
 scorecard:
   plugins:
     jira:
-      open_issues:
+      openIssues:
         thresholds:
           rules:
             - key: success

--- a/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/con-standardize-scorecard-metric-thresholds-across-components.adoc
@@ -8,7 +8,7 @@ You can define global thresholds in your `{product-very-short} {my-app-config-fi
 
 If you omit a threshold category, such as `success`, the Scorecard plugin does not assign that category to the metric.
 
-The following example defines thresholds for the `jira.openIssues` metric. These settings apply to all components using this metric unless an entity annotation overrides them.
+The following example defines thresholds for the `jira.openIssues` metric. These settings apply to all components that use this metric unless an entity annotation overrides them.
 
 [source,yaml]
 ----

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc
@@ -25,7 +25,7 @@ Add a standard scorecard summary card to your homepage using default, out-of-the
   importName: ScorecardHomepageCard
   config:
     props:
-      aggregationId: "github.open_prs"
+      aggregationId: "github.openPRs"
     layouts:
       xl: { w: 3, h: 6, x: 3 }
       lg: { w: 4, h: 6, x: 4 }

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-a-default-scorecard-aggregation-card.adoc
@@ -4,7 +4,7 @@
 = Configure a default scorecard aggregation card
 
 [role="_abstract"]
-Add a standard scorecard summary card to your homepage using default, out-of-the-box configurations.
+Add a standard scorecard summary card to your homepage by using default configurations.
 
 .Prerequisites
 
@@ -15,7 +15,7 @@ Add a standard scorecard summary card to your homepage using default, out-of-the
 .Procedure
 . Open your dynamic plugin configuration file.
 
-. Navigate to your scorecard card block under the `home.page/cards` mount point.
+. Go to your scorecard card block under the `home.page/cards` mount point.
 
 . Update the configuration to use the `aggregationId` property with an established system metric name:
 +

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
@@ -4,7 +4,7 @@
 = Configure aggregated KPIs for the scorecard
 
 [role="_abstract"]
-Define aggregated Key Performance Indicators (KPIs) in your configuration to provide a consolidated view of team or group health. Aggregating KPIs allows you to summarize technical metrics into high-level insights for management and stakeholders.
+Define aggregated key performance indicators (KPIs) in your configuration to create a consolidated view of team or group health. By aggregating KPIs, you can summarize technical metrics into high-level insights for management and stakeholders.
 
 .Prerequisites
 * The scorecard plugin is installed and configured in your {product} instance.
@@ -12,9 +12,9 @@ Define aggregated Key Performance Indicators (KPIs) in your configuration to pro
 
 .Procedure
 
-. Access your `app-config.yaml` file.
+. Open your `app-config.yaml` file.
 
-. Navigate to the `scorecard` section and add an `aggregationKPIs` block.
+. Go to the `scorecard` section and add an `aggregationKPIs` block.
 
 . Update the configuration to create a homepage card that summarizes a specific metric for a team portfolio. The following example adds a Jira open issues card that groups counts by threshold status for the entities that the signed-in user owns:
 +
@@ -41,6 +41,6 @@ where:
 
 .Verification
 
-. Navigate to the {product-short} homepage.
+. Go to the {product-short} homepage.
 
 . Verify that the new aggregated card is displayed with the defined name and calculated value.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-aggregated-kpis-for-the-scorecard.adoc
@@ -26,7 +26,7 @@ scorecard:
       title: 'Jira open issues KPI'
       description: 'Open issues across entities you own, grouped by status.'
       type: statusGrouped
-      metricId: jira.open_issues
+      metricId: jira.openIssues
 ----
 +
 where:
@@ -35,7 +35,7 @@ where:
 `title`:: Title shown for the KPI.
 `description`:: Short description of the KPI.
 `type`:: Aggregation strategy. Use `statusGrouped` for counts per threshold status, or `average` for a weighted portfolio score.
-`metricId`:: Metric provider ID. For example `jira.open_issues`, `github.open_prs`.
+`metricId`:: Metric provider ID. For example `jira.openIssues`, `github.openPRs`.
 
 . Save the configuration and restart your {product} instance.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-a-status-grouped-tracking-type.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-a-status-grouped-tracking-type.adoc
@@ -23,7 +23,7 @@ scorecard:
       title: "Team Alpha Bug KPI"
       description: "Portfolio bug counts grouped by status threshold"
       type: statusGrouped
-      metricId: jira.open_issues
+      metricId: jira.openIssues
 ----
 . Open your dynamic plugin configuration file.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-a-status-grouped-tracking-type.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-a-status-grouped-tracking-type.adoc
@@ -13,7 +13,7 @@ Configure a scorecard aggregation card to count entities based on status thresho
 .Procedure
 . Open your `app-config.yaml` file.
 
-. Navigate to the `scorecard` section and define your backend Key Performance Indicator (KPI) map within an `aggregationKPIs` block, setting the tracking type to `statusGrouped`:
+. Go to the `scorecard` section and define your backend key performance indicator (KPI) map within an `aggregationKPIs` block, setting the tracking type to `statusGrouped`:
 +
 [source,yaml]
 ----
@@ -25,6 +25,7 @@ scorecard:
       type: statusGrouped
       metricId: jira.openIssues
 ----
+
 . Open your dynamic plugin configuration file.
 
 . Reference your custom aggregation ID inside the homepage card properties block under the `home.page/cards` mount point:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-an-average-tracking-type.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-an-average-tracking-type.adoc
@@ -24,7 +24,7 @@ scorecard:
       title: "Portfolio Health KPI"
       description: "Weighted average score across portfolio components"
       type: average
-      metricId: github.open_prs
+      metricId: github.openPRs
       options:
         statusScores:
           success: 100

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-an-average-tracking-type.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-an-aggregation-card-with-an-average-tracking-type.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: PROCEDURE
+
 [id="configure-an-aggregation-card-with-an-average-tracking-type_{context}"]
 = Configure an aggregation card with an average tracking type
 
@@ -12,7 +13,7 @@ Configure a scorecard aggregation card to calculate a single weighted portfolio 
 
 . Open your `app-config.yaml` file.
 
-. Navigate to the `scorecard` section and define your backend Key Performance Indicator (KPI) map within an `aggregationKPIs` block, setting the tracking type to `average`.
+. Go to the `scorecard` section and define your backend key performance indicator (KPI) map within an `aggregationKPIs` block, setting the tracking type to `average`.
 
 . Add the required `statusScores` map to bind numeric weights to your status rules:
 +
@@ -32,7 +33,7 @@ scorecard:
           error: 0
 ----
 
-. Optional: To override the built-in system defaults, add custom threshold parameters using a continuous, gapless number range evaluated on a scale of `0` to `100`:
+. Optional: To override the built-in system defaults, add custom threshold parameters by using a continuous number range without gaps, evaluated on a scale of `0` to `100`:
 +
 [source,yaml]
 ----

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
@@ -49,7 +49,7 @@ scorecard:
 where:
 
 `myDatasource`:: represents your specific scorecard data source, such as `jira` 
-`myMetric`:: represents the metric identifier, such as `open_issues`
+`myMetric`:: represents the metric identifier, such as `openIssues`
 
 . Save the changes to the configuration file.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-custom-severity-levels-and-colors-for-scorecard.adoc
@@ -4,7 +4,7 @@
 = Configure custom severity levels and colors for Scorecard
 
 [role="_abstract"]
-Customizing severity thresholds and color mappings in your Scorecard configuration allows you to visualize platform metrics using your organization's custom operational terminology.
+You can customize severity thresholds and color mappings in your Scorecard configuration to visualize platform metrics by using your organization's custom operational terminology.
 
 [NOTE]
 ====
@@ -14,13 +14,13 @@ Each custom severity threshold key requires both a corresponding icon configurat
 .Prerequisites
 * You have administrative access to the {product} configuration files.
 * You have added a custom application configuration file to your {product} deployment workspace.
-* You have installed Scorecard backend and frontend plugins, and at least one Scorecard plugin module.
+* You have installed Scorecard back-end and front-end plugins, and at least one Scorecard plugin module.
 
 .Procedure
 
 . Open the {product-very-short} `app-config.yaml` file.
 
-. Navigate to the `scorecard.plugins` backend threshold definition block.
+. Go to the `scorecard.plugins` back-end threshold definition block.
 
 . Define your custom severity threshold keys by adding a structured rule entry containing your custom key string, your boundary expression, your preferred color parameter format, and a supported icon string variable.
 +
@@ -57,7 +57,7 @@ where:
 
 .Verification
 
-* Open the {product} UI, navigate to the Scorecard component, and verify that the custom severity levels display with the colors and icons you specified.
+* Open the {product} UI, go to the Scorecard component, and verify that the custom severity levels display with the colors and icons you specified.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
@@ -39,17 +39,17 @@ plugins:
               - mountPoint: home.page/cards
                 importName: ScorecardHomepageCard
                 config:
-                  id: "scorecard-jira.open_issues"
+                  id: "scorecard-jira.openIssues"
                   title: "Jira open blocking tickets"
                   props:
-                    metricId: "jira.open_issues"
+                    metricId: "jira.openIssues"
               - mountPoint: home.page/cards
                 importName: ScorecardHomepageCard
                 config:
-                  id: "scorecard-github.open_prs"
+                  id: "scorecard-github.openPRs"
                   title: "GitHub open PRs"
                   props:
-                    metricId: "github.open_prs"
+                    metricId: "github.openPRs"
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
     disabled: false
     pluginConfig:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-customizable-home-page.adoc
@@ -64,6 +64,7 @@ plugins:
 include::{docdir}/artifacts/snip-tag-for-OCI-package-paths.adoc[]
 +
 For more information, see {customizing-book-link}[{customizing-book-title}].
+
 . Log in to the {product-very-short} application.
 . Enter the *Edit* mode on the home page.
 . Click *Add widget* and select the metric to include.
@@ -78,5 +79,5 @@ You can add only one metric at a time.
 .Verification
 
 . Log in to {product-very-short}.
-. On the *Home* page, verify that the aggregated Scorecard widget appears with the name you provided.
-. Confirm that the displayed KPIs reflect the status of your owned components, systems, and resources.
+. On the *Home* page, verify that the aggregated Scorecard widget is displayed with the name you provided.
+. Confirm that the displayed key performance indicators (KPIs) reflect the status of your owned components, systems, and resources.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
@@ -41,7 +41,7 @@ plugins:
                 importName: ScorecardHomepageCard
                 config:
                   props:
-                    aggregationId: "jira.open_issues"
+                    aggregationId: "jira.openIssues"
                   layouts:
                     xl: { w: 3, h: 6 }
                     lg: { w: 4, h: 6 }
@@ -53,7 +53,7 @@ plugins:
                 importName: ScorecardHomepageCard
                 config:
                   props:
-                    aggregationId: "github.open_prs"
+                    aggregationId: "github.openPRs"
                   layouts:
                     xl: { w: 3, h: 6, x: 3 }
                     lg: { w: 4, h: 6, x: 4 }

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-portfolio-health-on-a-read-only-home-page.adoc
@@ -82,5 +82,5 @@ The widget automatically calculates and displays aggregations for the entities y
 .Verification
 
 . Log in to {product-very-short}.
-. On the *Home* page, verify that the aggregated Scorecard widget appears with the name you provided.
-. Confirm that the displayed KPIs reflect the status of your owned components, systems, and resources.
+. On the *Home* page, verify that the aggregated Scorecard widget is displayed with the name you provided.
+. Confirm that the displayed key performance indicators (KPIs) reflect the status of your owned components, systems, and resources.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rbac-for-scorecards-by-using-the-rbac-csv-file_{context}"]
-= Configure RBAC using the CSV file
+= Configure RBAC by using the CSV file
 
 [role="_abstract"]
-You can grant read access to Scorecard metrics by adding permission policies to your RBAC CSV file.
+You can grant read access to Scorecard metrics by adding permission policies to your role-based access control (RBAC) comma-separated values (CSV) file.
 
 .Prerequisites
 
@@ -13,9 +13,9 @@ You can grant read access to Scorecard metrics by adding permission policies to 
 
 .Procedure
 
-. Add the following policy to your CSV file to allow users to view metrics:
+. Add the following policy to your CSV file so that users can view metrics:
 +
-[source,yaml]
+[source,csv]
 ----
 g, user:default/<YOUR_USERNAME>, role:default/scorecard-viewer
 p, role:default/scorecard-viewer, scorecard.metric.read, read, allow
@@ -45,7 +45,7 @@ where:
 
 `metricIds`:: Enter the metric ID for user access, such as `github.openPRs`.
 +
-This policy allows users to read only the specified metrics and restricts access to all other metrics.
+With this policy, users can read only the specified metrics. Access to all other metrics is restricted.
 
 .Verification
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-configure-rbac-for-scorecards-by-using-the-rbac-csv-file.adoc
@@ -43,7 +43,7 @@ conditions:
 +
 where:
 
-`metricIds`:: Enter the metric ID for user access, such as `github.open_prs`.
+`metricIds`:: Enter the metric ID for user access, such as `github.openPRs`.
 +
 This policy allows users to read only the specified metrics and restricts access to all other metrics.
 

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -4,7 +4,7 @@
 = Integrate GitHub health metrics
 
 [role="_abstract"]
-You can configure the GitHub Scorecard plugin to display repository metrics in your {product-very-short} catalog. This integration allows you to monitor component health and security risks directly from {product}.
+You can configure the GitHub Scorecard plugin to display repository metrics in your {product-very-short} catalog. With this integration, you can monitor component health and security risks directly from {product}.
 
 You can grant {product-very-short} access to the GitHub API by using a https://docs.github.com/en/apps/overview[GitHub App] or a https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens[GitHub token].
 
@@ -23,7 +23,7 @@ For long-lived integrations or organizational access, you must use a GitHub App.
 .Procedure
 
 . Grant GitHub API access: Create one of the following authentication methods:
-** Configure using a GitHub App.
+** Configure by using a GitHub App.
 ... Create a https://docs.github.com/en/apps/overview[GitHub App] with the required permissions (Read-only for Contents to allow reading repositories).
 +
 [NOTE]
@@ -32,7 +32,7 @@ You must install the GitHub App on the organization (or user account) that owns 
 ====
 .... In the *General > Clients secrets* section, click *Generate a new client secret*.
 .... In the *General > Private keys* section, click *Generate a private key*.
-.... In the *Install App* tab, choose an account to install your GitHub App on.
+.... In the *Install App* tab, select an account to install your GitHub App on.
 .... Record the *App ID*, *Client ID*, *Client Secret*, and *Private key* values.
 
 ... Add secrets to {product-very-short} by adding the following key/value pairs to your 
@@ -60,7 +60,7 @@ integrations:
             ${GITHUB_INTEGRATION_PRIVATE_KEY_FILE}
 ----
 
-** Configure using a GitHub token.
+** Configure by using a GitHub token.
 ... Create a https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens[GitHub token] with the following permissions:
 **** https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic[Classic Personal Access Token] (PAT): Select the `repo` scope for read/write access to private repositories.
 **** https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token[Fine-Grained Personal Access Token] (PAT):
@@ -124,7 +124,7 @@ where:
 You must add the team entity to the Catalog to ensure the provided permissions are applicable.
 ====
 
-. Ingest the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file:
+. Import the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in your {product-very-short} `{my-app-config-file}` file:
 +
 [source,yaml]
 ----
@@ -154,8 +154,8 @@ scorecard:
 +
 where:
 
-`scorecard:plugins:github:openPRs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
-
+`scorecard:plugins:github:openPRs:thresholds`:: Lists the default threshold values for the GitHub open pull requests (PRs) metric.
++
 [NOTE]
 ====
 GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.openPRs`) metric:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-github-health-metrics-using-scorecards.adoc
@@ -134,14 +134,14 @@ catalog:
       target: https://github.com/<owner>/<repository>/catalog-info.yaml
 ----
 
-. Optional: Customize thresholds:  Define custom roles for the *GitHub Open Pull Requests* (`github.open_prs`) metric in your {product-very-short} `{my-app-config-file}` file:
+. Optional: Customize thresholds:  Define custom roles for the *GitHub Open Pull Requests* (`github.openPRs`) metric in your {product-very-short} `{my-app-config-file}` file:
 +
 [source,yaml]
 ----
 scorecard:
   plugins:
     github:
-      open_prs:
+      openPRs:
         thresholds:
           rules:
             - key: success
@@ -154,11 +154,11 @@ scorecard:
 +
 where:
 
-`scorecard:plugins:github:open_prs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
+`scorecard:plugins:github:openPRs:thresholds`:: Lists the default threshold values for the GitHub open PRs metric.
 
 [NOTE]
 ====
-GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.open_prs`) metric:
+GitHub metrics use the following default thresholds for the *GitHub Open Pull Requests* (`github.openPRs`) metric:
 
 * *Error*: More than 50 open pull requests.
 * *Warning*: Between 10 and 50 open pull requests.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -17,8 +17,8 @@ The plugin supports Jira Cloud (API v3) and Jira Data Center (API v2).
 
 .Procedure
 
-. Generate a Jira configuration token using one of the following methods, depending on your Jira product:
-** Jira Cloud: https://id.atlassian.com/manage-profile/security/api-tokens[Create a personal token]. You must create a `Base64-encoded` string using the following plain text format: `your-atlassian-email:your-jira-api-token`.
+. Generate a Jira configuration token by using one of the following methods, depending on your Jira product:
+** Jira Cloud: https://id.atlassian.com/manage-profile/security/api-tokens[Create a personal token]. You must create a `Base64-encoded` string by using the following plain text format: `your-atlassian-email:your-jira-api-token`.
 +
 [source,bash]
 ----
@@ -31,7 +31,7 @@ $ echo -n 'your-atlassian-email:your-jira-api-token' | base64
 `JIRA_TOKEN`:: Enter your generated Jira token.
 `JIRA_BASE_URL`:: Enter your Jira base URL.
 
-. Configure the plugin: In your {product-very-short} `dynamic-plugins-config.yaml` file, enable the plugin using either a direct setup or a proxy setup.
+. Configure the plugin: In your {product-very-short} `dynamic-plugins-config.yaml` file, enable the plugin by using either a direct setup or a proxy setup.
 +
 [NOTE]
 ====
@@ -113,7 +113,7 @@ metadata:
     jira/component: Component
     jira/label: UI
     jira/team: 9d3ea319-fb5b-4621-9dab-05fe502283e
-    jira/custom-filter: 'reporter = "abc@xyz.com" AND resolution is not EMPTY'
+    jira/custom-filter: 'reporter = "user@example.com" AND resolution is not EMPTY'
 spec:
   type: website
   lifecycle: experimental
@@ -130,7 +130,7 @@ where:
 `jira/team`:: Optional: Enter the Jira team ID (not the team title).
 `jira/custom-filter`:: Optional: Enter a custom Jira Query Language (JQL) filter.
 
-. Ingest the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in the {product-very-short} `{my-app-config-file}` file:
+. Import the catalog entity: Add the location of your `catalog-info.yaml` to the `catalog.locations` section in the {product-very-short} `{my-app-config-file}` file:
 +
 [source,yaml]
 ----
@@ -179,7 +179,7 @@ where:
 
 `mandatoryFilter`:: Optional: Replaces the default filter (`type = Bug and resolution = Unresolved`).
 `customFilter`:: Optional: Specifies a global custom filter. The entity annotation `jira/custom-filter` overrides this value.
-
++
 [NOTE]
 ====
 Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.openIssues`) metric:

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-integrate-jira-health-metrics-using-scorecards.adoc
@@ -147,7 +147,7 @@ catalog:
 scorecard:
   plugins:
     jira:
-      open_issues:
+      openIssues:
         thresholds:
           rules:
             - key: success
@@ -160,7 +160,7 @@ scorecard:
 +
 where:
 
-`scorecard:plugins:jira:open_issues:thresholds`:: Lists the default threshold values for the *Jira Open Issues* metric.
+`scorecard:plugins:jira:openIssues:thresholds`:: Lists the default threshold values for the *Jira Open Issues* metric.
 
 . Optional: Define global or custom mandatory filters that entities can override by adding the following code to your {product-very-short} `{my-app-config-file}` file:
 +
@@ -169,7 +169,7 @@ where:
 scorecard:
   plugins:
     jira:
-      open_issues:
+      openIssues:
         options:
           mandatoryFilter: Type = Task AND Resolution = Unresolved
           customFilter: priority in ("Critical", "Blocker")
@@ -182,7 +182,7 @@ where:
 
 [NOTE]
 ====
-Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.open_issues`) metric:
+Jira metrics use the following default thresholds for the *Jira Open Issues* (`jira.openIssues`) metric:
 
 * *Error*: More than 100 open issues.
 * *Warning*: More than 50 open issues.

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-view-detailed-metrics-from-aggregated-scorecard-kpis.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-view-detailed-metrics-from-aggregated-scorecard-kpis.adoc
@@ -27,7 +27,7 @@ jira:
 scorecard:
   plugins:
     jira:
-      open_issues:
+      openIssues:
         schedule:
           frequency: { minutes: 5 }
           timeout: { minutes: 10 }

--- a/modules/observability_evaluate-project-health-using-scorecards/proc-view-detailed-metrics-from-aggregated-scorecard-kpis.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/proc-view-detailed-metrics-from-aggregated-scorecard-kpis.adoc
@@ -4,7 +4,7 @@
 = View detailed metrics from aggregated scorecard KPIs
 
 [role="_abstract"]
-Configure the {product} Scorecard plugin to enable drill-down capabilities. This allows you to investigate the specific catalog entities and metrics that contribute to aggregated KPI scores, helping to identify and troubleshoot failing applications across a portfolio.
+Configure the {product} Scorecard plugin to enable drill-down capabilities. You can then investigate the specific catalog entities and metrics that contribute to aggregated key performance indicator (KPI) scores, helping to identify and troubleshoot failing applications across a portfolio.
 
 .Prerequisites
 
@@ -34,7 +34,7 @@ scorecard:
           initialDelay: { seconds: 10 }
 ----
 
-. Configure Role-Based Access Control (RBAC) permissions for the relevant user roles to enable scorecard access.
+. Configure role-based access control (RBAC) permissions for the relevant user roles to enable scorecard access.
 
 .. Open your RBAC policy file, typically `rbac-policy.csv`.
 
@@ -48,10 +48,10 @@ p, role:default/team_lead, catalog.entity.read, read, allow
 
 .Verification
 
-.. Navigate to the {product} Home Page.
+. Go to the {product} home page.
 
-.. Click an aggregated KPI tile, such as *Critical Jira Issues*.
+. Click an aggregated KPI tile, such as *Critical Jira Issues*.
 
-.. Verify that a list of individual catalog entities appears, showing the components contributing to that aggregate score.
+. Verify that a list of individual catalog entities is displayed, showing the components contributing to that aggregated score.
 +
-If the list does not appear, ensure you are using the latest version of the {product-very-short} plugins.
+If the list is not displayed, ensure you are using the latest version of the {product-very-short} plugins.

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-metric-data-for-entities.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-metric-data-for-entities.adoc
@@ -50,7 +50,7 @@ You must not use both parameters in the same request.
 |`metricIds`
 |String
 |No
-|A comma-separated list of IDs (for example, `github.open_prs`).
+|A comma-separated list of IDs (for example, `github.openPRs`).
 
 |`datasource`
 |String

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -13,43 +13,43 @@ The following metric providers are supported:
 | Provider | Metric ID | Title | Description | Type
 
 | GitHub
-| `github.open_prs`
+| `github.openPRs`
 | GitHub open PRs
 | Number of open pull requests in GitHub.
 | number
 
 | Jira
-| `jira.open_issues`
+| `jira.openIssues`
 | Jira open issues
 | Number of open issues in Jira.
 | number
 
 | OpenSSF
-| `openssf.binary_artifacts`
+| `openssf.binaryArtifacts`
 | Binary Artifacts
 | Determines if the project has generated executable (binary) artifacts in the source repository.
 | score (0-10)
 
 | OpenSSF
-| `openssf.branch_protection`
+| `openssf.branchProtection`
 | Branch Protection
 | Determines if the default and release branches are protected with branch protection settings.
 | score (0-10)
 
 | OpenSSF
-| `openssf.cii_best_practices`
+| `openssf.ciiBestPractices`
 | CII Best Practices
 | Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.
 | score (0-10)
 
 | OpenSSF
-| `openssf.ci_tests`
+| `openssf.ciTests`
 | CI Tests
 | Determines if the project runs tests before pull requests are merged.
 | score (0-10)
 
 | OpenSSF
-| `openssf.code_review`
+| `openssf.codeReview`
 | Code Review
 | Determines if the project requires human code review before pull requests are merged.
 | score (0-10)
@@ -61,13 +61,13 @@ The following metric providers are supported:
 | score (0-10)
 
 | OpenSSF
-| `openssf.dangerous_workflow`
+| `openssf.dangerousWorkflow`
 | Dangerous Workflow
 | Determines if the project's GitHub Action workflows avoid dangerous patterns.
 | score (0-10)
 
 | OpenSSF
-| `openssf.dependency_update_tool`
+| `openssf.dependencyUpdateTool`
 | Dependency Update Tool
 | Determines if the project uses a dependency update tool.
 | score (0-10)
@@ -97,7 +97,7 @@ The following metric providers are supported:
 | score (0-10)
 
 | OpenSSF
-| `openssf.pinned_dependencies`
+| `openssf.pinnedDependencies`
 | Pinned Dependencies
 | Determines if the project has declared and pinned the dependencies of its build process.
 | score (0-10)
@@ -109,19 +109,19 @@ The following metric providers are supported:
 | score (0-10)
 
 | OpenSSF
-| `openssf.security_policy`
+| `openssf.securityPolicy`
 | Security Policy
 | Determines if the project has published a security policy.
 | score (0-10)
 
 | OpenSSF
-| `openssf.signed_releases`
+| `openssf.signedReleases`
 | Signed Releases
 | Determines if the project cryptographically signs release artifacts.
 | score (0-10)
 
 | OpenSSF
-| `openssf.token_permissions`
+| `openssf.tokenPermissions`
 | Token Permissions
 | Determines if the project's workflows follow the principle of least privilege.
 | score (0-10)

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-available-scorecard-metric-providers-and-metric-ids.adoc
@@ -1,12 +1,10 @@
 :_mod-docs-content-type: REFERENCE
 
 [id="available-scorecard-metric-providers-and-metric-ids_{context}"]
-= Supported Scorecard metrics providers
+= Supported Scorecard metric providers
 
 [role="_abstract"]
 The Scorecard plugin gathers data from third-party systems through metric providers. Use the following table to identify which metrics are available for each supported provider.
-
-The following metric providers are supported:
 
 [cols="1,1,2,3,1", options="header"]
 |===

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
@@ -17,8 +17,8 @@ The annotation key must use the following format:
 
 | `{providerId}`
 | Unique identifier of the metric
-| `scorecard.io/jira.open_issues...`
-| `jira.open_issues`
+| `scorecard.io/jira.openIssues...`
+| `jira.openIssues`
 
 | `{thresholdKey}`
 | The overridden category
@@ -33,7 +33,7 @@ The annotation key must use the following format:
 
 == Example: Override global Jira thresholds
 
-In the following example, the component overrides the `warning` and `error` rules for the `jira.open_issues` metric. The `success` rule remains unchanged from the global configuration.
+In the following example, the component overrides the `warning` and `error` rules for the `jira.openIssues` metric. The `success` rule remains unchanged from the global configuration.
 
 [source,yaml]
 ----
@@ -44,9 +44,9 @@ metadata:
   name: critical-production-service
   annotations:
     # Changes global 'warning' from '>50' to '10-15'
-    scorecard.io/jira.open_issues.thresholds.rules.warning: '10-15'
+    scorecard.io/jira.openIssues.thresholds.rules.warning: '10-15'
     # Changes global 'error' from '>100' to '>15'
-    scorecard.io/jira.open_issues.thresholds.rules.error: '>15'
+    scorecard.io/jira.openIssues.thresholds.rules.error: '>15'
 spec:
   type: service
 ----

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-override-rules-to-configure-entity-specific-thresholds-in-scorecards.adoc
@@ -13,7 +13,7 @@ The annotation key must use the following format:
 
 [cols="1,2,2,2", options="header"]
 |===
-| Element | Description | Example Annotation | Example Value
+| Element | Description | Example annotation | Example value
 
 | `{providerId}`
 | Unique identifier of the metric

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
@@ -47,7 +47,7 @@ You must not use both parameters in the same request.
 |`metricIds`
 |String
 |No
-|A comma-separated list of IDs (for example, `github.open_prs`).
+|A comma-separated list of IDs (for example, `github.openPRs`).
 
 |`datasource`
 |String

--- a/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
+++ b/modules/observability_evaluate-project-health-using-scorecards/ref-scorecard-plugin-rest-api-endpoints-and-parameters.adoc
@@ -4,7 +4,7 @@
 = API endpoints and parameter details
 
 [role="_abstract"]
-REST API endpoints for the scorecard plugin used to fetch portfolio evaluations and component summaries.
+You can use the Scorecard plugin REST API endpoints to fetch portfolio evaluations and component summaries.
 
 == Required permissions
 To use these endpoints, make sure your account has the following permissions:
@@ -28,8 +28,8 @@ The endpoint `GET /metrics/:metricId/catalog/aggregations` is deprecated. Update
 ====
 
 == API parameter definitions
-`aggregationId`:: The unique identification key tracking a targeted scorecard summary layout block.
-`metricId`:: The unique provider key tracking an individual metrics collection channel source layer.
+`aggregationId`:: The unique identifier for a scorecard summary configuration.
+`metricId`:: The unique identifier for a specific metric from a provider.
 
 == Filtering metrics (GET /metrics)
 


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
release-2.1 only

**Issue:**
[RHIDP-14328](https://redhat.atlassian.net/browse/RHIDP-14328)
[RHIDP-15520](https://redhat.atlassian.net/browse/RHIDP-15520)

**Preview:**
N/A (no new pages — metric ID text replacements only)

## Summary

- Updates all scorecard metric IDs from `snake_case` to `lowerCamelCase` across 16 files to align with the naming convention change in RHDH 2.1 ([rhdh-plugins PR #3534](https://github.com/redhat-developer/rhdh-plugins/pull/3534))
- Updates YAML config keys (e.g., `open_prs:` → `openPRs:`), annotation examples, description list references, and the metric providers reference table
- No new modules added; no structural changes

## Metric ID migration mapping reference

A standalone migration mapping module (D5 from the doc plan) is deferred to the broader RHDH 2.1 migration guide work tracked under [RHIDP-15143](https://redhat.atlassian.net/browse/RHIDP-15143). The full old-to-new metric ID mapping is documented in the planning file `RHIDP-15520-Scorecard-Metric-ID-Plan.md`.

## Test plan

- [ ] Verify no `snake_case` metric IDs remain in scorecard docs (`grep -rn "open_prs\|open_issues\|binary_artifacts\|branch_protection" modules/observability_evaluate-project-health-using-scorecards/`)
- [ ] Verify YAML config examples use `lowerCamelCase` keys
- [ ] Verify annotation examples use updated metric IDs
- [ ] CQA checks pass with no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)