### PR TITLE
[RHIDP-15826]: Rebrand Lightspeed to intelligent assistant

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -60,8 +60,9 @@
 // Red Hat Platforms (in alphabetical order)
 :logging-brand-name: Red Hat OpenShift Logging
 :logging-short: OpenShift Logging
-:ls-brand-name: {product} intelligent assistant
-:ls-short: {product-short} intelligent assistant
+:ia-brand-name: {product} intelligent assistant
+:ia-short: {product-short} intelligent assistant
+:ia-very-short: intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP
@@ -141,7 +142,7 @@
 :develop-and-deploy-dynamic-plugins-book-link: {product-docs-link}/html-single/develop_and_deploy_dynamic_plugins_in_red_hat_developer_hub/index
 :develop-and-deploy-dynamic-plugins-book-title: Develop and deploy dynamic plugins in {product}
 :developer-lightspeed-book-link: {product-docs-link}/html-single/interacting_with_the_red_hat_developer_hub_intelligent_assistant/index
-:developer-lightspeed-book-title: Interacting with the {ls-brand-name}
+:developer-lightspeed-book-title: Interacting with the {ia-brand-name}
 :diagnostic-data-collection-book-link: {product-docs-link}/html-single/collect_diagnostic_data_to_streamline_support_resolution/index
 :diagnostic-data-collection-book-title: Collect diagnostic data to streamline support resolution
 :discover-category-link: {product-docs-link}/#Discover

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -62,7 +62,6 @@
 :logging-short: OpenShift Logging
 :ia-brand-name: {product} intelligent assistant
 :ia-short: {product-short} intelligent assistant
-:ia-very-short: intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -60,8 +60,8 @@
 // Red Hat Platforms (in alphabetical order)
 :logging-brand-name: Red Hat OpenShift Logging
 :logging-short: OpenShift Logging
-:ls-brand-name: Red Hat Developer Lightspeed for {product}
-:ls-short: Developer Lightspeed for {product-very-short}
+:ls-brand-name: {product} intelligent assistant
+:ls-short: {product-short} intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP
@@ -140,8 +140,8 @@
 :default-helm-chart-values-link: link:https://github.com/redhat-developer/rhdh-chart/blob/release-{product-version}/charts/backstage/values.yaml
 :develop-and-deploy-dynamic-plugins-book-link: {product-docs-link}/html-single/develop_and_deploy_dynamic_plugins_in_red_hat_developer_hub/index
 :develop-and-deploy-dynamic-plugins-book-title: Develop and deploy dynamic plugins in {product}
-:developer-lightspeed-book-link: {product-docs-link}/html-single/interacting_with_red_hat_developer_lightspeed_for_red_hat_developer_hub/index
-:developer-lightspeed-book-title: Interacting with {ls-brand-name}
+:developer-lightspeed-book-link: {product-docs-link}/html-single/interacting_with_the_red_hat_developer_hub_intelligent_assistant/index
+:developer-lightspeed-book-title: Interacting with the {ls-brand-name}
 :diagnostic-data-collection-book-link: {product-docs-link}/html-single/collect_diagnostic_data_to_streamline_support_resolution/index
 :diagnostic-data-collection-book-title: Collect diagnostic data to streamline support resolution
 :discover-category-link: {product-docs-link}/#Discover

--- a/assemblies/integrate_interacting-with-model-context-protocol-tools-for-rhdh/assembly-store-personal-access-tokens-securely-to-authorize-ai-workflows-on-your-behalf.adoc
+++ b/assemblies/integrate_interacting-with-model-context-protocol-tools-for-rhdh/assembly-store-personal-access-tokens-securely-to-authorize-ai-workflows-on-your-behalf.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 :context: store-personal-access-tokens-securely-to-authorize-ai-workflows-on-your-behalf
 
 [role="_abstract"]
-When using third-party MCP integrations, you can store your personal access tokens securely and manage credentials in {ls-brand-name} so that the AI acts on your behalf.
+When using third-party MCP integrations, you can store your personal access tokens securely and manage credentials in {ia-brand-name} so that the AI acts on your behalf.
 
 include::../modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-enable-encryption-and-database-storage-for-mcp-server-tokens.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-ai-model-evaluation-data-to-select-the-right-ai-model.adoc
+++ b/assemblies/shared/assembly-ai-model-evaluation-data-to-select-the-right-ai-model.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 [id="ai-model-evaluation-data-to-select-the-right-ai-model_{context}"]
 = AI model evaluation data to select the right AI model
 
-:context: assembly-evaluate-developer-lightspeed-performance
+:context: assembly-evaluate-intelligent-assistant-performance
 
 [role="_abstract"]
 Use the {ls-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ls-short}. 

--- a/assemblies/shared/assembly-ai-model-evaluation-data-to-select-the-right-ai-model.adoc
+++ b/assemblies/shared/assembly-ai-model-evaluation-data-to-select-the-right-ai-model.adoc
@@ -7,7 +7,7 @@ ifdef::context[:parent-context: {context}]
 :context: assembly-evaluate-intelligent-assistant-performance
 
 [role="_abstract"]
-Use the {ls-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ls-short}. 
+Use the {ia-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ia-short}. 
 
 With this automated toolset, you can measure how effectively various large language models (LLMs) answer questions based on {product} documentation.
 
@@ -17,7 +17,7 @@ With this automated toolset, you can measure how effectively various large langu
 | Component | Description
 | Evaluation framework | Contains the core logic and scripts used to run evaluations.
 | Datasets | Includes the input files used to test the model.
-| Evaluation metrics integration | Provides scoring through various metrics, including Ragas, DeepEval, and custom metrics. Ragas is the primary metric used to validate {ls-short} performance.
+| Evaluation metrics integration | Provides scoring through various metrics, including Ragas, DeepEval, and custom metrics. Ragas is the primary metric used to validate {ia-short} performance.
 |===
 
 include::../modules/shared/proc-configure-the-evaluation-environment-to-validate-model-accuracy.adoc[leveloffset=+1]

--- a/assemblies/shared/assembly-appendix-llm-requirements.adoc
+++ b/assemblies/shared/assembly-appendix-llm-requirements.adoc
@@ -7,7 +7,7 @@ ifdef::context[:parent-context: {context}]
 
 :context: appendix-llm-requirements
 [role="_abstract"]
-Review large language model (LLM) provider compatibility and system requirements for OpenAI, {rhoai-brand-name}, Ollama, vLLM, and Vertex AI to plan your {ls-short} infrastructure deployment.
+Review large language model (LLM) provider compatibility and system requirements for OpenAI, {rhoai-brand-name}, Ollama, vLLM, and Vertex AI to plan your {ia-short} infrastructure deployment.
 
 include::../modules/shared/con-large-language-model-llm-requirements.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-build-a-private-knowledge-base-with-notebooks.adoc
+++ b/assemblies/shared/assembly-build-a-private-knowledge-base-with-notebooks.adoc
@@ -2,12 +2,12 @@
 ifdef::context[:parent-context: {context}]
 
 [id="build-a-private-knowledge-base-with-notebooks_{context}"]
-= Build a private knowledge base with {ls-short} Notebooks
+= Build a private knowledge base with {ia-short} Notebooks
 
 :context: build-a-private-knowledge-base-with-notebooks
 
 [role="_abstract"]
-Use {ls-short} notebooks to create isolated research environments. These workspaces allow you to analyze project data securely by using a large language model (LLM) grounded in your specific documentation.
+Use {ia-short} notebooks to create isolated research environments. These workspaces allow you to analyze project data securely by using a large language model (LLM) grounded in your specific documentation.
 
 include::{docdir}/artifacts/snip-developer-preview.adoc[]
 

--- a/assemblies/shared/assembly-configure-to-initialize-the-ai-assistant.adoc
+++ b/assemblies/shared/assembly-configure-to-initialize-the-ai-assistant.adoc
@@ -2,12 +2,12 @@
 ifdef::context[:parent-context: {context}]
 
 [id="configure-to-initialize-the-ai-assistant_{context}"]
-= Configure {ls-short} to initialize the AI assistant
+= Configure {ia-short} to initialize the AI assistant
 
 :context: configure-to-initialize-the-ai-assistant
 
 [role="_abstract"]
-{ls-brand-name} is enabled by default on {product} ({product-very-short}) instances. To provide developers with chat assistance, configure your deployment settings by using either the Operator or the Helm chart.
+{ia-brand-name} is enabled by default on {product} ({product-very-short}) instances. To provide developers with chat assistance, configure your deployment settings by using either the Operator or the Helm chart.
 
 include::../modules/shared/proc-configure-by-using-the-operator.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-customize-ai-responses.adoc
+++ b/assemblies/shared/assembly-customize-ai-responses.adoc
@@ -2,14 +2,14 @@
 ifdef::context[:parent-context: {context}]
 
 [id="customize-ai-responses_{context}"]
-= Customize {ls-short} AI responses
+= Customize {ia-short} AI responses
 
 :context: customize
 
 [role="_abstract"]
-You can customize {ls-short} to align model behavior with your operational goals, enhance developer productivity, and ensure secure data retention. 
+You can customize {ia-short} to align model behavior with your operational goals, enhance developer productivity, and ensure secure data retention. 
 
-Customize {ls-short} by enabling user feedback, persisting chat history, and {model-context-protocol-book-link}#proc-configure-mcp-tools-for-developer-lightspeed_assembly-model-context-protocol-tools[configuring Model Context Protocol (MCP) tools].
+Customize {ia-short} by enabling user feedback, persisting chat history, and {model-context-protocol-book-link}#proc-configure-mcp-tools-for-developer-lightspeed_assembly-model-context-protocol-tools[configuring Model Context Protocol (MCP) tools].
 
 include::../modules/shared/proc-enable-user-feedback-to-improve-model-performance.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-get-ai-assisted-help-for-your-development-tasks.adoc
+++ b/assemblies/shared/assembly-get-ai-assisted-help-for-your-development-tasks.adoc
@@ -7,11 +7,11 @@ ifdef::context[:parent-context: {context}]
 :context: get-ai-assisted-help-for-your-development-tasks
 
 [role="_abstract"]
-Use {ls-brand-name}, a generative AI assistant in {product} ({product-very-short}), to ask platform questions, analyze logs, generate code, and create test plans from a chat interface.
+Use {ia-brand-name}, a generative AI assistant in {product} ({product-very-short}), to ask platform questions, analyze logs, generate code, and create test plans from a chat interface.
 
 == Prerequisites
 
-* Your platform engineer has configured the {ls-short} service in your {product-very-short} instance.
+* Your platform engineer has configured the {ia-short} service in your {product-very-short} instance.
 
 include::../modules/shared/proc-configure-safety-guards-in-rhdh.adoc[leveloffset=+1]
 

--- a/assemblies/shared/assembly-mirror-images-for-air-gapped-environments.adoc
+++ b/assemblies/shared/assembly-mirror-images-for-air-gapped-environments.adoc
@@ -2,12 +2,12 @@
 ifdef::context[:parent-context: {context}]
 
 [id="mirror-images-for-air-gapped-environments_{context}"]
-= Mirror {ls-short} images for air-gapped environments
+= Mirror {ia-short} images for air-gapped environments
 
 :context: mirror-images-for-air-gapped-environments
 
 [role="_abstract"]
-To provide chat assistance in a network environment without internet access, you must mirror the required {ls-short} container images and dynamic plugins to your local registry. This ensures your secure environment can pull the necessary components inside your network perimeter.
+To provide chat assistance in a network environment without internet access, you must mirror the required {ia-short} container images and dynamic plugins to your local registry. This ensures your secure environment can pull the necessary components inside your network perimeter.
 
 
 include::../modules/shared/proc-mirror-images-for-operator-deployments.adoc[leveloffset=+1]

--- a/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
+++ b/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="solve-project-specific-challenges-with-notebooks_{context}"]
 = Solve project-specific challenges with {ls-short} Notebooks
-:context: solve-project-specific-challenges-with-developer-lightspeed-notebooks
+:context: solve-project-specific-challenges-with-intelligent-assistant-notebooks
 
 [role="_abstract"]
 Use {ls-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.
@@ -25,7 +25,7 @@ The following constraints apply during the {developer-preview}:
 `Ephemeral defaults`:: Without a configured Persistent Volume (PV), all Notebook data and uploaded files are lost upon service restart.
 
 +
-image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-notebook-fullscreen-page.png["Lightspeed Notebook Fullscreen page"]
+image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-notebook-fullscreen-page.png["Intelligent assistant notebook fullscreen page"]
 
 include::{docdir}/artifacts/snip-developer-preview.adoc[]
 

--- a/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
+++ b/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="solve-project-specific-challenges-with-notebooks_{context}"]
 = Solve project-specific challenges with {ia-short} Notebooks
-:context: solve-project-specific-challenges-with-intelligent-assistant-notebooks
+:context: solve-project-specific-challenges-with-notebooks
 
 [role="_abstract"]
 Use {ia-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.

--- a/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
+++ b/assemblies/shared/assembly-solve-project-specific-challenges-with-notebooks.adoc
@@ -2,11 +2,11 @@
 ifdef::context[:parent-context: {context}]
 
 [id="solve-project-specific-challenges-with-notebooks_{context}"]
-= Solve project-specific challenges with {ls-short} Notebooks
+= Solve project-specific challenges with {ia-short} Notebooks
 :context: solve-project-specific-challenges-with-intelligent-assistant-notebooks
 
 [role="_abstract"]
-Use {ls-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.
+Use {ia-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.
 
 Use Notebooks to achieve the following goals:
 

--- a/modules/configure_configuring-rhdh/con-configuration-precedence.adoc
+++ b/modules/configure_configuring-rhdh/con-configuration-precedence.adoc
@@ -18,4 +18,4 @@ Environment variable resolution::
 References using the `$\{VAR_NAME}` syntax in any YAML configuration file resolve at runtime from environment variables. If a referenced environment variable is not set, {product-short} fails to start.
 
 Operator flavor merging::
-When you enable multiple pre-configured settings (for example, Orchestrator and the intelligent assistant), the Operator merges their configurations automatically. Settings from both configurations merge without manual intervention.
+When you enable multiple pre-configured settings (for example, Orchestrator and {ia-short}), the Operator merges their configurations automatically. Settings from both configurations merge without manual intervention.

--- a/modules/configure_configuring-rhdh/con-configuration-precedence.adoc
+++ b/modules/configure_configuring-rhdh/con-configuration-precedence.adoc
@@ -18,4 +18,4 @@ Environment variable resolution::
 References using the `$\{VAR_NAME}` syntax in any YAML configuration file resolve at runtime from environment variables. If a referenced environment variable is not set, {product-short} fails to start.
 
 Operator flavor merging::
-When you enable multiple pre-configured settings (for example, Orchestrator and Lightspeed), the Operator merges their configurations automatically. Settings from both configurations merge without manual intervention.
+When you enable multiple pre-configured settings (for example, Orchestrator and the intelligent assistant), the Operator merges their configurations automatically. Settings from both configurations merge without manual intervention.

--- a/modules/configure_configuring-rhdh/ref-pre-configured-settings-for-common-use-cases.adoc
+++ b/modules/configure_configuring-rhdh/ref-pre-configured-settings-for-common-use-cases.adoc
@@ -114,7 +114,7 @@ To disable, set `spec.flavours: [{name: lightspeed, enabled: false}]`.
 * External LLM provider endpoint (OpenAI, {azure-short} OpenAI, or compatible API)
 * LLM API credentials
 +
-For complete configuration details, provider-specific guidance, and troubleshooting, see {developer-lightspeed-book-link}#install-and-configure_interacting-with-developer-lightspeed-for-rhdh[Install and configure {ls-brand-name}].
+For complete configuration details, provider-specific guidance, and troubleshooting, see {developer-lightspeed-book-link}#install-and-configure_interacting-with-the-intelligent-assistant-for-rhdh[Install and configure {ls-brand-name}].
 
 == Multiple pre-configured settings
 

--- a/modules/configure_configuring-rhdh/ref-pre-configured-settings-for-common-use-cases.adoc
+++ b/modules/configure_configuring-rhdh/ref-pre-configured-settings-for-common-use-cases.adoc
@@ -75,14 +75,14 @@ For configuration details, see {configuring-book-link}#configure-external-postgr
 +
 For detailed steps, see xref:deploy-rhdh-for-workflow-automation_{context}[Deploy {product} for workflow automation].
 
-== {ls-short}
+== {ia-short}
 
-{ls-short} is enabled by default in {product} 1.10.0 and later. Connect your LLM provider to use AI chat assistance.
+{ia-short} is enabled by default in {product} 1.10.0 and later. Connect your LLM provider to use AI chat assistance.
 
 *Automatically configured components:*
 
-* {ls-short} front-end plugin
-* {ls-short} backend plugin
+* {ia-short} front-end plugin
+* {ia-short} backend plugin
 * {lcs-name} sidecar
 
 *Minimal CR example:*
@@ -104,7 +104,7 @@ spec:
 
 [NOTE]
 ====
-{ls-short} is enabled by default.
+{ia-short} is enabled by default.
 You do not need to set `spec.flavours` to enable AI assistance.
 To disable, set `spec.flavours: [{name: lightspeed, enabled: false}]`.
 ====
@@ -114,11 +114,11 @@ To disable, set `spec.flavours: [{name: lightspeed, enabled: false}]`.
 * External LLM provider endpoint (OpenAI, {azure-short} OpenAI, or compatible API)
 * LLM API credentials
 +
-For complete configuration details, provider-specific guidance, and troubleshooting, see {developer-lightspeed-book-link}#install-and-configure_interacting-with-the-intelligent-assistant-for-rhdh[Install and configure {ls-brand-name}].
+For complete configuration details, provider-specific guidance, and troubleshooting, see {developer-lightspeed-book-link}#install-and-configure_interacting-with-the-intelligent-assistant-for-rhdh[Install and configure {ia-brand-name}].
 
 == Multiple pre-configured settings
 
-Enable both Orchestrator and {ls-short} in a single deployment:
+Enable both Orchestrator and {ia-short} in a single deployment:
 
 [source,yaml,subs="+attributes"]
 ----
@@ -140,9 +140,9 @@ spec:
 
 [NOTE]
 ====
-{ls-short} is enabled by default, so you only need to explicitly enable Orchestrator.
+{ia-short} is enabled by default, so you only need to explicitly enable Orchestrator.
 Settings from both configurations merge automatically.
 For production deployments with external PostgreSQL database, add the database configuration as shown in {configuring-book-link}#configure-external-postgresql-databases_configuring-rhdh[Configure external PostgreSQL databases].
 ====
 
-You must meet prerequisites for both: OpenShift Serverless components for Orchestrator and external LLM provider for {ls-short}.
+You must meet prerequisites for both: OpenShift Serverless components for Orchestrator and external LLM provider for {ia-short}.

--- a/modules/get-started_navigate-rhdh-on-your-first-day/con-overview-of-the-onboarding-workflow.adoc
+++ b/modules/get-started_navigate-rhdh-on-your-first-day/con-overview-of-the-onboarding-workflow.adoc
@@ -35,4 +35,4 @@ Production instances give access to live infrastructure data and technical guide
 
 * {navigate-rhdh-on-your-first-day-book-link}#con-navigate-the-rhdh-interface_quickly-gain-access-and-find-what-you-need-in-rhdh[*Start your day*]: Navigate to the {product-very-short} *Home Page* to view your personalized dashboard.
 * {navigate-rhdh-on-your-first-day-book-link}#con-navigate-the-rhdh-interface_quickly-gain-access-and-find-what-you-need-in-rhdh[*Learn the interface*]: Understand the Global Header and Sidebar tools.
-* {navigate-rhdh-on-your-first-day-book-link}#get-ai-assisted-help[*Get AI help*]: If enabled in production, open {ls-short} to ask questions about your new environment.
+* {navigate-rhdh-on-your-first-day-book-link}#get-ai-assisted-help[*Get AI help*]: If enabled in production, open {ia-short} to ask questions about your new environment.

--- a/modules/get-started_navigate-rhdh-on-your-first-day/proc-access-platform-wide-tools-using-global-plugins.adoc
+++ b/modules/get-started_navigate-rhdh-on-your-first-day/proc-access-platform-wide-tools-using-global-plugins.adoc
@@ -12,5 +12,5 @@ To manage technology standards, track project costs, or access AI help, use the 
 . In the left navigation sidebar, locate the standard or custom items that represent specific global extensions, such as:
 . *Tech Radar*: Use this to visualize your organization's approved and deprecated technologies.
 . *Cost Insights*: Use this to track and analyze cloud infrastructure spending for your projects.
-. *{ls-short}*: Access this conversational interface for AI-assisted development help and platform queries.
+. *{ia-short}*: Access this conversational interface for AI-assisted development help and platform queries.
 . *Learning Paths*: Access training and educational resources to improve your technical skills.

--- a/modules/get-started_navigate-rhdh-on-your-first-day/proc-log-in-to-rhdh.adoc
+++ b/modules/get-started_navigate-rhdh-on-your-first-day/proc-log-in-to-rhdh.adoc
@@ -24,6 +24,6 @@ Guest access has limited permissions. You cannot create or register components w
 
 . The portal redirects you to the *Home* page.
 
-image::shared/homepage-lightspeed-fab.png["Home page with Lightspeed button"]
+image::shared/homepage-lightspeed-fab.png["Home page with intelligent assistant button"]
 
 . The system displays your personalized dashboard, showing your username and recently accessed items.

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
@@ -24,7 +24,7 @@ Some clients do not yet support the Streamable endpoint. Use the SSE (Legacy) en
 
 .Procedure
 
-. Configure *{ls-short}* as a client. For more details, see {developer-lightspeed-link}[{ls-brand-name}].
+. Configure *{ia-short}* as a client. For more details, see {developer-lightspeed-link}[{ia-brand-name}].
 .. In the `lightspeed-stack.yaml` configuration, add the following `mcp_servers` configuration:
 +
 [source,yaml,subs="+attributes,+quotes"]
@@ -51,7 +51,7 @@ providers:
     config: {}
 ----
 
-.. To authorize requests to the MCP endpoint using `_<MCP_TOKEN>_`, add one or more servers to the `mcpServers` list in the {ls-short} `{my-app-config-file}` file, to make POST requests to {lcs-short}:
+.. To authorize requests to the MCP endpoint using `_<MCP_TOKEN>_`, add one or more servers to the `mcpServers` list in the {ia-short} `{my-app-config-file}` file, to make POST requests to {lcs-short}:
 +
 [source,yaml]
 ----
@@ -65,7 +65,7 @@ lightspeed:
 where:
 
 `name`:: Enter the server name. This must match the name configured in the {lcs-short}.
-`token`:: Optional: Enter the static token used to authorize requests. You can also configure the token through the *MCP Server Settings* in the *{ls-short}* user interface. The setting remains disabled until you configure the token.
+`token`:: Optional: Enter the static token used to authorize requests. You can also configure the token through the *MCP Server Settings* in the *{ia-short}* user interface. The setting remains disabled until you configure the token.
 
 .. Optional: Query the {lcs-short} `/v1/streaming_query` endpoint directly by providing the `MCP_TOKEN` in the header:
 +

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-resolve-authentication-issues-when-tools-are-not-found.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-resolve-authentication-issues-when-tools-are-not-found.adoc
@@ -10,8 +10,8 @@ If an MCP client connects to the server but cannot find deployed tools, verify t
 
 .Procedure
 
-. Check the token validation status in the {ls-brand-name} interface:
-.. In the {ls-brand-name} chat box, click the menu icon (*Chatbot options*) and select *MCP settings*.
+. Check the token validation status in the {ia-brand-name} interface:
+.. In the {ia-brand-name} chat box, click the menu icon (*Chatbot options*) and select *MCP settings*.
 .. Locate the relevant server and check the status message displayed below the token field.
 .. If the status is *Authorization failed. Try again*, the token is incorrect, improperly formatted, or missing. You must verify the token value and ensure the server is enabled.
 

--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-toggle-mcp-tools-in-the-chat-interface-to-control-the-data-context-provided-to-the-ai.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-toggle-mcp-tools-in-the-chat-interface-to-control-the-data-context-provided-to-the-ai.adoc
@@ -4,9 +4,9 @@
 = Toggle MCP tools in the chat interface
 
 [role="_abstract"]
-Use the {ls-brand-name} chat interface options to securely configure your personal tokens, toggle specific Model Context Protocol (MCP) services, and directly control the data context made available to the AI assistant.
+Use the {ia-brand-name} chat interface options to securely configure your personal tokens, toggle specific Model Context Protocol (MCP) services, and directly control the data context made available to the AI assistant.
 
-You can use the *MCP settings* panel in the {ls-short} chat interface to review server status and enable or disable specific tools for your session.
+You can use the *MCP settings* panel in the {ia-short} chat interface to review server status and enable or disable specific tools for your session.
 
 .Prerequisites
 
@@ -15,7 +15,7 @@ You can use the *MCP settings* panel in the {ls-short} chat interface to review 
 
 .Procedure
 
-. In the {ls-brand-name} chat box, click the *Chatbot options* menu icon in the header.
+. In the {ia-brand-name} chat box, click the *Chatbot options* menu icon in the header.
 . Select *MCP settings*.
 +
 image::shared/lightspeed-chat-mcp.png["MCP in chat"]
@@ -40,4 +40,4 @@ You must configure a token before you can enable a server that requires authenti
 
 . Submit a query in the chat that requires an MCP tool, such as requesting catalog resources or server information.
 . If you enabled a server, verify that the response contains data from that specific MCP tool.
-. If you disabled a server, verify that {ls-short} uses standard documentation or general knowledge instead of the MCP tool to provide the response.
+. If you disabled a server, verify that {ia-short} uses standard documentation or general knowledge instead of the MCP tool to provide the response.

--- a/modules/shared/con-ai-reference-and-tool-calling-capabilities-through.adoc
+++ b/modules/shared/con-ai-reference-and-tool-calling-capabilities-through.adoc
@@ -29,4 +29,4 @@ Verify that your model supports tool calling before you enable MCP features. Usi
 
 * Chat history
 
-{ls-short} sends prompts and receives LLM responses through the {lcs-short} sidecar.
+{ia-short} sends prompts and receives LLM responses through the {lcs-short} sidecar.

--- a/modules/shared/con-ai-response-monitoring-and-context-management.adoc
+++ b/modules/shared/con-ai-response-monitoring-and-context-management.adoc
@@ -4,7 +4,7 @@
 = AI response monitoring and context management
 
 [role="_abstract"]
-{ls-short} provides features to track the AI reasoning process and keep the context of your development tasks.
+{ia-short} provides features to track the AI reasoning process and keep the context of your development tasks.
 
 Thinking cards::
 An expandable thinking card is displayed while the AI processes a query. A pulse animation indicates the reasoning phase. You can expand the card to view detailed reasoning or collapse it to minimize screen clutter.
@@ -16,7 +16,7 @@ Context-aware citations::
 Retrieval-Augmented Generation (RAG) citations appear only when the AI uses internal documentation. This makes sure that general knowledge responses remain concise.
 
 Context preservation during model changes::
-When you select a different AI model, {ls-short} starts a new conversation. This keeps your earlier chats available in your history.
+When you select a different AI model, {ia-short} starts a new conversation. This keeps your earlier chats available in your history.
 
 Structural readability::
 The interface formats headings and bullet points automatically to make sure responses are scannable.

--- a/modules/shared/con-architecture-for-your-ai-backend-deployment.adoc
+++ b/modules/shared/con-architecture-for-your-ai-backend-deployment.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="architecture-for-your-ai-backend-deployment_{context}"]
-= {ls-brand-name} architecture for your AI backend deployment
+= {ia-brand-name} architecture for your AI backend deployment
 
 [role="_abstract"]
-Review the {ls-short} component architecture to plan your system layout and coordinate connections with your artificial intelligence (AI) backend deployment.
+Review the {ia-short} component architecture to plan your system layout and coordinate connections with your artificial intelligence (AI) backend deployment.
 
-The architecture relies on the {lcs-name} ({lcs-short}) container, which operates as the primary intermediary layer to manage {ls-short} functionality and console user interactions. After you enable the plugin, the interface appears as the *Intelligent Assistant* button on all platforms that host {product-very-short}.
+The architecture relies on the {lcs-name} ({lcs-short}) container, which operates as the primary intermediary layer to manage {ia-short} functionality and console user interactions. After you enable the plugin, the interface appears as the *Intelligent Assistant* button on all platforms that host {product-very-short}.
 
 .Additional resources
 * link:https://access.redhat.com/support/policy/updates/developerhub[{product} Life Cycle and supported platforms]

--- a/modules/shared/con-bring-your-own-model-integration.adoc
+++ b/modules/shared/con-bring-your-own-model-integration.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 Review _Bring Your Own Model (BYOM)_ requirements to select and integrate an OpenAI API-compatible inference service with {lcs-name}.
 
-{ls-short} relies on a BYOM architecture that let you connect the {lcs-name} ({lcs-short}) layer to any OpenAI API-compatible inference platforms. To establish connection compatibility, your chosen inference service must satisfy the following technical criteria:
+{ia-short} relies on a BYOM architecture that let you connect the {lcs-name} ({lcs-short}) layer to any OpenAI API-compatible inference platforms. To establish connection compatibility, your chosen inference service must satisfy the following technical criteria:
 
 * The service must conform to the OpenAI API specification for chat completions.
 * The host environment must match the specified infrastructure configuration and installation instructions.

--- a/modules/shared/con-chat-assistance-with.adoc
+++ b/modules/shared/con-chat-assistance-with.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="chat-assistance-with_{context}"]
-= Chat assistance with {ls-short}
+= Chat assistance with {ia-short}
 
 [role="_abstract"]
-Use {ls-short} to find product information, discover features, and resolve technical questions using natural language prompts directly within the {product-very-short} console.
+Use {ia-short} to find product information, discover features, and resolve technical questions using natural language prompts directly within the {product-very-short} console.
 
 image::shared/homepage-lightspeed-fab.png["Lightspeed chatbot on the home page"]
 

--- a/modules/shared/con-data-use-and-privacy-practices.adoc
+++ b/modules/shared/con-data-use-and-privacy-practices.adoc
@@ -4,8 +4,8 @@
 = Manage user data security
 
 [role="_abstract"]
-Review data routing and privacy practices to evaluate how {ls-short} handles chat messages and operational information transmitted to large language model (LLM) providers.
+Review data routing and privacy practices to evaluate how {ia-short} handles chat messages and operational information transmitted to large language model (LLM) providers.
 
-{ls-short} sends your chat messages directly to your configured large language model (LLM) provider. Because these messages can contain sensitive operational data regarding your cluster, users, or business environment, ensure that your provider compliance policies align with your organizational security standards.
+{ia-short} sends your chat messages directly to your configured large language model (LLM) provider. Because these messages can contain sensitive operational data regarding your cluster, users, or business environment, ensure that your provider compliance policies align with your organizational security standards.
 
-{ls-short} has limited capabilities to filter or redact the information you submit during user interactions. To mitigate data exposure risks, do not enter proprietary or confidential information into {ls-short}. To encourage user compliance, {ls-short} displays a mandatory warning at the start of each sessions, reminding users to omit personal or sensitive details.
+{ia-short} has limited capabilities to filter or redact the information you submit during user interactions. To mitigate data exposure risks, do not enter proprietary or confidential information into {ia-short}. To encourage user compliance, {ia-short} displays a mandatory warning at the start of each sessions, reminding users to omit personal or sensitive details.

--- a/modules/shared/con-large-language-model-llm-requirements.adoc
+++ b/modules/shared/con-large-language-model-llm-requirements.adoc
@@ -4,11 +4,11 @@
 = Large language model (LLM) requirements
 
 [role="_abstract"]
-To plan your {ls-short} deployment, you must determine which compatible large language model (LLM) inference provider fits your infrastructure. 
+To plan your {ia-short} deployment, you must determine which compatible large language model (LLM) inference provider fits your infrastructure. 
 
-{ls-short} operates on a _Bring Your Own Model (BYOM)_ architecture. Because the service does not include a native model, you must connect a compatible inference provider during installation. 
+{ia-short} operates on a _Bring Your Own Model (BYOM)_ architecture. Because the service does not include a native model, you must connect a compatible inference provider during installation. 
 
-The underlying {lcs-short} service integrates with platforms that support either the OpenAI API specification or the vLLM inference engine. {ls-short} supports the following inference provider configurations:
+The underlying {lcs-short} service integrates with platforms that support either the OpenAI API specification or the vLLM inference engine. {ia-short} supports the following inference provider configurations:
 
 * **OpenAI:** Cloud-based inference services.
 * **vLLM:** Enterprise inference servers, which include models hosted on {rhoai-brand-name} and {rhel} AI.

--- a/modules/shared/con-ollama-model-integration-requirements.adoc
+++ b/modules/shared/con-ollama-model-integration-requirements.adoc
@@ -4,17 +4,17 @@
 = Ollama model integration requirements
 
 [role="_abstract"]
-To integrate the open-source Ollama framework with {ls-short}, you must ensure that your network topology allows the {ls-short} service to route traffic to the Ollama server endpoint. 
+To integrate the open-source Ollama framework with {ia-short}, you must ensure that your network topology allows the {ia-short} service to route traffic to the Ollama server endpoint. 
 
 The Ollama server operates as a containerized layer, providing a command-line interface (CLI) to download, manage, and execute open-source models such as Llama 3 and Mistral. You can deploy Ollama on both local workstations and cluster environments.
 
-However, a cluster-deployed {ls-short} instance cannot access an Ollama server that runs exclusively on a workstation `localhost` interface. For cluster deployments, the Ollama server must reside on an externally accessible network perimeter or run directly inside the cluster.
+However, a cluster-deployed {ia-short} instance cannot access an Ollama server that runs exclusively on a workstation `localhost` interface. For cluster deployments, the Ollama server must reside on an externally accessible network perimeter or run directly inside the cluster.
 
 The following integration configurations are supported:
 
-* Both {ls-short} and Ollama deploy on a local workstation.
-* {ls-short} deploys locally and connects to an externally accessible cluster Ollama server.
-* Both {ls-short} and Ollama deploy inside the cluster infrastructure.
+* Both {ia-short} and Ollama deploy on a local workstation.
+* {ia-short} deploys locally and connects to an externally accessible cluster Ollama server.
+* Both {ia-short} and Ollama deploy inside the cluster infrastructure.
 
 
 .Additional resources

--- a/modules/shared/con-openai-model-integration-for-your-deployment.adoc
+++ b/modules/shared/con-openai-model-integration-for-your-deployment.adoc
@@ -4,7 +4,7 @@
 = OpenAI model integration for your deployment
 
 [role="_abstract"]
-Use OpenAI models to provide generative artificial intelligence (AI) inference services, such as GPT 5, for your {ls-short} deployment.
+Use OpenAI models to provide generative artificial intelligence (AI) inference services, such as GPT 5, for your {ia-short} deployment.
 
 The system connects directly to the OpenAI API platform to route user prompts and return model insights. To configure this large language model (LLM) provider, you must have an active API key generated from your OpenAI developer account.
 

--- a/modules/shared/con-user-feedback-collection.adoc
+++ b/modules/shared/con-user-feedback-collection.adoc
@@ -4,6 +4,6 @@
 = User feedback collection
 
 [role="_abstract"]
-Review how {ls-short} collects and isolates user feedback data within your cluster to manage local storage requirements and data privacy standards.
+Review how {ia-short} collects and isolates user feedback data within your cluster to manage local storage requirements and data privacy standards.
 
-{ls-short} saves user feedback submissions, including numerical ratings and text commentary, locally within the pod filesystem. Because {company-name} does not collect, access, or transmit this data, local platform administrators must manage and monitor these storage directories.
+{ia-short} saves user feedback submissions, including numerical ratings and text commentary, locally within the pod filesystem. Because {company-name} does not collect, access, or transmit this data, local platform administrators must manage and monitor these storage directories.

--- a/modules/shared/con-vertex-ai-integration-for-gemini-models.adoc
+++ b/modules/shared/con-vertex-ai-integration-for-gemini-models.adoc
@@ -4,9 +4,9 @@
 = Vertex AI integration for Gemini models
 
 [role="_abstract"]
-To use Gemini models with {ls-short}, you can configure {gcp-brand-name} Vertex AI to act as your managed large language model (LLM) inference provider. 
+To use Gemini models with {ia-short}, you can configure {gcp-brand-name} Vertex AI to act as your managed large language model (LLM) inference provider. 
 
-The underlying {lcs-short} service connects to Vertex AI to access hosted Gemini models. This integration provides {ls-short} with enterprise-grade language processing and chat assistance capabilities without requiring you to maintain a local inference server.
+The underlying {lcs-short} service connects to Vertex AI to access hosted Gemini models. This integration provides {ia-short} with enterprise-grade language processing and chat assistance capabilities without requiring you to maintain a local inference server.
 
 .Additional resources
 * link:https://cloud.google.com/vertex-ai/docs[Vertex AI documentation]

--- a/modules/shared/con-vllm-model-integration-for-high-throughput-inference.adoc
+++ b/modules/shared/con-vllm-model-integration-for-high-throughput-inference.adoc
@@ -4,7 +4,7 @@
 = vLLM model integration for high-throughput inference
 
 [role="_abstract"]
-Use the open-source vLLM high-throughput serving framework to optimize memory utilization and manage high volumes of concurrent requests for your {ls-short} deployment.
+Use the open-source vLLM high-throughput serving framework to optimize memory utilization and manage high volumes of concurrent requests for your {ia-short} deployment.
 
 The vLLM framework operates as an enterprise inference server that optimizes memory allocation to maximize the processing efficiency of large language models (LLMs). Integrating vLLM ensures that your environment maintains high performance and responsiveness under heavy concurrent user traffic.
 

--- a/modules/shared/con-your-compliance-and-data-sharing-responsibility.adoc
+++ b/modules/shared/con-your-compliance-and-data-sharing-responsibility.adoc
@@ -4,6 +4,6 @@
 = Your compliance and data-sharing responsibility
 
 [role="_abstract"]
-Review compliance requirements and data-sharing responsibilities to ensure that user interactions with {ls-short} align with your organization's data privacy policies.
+Review compliance requirements and data-sharing responsibilities to ensure that user interactions with {ia-short} align with your organization's data privacy policies.
 
-All data that users submit through prompts and responses within {ls-short} is transmitted directly to your configured large language model (LLM) inference service. Platform administrators must ensure that these external data transfers comply with corporate security standards, governance frameworks, and local data protection policies.
+All data that users submit through prompts and responses within {ia-short} is transmitted directly to your configured large language model (LLM) inference service. Platform administrators must ensure that these external data transfers comply with corporate security standards, governance frameworks, and local data protection policies.

--- a/modules/shared/proc-analyze-evaluation-results-to-identify-performance-gaps.adoc
+++ b/modules/shared/proc-analyze-evaluation-results-to-identify-performance-gaps.adoc
@@ -4,7 +4,7 @@
 = Analyze evaluation results to identify performance gaps
 
 [role="_abstract"]
-Determine the performance of {ls-short} and identify documentation areas that require model improvement by analyzing evaluation results in the repository. You can use these reports to compare performance across different large language models (LLMs) and topics.
+Determine the performance of {ia-short} and identify documentation areas that require model improvement by analyzing evaluation results in the repository. You can use these reports to compare performance across different large language models (LLMs) and topics.
 
 .Prerequisites
 * You must have access to the link:https://github.com/redhat-ai-dev/developer-lightspeed-evaluation/tree/main[`developer-lightspeed-evaluation` repository].

--- a/modules/shared/proc-configure-by-using-the-helm-chart.adoc
+++ b/modules/shared/proc-configure-by-using-the-helm-chart.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-by-using-the-helm-chart_{context}"]
-= Configure {ls-short} by using the Helm chart
+= Configure {ia-short} by using the Helm chart
 
 [role="_abstract"]
-Configure {ls-short} by using the Helm chart to manage large language model (LLM) providers, enable validation guardrails, and authorize custom role-based access control (RBAC) policies.
+Configure {ia-short} by using the Helm chart to manage large language model (LLM) providers, enable validation guardrails, and authorize custom role-based access control (RBAC) policies.
 
 .Prerequisites
 * You have access to a running {product-very-short} instance deployed with Helm.

--- a/modules/shared/proc-configure-by-using-the-operator.adoc
+++ b/modules/shared/proc-configure-by-using-the-operator.adoc
@@ -4,7 +4,7 @@
 = Configure the virtual assistant components
 
 [role="_abstract"]
-Configure {ls-short} by updating your {backstage} custom resource (CR) to map environment variables, manage configurations, and set access rights.
+Configure {ia-short} by updating your {backstage} custom resource (CR) to map environment variables, manage configurations, and set access rights.
 
 .Prerequisites
 * The {product-very-short} Operator is installed on your cluster.

--- a/modules/shared/proc-configure-the-evaluation-environment-to-validate-model-accuracy.adoc
+++ b/modules/shared/proc-configure-the-evaluation-environment-to-validate-model-accuracy.adoc
@@ -4,7 +4,7 @@
 = Configure the evaluation environment to validate model accuracy
 
 [role="_abstract"]
-Set up the evaluation environment to validate the performance and accuracy of {ls-short}. Configure this evaluation to ensure the model correctly interprets documentation and provides dependable answers. 
+Set up the evaluation environment to validate the performance and accuracy of {ia-short}. Configure this evaluation to ensure the model correctly interprets documentation and provides dependable answers. 
 
 include::{docdir}/artifacts/snip-developer-preview.adoc[]
 
@@ -46,7 +46,7 @@ export GEMINI_API_KEY="your-google-api-key"
 export OPENAI_API_KEY="your-key"
 ----
 
-. Optional: If you test with a live service, set your {ls-short} service API key:
+. Optional: If you test with a live service, set your {ia-short} service API key:
 +
 [source,bash]
 ----

--- a/modules/shared/proc-create-isolated-research-workspaces.adoc
+++ b/modules/shared/proc-create-isolated-research-workspaces.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 Organize your work into individual notebook sessions to keep research topics separate and private.
 
-image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-notebook-fullscreen-page.png["Notebook upload option"]
+image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-notebook-fullscreen-page.png["Intelligent assistant notebook fullscreen page"]
 
 .Procedure
 . In the {product-very-short} interface, click the *Intelligent Assistant* button.

--- a/modules/shared/proc-create-isolated-research-workspaces.adoc
+++ b/modules/shared/proc-create-isolated-research-workspaces.adoc
@@ -9,7 +9,7 @@ image::integrate_interacting-with-developer-lightspeed-for-rhdh/lightspeed-noteb
 
 .Procedure
 . In the {product-very-short} interface, click the *Intelligent Assistant* button.
-. In your *{ls-short}* page, select the *Notebooks* tab.
+. In your *{ia-short}* page, select the *Notebooks* tab.
 . Click *Create a new notebook* to start a new workspace.
 . Optional: To manage your workspaces, click the *More options* icon on a notebook card to *Rename*, *Delete*, or add *Tags* to the session.
 +

--- a/modules/shared/proc-disable-by-using-the-helm-chart.adoc
+++ b/modules/shared/proc-disable-by-using-the-helm-chart.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="disable-by-using-the-helm-chart_{context}"]
-= Disable {ls-short} by using the Helm chart
+= Disable {ia-short} by using the Helm chart
 
 [role="_abstract"]
-Disable the {ls-short} chat interface and stop associated container processes to remove the service from your Helm-deployed environment.
+Disable the {ia-short} chat interface and stop associated container processes to remove the service from your Helm-deployed environment.
 
 .Prerequisites
 * You have access to the cluster where your instance is deployed.

--- a/modules/shared/proc-disable-by-using-the-operator.adoc
+++ b/modules/shared/proc-disable-by-using-the-operator.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="disable-by-using-the-operator_{context}"]
-= Disable {ls-short} by using the Operator
+= Disable {ia-short} by using the Operator
 
 [role="_abstract"]
-Disable the {ls-short} chat interface and stop associated container processes to remove the service from your Operator-backed deployment.
+Disable the {ia-short} chat interface and stop associated container processes to remove the service from your Operator-backed deployment.
 
 .Prerequisites
 * You have access to the cluster where your instance is deployed.

--- a/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="enable-data-persistence-for-intelligent-assistant-notebooks_{context}"]
-= Enable data persistence for {ls-short} Notebooks
+= Enable data persistence for {ia-short} Notebooks
 
 [role="_abstract"]
 To persist Notebook sessions, documents, and AI history across service restarts, you must configure the Notebooks storage backends to use persistent volumes. 

--- a/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enable-data-persistence-for-intelligent-assistant-notebooks_{context}"]
+[id="enable-data-persistence-for-developer-lightspeed-notebooks_{context}"]
 = Enable data persistence for {ia-short} Notebooks
 
 [role="_abstract"]

--- a/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enable-data-persistence-for-developer-lightspeed-notebooks_{context}"]
+[id="enable-data-persistence-for-intelligent-assistant-notebooks_{context}"]
 = Enable data persistence for {ls-short} Notebooks
 
 [role="_abstract"]

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enable-secure-ai-research-with-intelligent-assistant-notebooks_{context}"]
+[id="enable-secure-ai-research-with-developer-lightspeed-notebooks_{context}"]
 = Solve project-specific challenges
 
 [role="_abstract"]

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -4,7 +4,7 @@
 = Solve project-specific challenges
 
 [role="_abstract"]
-Configure {product} and {ls-brand-name} to provide users with private, document-based AI workspaces.
+Configure {product} and {ia-brand-name} to provide users with private, document-based AI workspaces.
 
 .Prerequisites
 * A deployed instance of {product-very-short}.

--- a/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-secure-ai-research-with-developer-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enable-secure-ai-research-with-developer-lightspeed-notebooks_{context}"]
+[id="enable-secure-ai-research-with-intelligent-assistant-notebooks_{context}"]
 = Solve project-specific challenges
 
 [role="_abstract"]

--- a/modules/shared/proc-extract-and-verify-document-based-insights.adoc
+++ b/modules/shared/proc-extract-and-verify-document-based-insights.adoc
@@ -5,7 +5,7 @@
 [role="_abstract"]
 After providing context, use the AI to perform reasoning across your files and verify the accuracy of the responses.
 
-image::shared/lightspeed-notebook-chat.png["Lightspeed Notebook chat preview"]
+image::shared/lightspeed-notebook-chat.png["Intelligent assistant notebook chat preview"]
 
 .Prerequisites
 * You have uploaded documents or URLs to the active chat session to establish context.

--- a/modules/shared/proc-manage-chats.adoc
+++ b/modules/shared/proc-manage-chats.adoc
@@ -24,40 +24,40 @@ image::shared/lightspeed-chat-display.png["Chat display options"]
 
 ** *Overlay*: A floating window is displayed over the current page content.
 +
-image::shared/lightspeed-chat-overlay.png["Lightspeed overlay mode"]
+image::shared/lightspeed-chat-overlay.png["Intelligent assistant overlay mode"]
 
 ** *Dock to window*: A panel attaches to the right side of the screen. Activating this mode automatically closes the *quick start* panel if it is already open.
 +
-image::shared/lightspeed-chat-dock-to-window.png["Lightspeed docked mode"]
+image::shared/lightspeed-chat-dock-to-window.png["Intelligent assistant docked mode"]
 
-** *Fullscreen*: A dedicated page opens for intensive chat sessions. This mode displays a revised header containing the *Lightspeed* logo and a horizontal tab bar, which replaces the previous main menu. Bookmark the URL in your browser to save a direct link to the chat interface.
+** *Fullscreen*: A dedicated page opens for intensive chat sessions. This mode displays a revised header containing the *intelligent assistant* logo and a horizontal tab bar, which replaces the previous main menu. Bookmark the URL in your browser to save a direct link to the chat interface.
 +
-image::shared/lightspeed-chat-fullscreen.png["Lightspeed full-screen mode"]
+image::shared/lightspeed-chat-fullscreen.png["Intelligent assistant full-screen mode"]
 
 ** Optional: Toggle *Enable pinned chats*/*Disable pinned chats* to enable or hide the pinned chats. The system enables this option by default.
 
 ** Available only if MCP is configured: {model-context-protocol-book-link}[Manage Model Context Protocol connections].
 +
-image::shared/lightspeed-chat-mcp.png["Lightspeed chat mcp mode"]
+image::shared/lightspeed-chat-mcp.png["Intelligent assistant chat MCP mode"]
 
 . Start a chat or load an earlier session:
 
-** *Enter a prompt*: Type a query in the *Enter a prompt for Lightspeed* chat field and press *Enter*.
+** *Enter a prompt*: Type a query in the *Enter a prompt for the intelligent assistant* chat field and press *Enter*.
 ** *Use a sample*: Click a prompt tile.
 ** *Change the AI model*: Select a model from the model selector dropdown menu inside the prompt bar.
 +
-image::shared/lightspeed-chat-ai-model.png["Lightspeed chat AI model"]
+image::shared/lightspeed-chat-ai-model.png["Intelligent assistant chat AI model"]
 
 ** *Attach a file*: Click the (`+`) icon on the left of the prompt bar to upload a `.yaml`, `.json`, or `.txt` file. Descriptive text clarifies the function of the icon.
 ... Click the file name to open the preview model.
 ... View or edit the content of the file:
 +
-image::shared/lightspeed-chat-attach.png["Lightspeed file attachment preview"]
+image::shared/lightspeed-chat-attach.png["Intelligent assistant file attachment preview"]
 
 ** *Use voice*: Click the *Use microphone* icon. The microphone and send buttons are located on the right side of the prompt bar.
 ** *Control AI generation*: Use the control buttons on the right side of the prompt bar. Click the start/send (`>`) button to submit queries, or click the stop (`[]`) button to halt AI generation.
 +
-image::shared/lightspeed-chat-ai-model.png["Lightspeed file attachment preview"]
+image::shared/lightspeed-chat-ai-model.png["Intelligent assistant file attachment preview"]
 
 ** *Resume a chat*: Select a title from the *Recent* list.
 
@@ -65,7 +65,7 @@ image::shared/lightspeed-chat-ai-model.png["Lightspeed file attachment preview"]
 
 ** *Start a new topic*: Click *New chat* to reset the assistant's context. When the history panel is collapsed, you must click the *Edit square* icon to create a new chat.
 +
-image::shared/lightspeed-chat-newchat.png["Lightspeed new chat"]
+image::shared/lightspeed-chat-newchat.png["Intelligent assistant new chat"]
 
 ** *Search history*: Enter a keyword in the *Search* field.
 ** *Rename a session*: Click *Options* next to a chat title, select *Rename*, and enter a new name.
@@ -90,7 +90,7 @@ image::shared/lightspeed-chat-collapse.png["Collapse chat option"]
 The expanded panel is resizable up to a defined maximum width.
 ====
 
-. Optional: To hide the interface, if you are in the *Overlay* or *Dock to window* mode, click the *Close Lightspeed* icon (X) to hide the window. If you are in *Fullscreen* mode, revert to the other modes and click the *Close Lightspeed* icon (X). The system preserves your active query and history.
+. Optional: To hide the interface, if you are in the *Overlay* or *Dock to window* mode, click the *Close intelligent assistant* icon (X) to hide the window. If you are in *Fullscreen* mode, revert to the other modes and click the *Close intelligent assistant* icon (X). The system preserves your active query and history.
 
 . Optional: In *Fullscreen* mode, bookmark the URL in your browser to save a direct link to the chat interface.
 

--- a/modules/shared/proc-manage-chats.adoc
+++ b/modules/shared/proc-manage-chats.adoc
@@ -9,7 +9,7 @@ Manage your chat history and configuration in {product-very-short} to organize y
 image::shared/lightspeed-chat-display.png["Chat menu options"]
 
 .Prerequisites
-* You have configured the {ls-short} plugin in {product}.
+* You have configured the {ia-short} plugin in {product}.
 * You have logged in to the portal.
 
 .Procedure

--- a/modules/shared/proc-mirror-images-for-helm-deployments-on-kubernetes.adoc
+++ b/modules/shared/proc-mirror-images-for-helm-deployments-on-kubernetes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="mirror-images-for-helm-deployments-on-kubernetes_{context}"]
-= Mirror {ls-short} images for Helm deployments on Kubernetes
+= Mirror {ia-short} images for Helm deployments on Kubernetes
 
 [role="_abstract"]
 Isolate image references, copy them manually to your internal registry, and update your configuration file when deploying the Helm chart on non-{platform-generic} platforms.
@@ -8,7 +8,7 @@ Isolate image references, copy them manually to your internal registry, and upda
 .Prerequisites
 * You have a target mirror registry accessible to your disconnected cluster.
 * You authenticated to the {rhcr} and your target mirror registry.
-* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-on-a-supported-kubernetes-platform-in-an-air-gapped-environment-with-the-helm-chart[Install {product} on a supported Kubernetes platform in an air-gapped environment with the Helm chart]. The `kubelet` requires these credentials to pull all {product} container images, including the {ls-short} sidecar images.
+* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-on-a-supported-kubernetes-platform-in-an-air-gapped-environment-with-the-helm-chart[Install {product} on a supported Kubernetes platform in an air-gapped environment with the Helm chart]. The `kubelet` requires these credentials to pull all {product} container images, including the {ia-short} sidecar images.
 
 .Procedure
 

--- a/modules/shared/proc-mirror-images-for-helm-deployments-on-ocp.adoc
+++ b/modules/shared/proc-mirror-images-for-helm-deployments-on-ocp.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: PROCEDURE
 [id="mirror-images-for-helm-deployments-on-ocp_{context}"]
-= Mirror {ls-short} images for Helm deployments on {ocp-short}
+= Mirror {ia-short} images for Helm deployments on {ocp-short}
 
 [role="_abstract"]
-Mirror the required {ls-short} container images to your local registry by using the `oc-mirror` plugin when deploying the Helm chart on an {ocp-short} cluster.
+Mirror the required {ia-short} container images to your local registry by using the `oc-mirror` plugin when deploying the Helm chart on an {ocp-short} cluster.
 
 .Prerequisites
 * You have a target mirror registry accessible to your disconnected {ocp-short} cluster.
 * You authenticated to the {rhcr} and your target mirror registry.
-* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-on-ocp-in-an-air-gapped-environment-with-the-helm-chart[Install {product} on {ocp-short} in an air-gapped environment with the Helm chart]. The `kubelet` requires these credentials to pull all {product} container images, including the {ls-short} sidecar images.
+* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-on-ocp-in-an-air-gapped-environment-with-the-helm-chart[Install {product} on {ocp-short} in an air-gapped environment with the Helm chart]. The `kubelet` requires these credentials to pull all {product} container images, including the {ia-short} sidecar images.
 
 .Procedure
 

--- a/modules/shared/proc-mirror-images-for-operator-deployments.adoc
+++ b/modules/shared/proc-mirror-images-for-operator-deployments.adoc
@@ -3,14 +3,14 @@
 = Mirror intelligent assistant images for air-gapped environments
 
 [role="_abstract"]
-Mirror the required {ls-short} container images and plugins to your local registry to provide chat assistance in an air-gapped environment. 
+Mirror the required {ia-short} container images and plugins to your local registry to provide chat assistance in an air-gapped environment. 
 
-The {installing-in-air-gap-book-link}#install-rhdh-in-a-fully-disconnected-environment-with-the-operator_install-rhdh-in-an-air-gapped-environment-with-the-operator[`prepare-restricted-environment.sh`] script does not automatically parse `{ls-short}` images from the bundle manifest, so mirror these images manually before running the script.
+The {installing-in-air-gap-book-link}#install-rhdh-in-a-fully-disconnected-environment-with-the-operator_install-rhdh-in-an-air-gapped-environment-with-the-operator[`prepare-restricted-environment.sh`] script does not automatically parse `{ia-short}` images from the bundle manifest, so mirror these images manually before running the script.
 
 .Prerequisites
 * You have a target mirror registry accessible to your disconnected cluster.
 * You authenticated to the {rhcr} and your target mirror registry.
-* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-in-an-air-gapped-environment-with-the-operator[Install {product} in an air-gapped environment with the Operator]. The `kubelet` requires these credentials to pull all {product} container images, including the {ls-short} sidecar images.
+* You have configured image pull authentication for your mirror registry as described in {installing-in-air-gap-book-link}#install-rhdh-in-an-air-gapped-environment-with-the-operator[Install {product} in an air-gapped environment with the Operator]. The `kubelet` requires these credentials to pull all {product} container images, including the {ia-short} sidecar images.
 
 .Procedure
 

--- a/modules/shared/proc-mirror-images-for-operator-deployments.adoc
+++ b/modules/shared/proc-mirror-images-for-operator-deployments.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="mirror-images-for-operator-deployments_{context}"]
-= Mirror Lightspeed images for air-gapped environments
+= Mirror intelligent assistant images for air-gapped environments
 
 [role="_abstract"]
 Mirror the required {ls-short} container images and plugins to your local registry to provide chat assistance in an air-gapped environment. 

--- a/modules/shared/proc-prepare-evaluation-datasets-to-verify-ai-generated-responses.adoc
+++ b/modules/shared/proc-prepare-evaluation-datasets-to-verify-ai-generated-responses.adoc
@@ -4,7 +4,7 @@
 = Prepare evaluation datasets to verify AI-generated responses
 
 [role="_abstract"]
-Prepare evaluation data sets to test the performance of {ls-short}. You can use pre-generated AI data sets for specific {product} releases or generate custom AI data sets from your own documentation.
+Prepare evaluation data sets to test the performance of {ia-short}. You can use pre-generated AI data sets for specific {product} releases or generate custom AI data sets from your own documentation.
 
 .Prerequisites
 

--- a/modules/shared/proc-run-performance-tests-to-ensure-ai-response-reliability.adoc
+++ b/modules/shared/proc-run-performance-tests-to-ensure-ai-response-reliability.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 Use the evaluation framework to run performance tests in either static mode to evaluate pre-recorded responses or dynamic mode to call a live service. 
 
-These evaluations identify performance gaps, allow you to compare different large language models (LLMs), and ensure that {ls-short} provides reliable information to users.
+These evaluations identify performance gaps, allow you to compare different large language models (LLMs), and ensure that {ia-short} provides reliable information to users.
 
 .Prerequisites
 
@@ -22,7 +22,7 @@ These evaluations identify performance gaps, allow you to compare different larg
 | Field | Description
 | `llm` | Defines the judge LLM that scores the responses, such as `gemini-2.5-pro`.
 | `api.enabled` | Set to `false` for static mode to use pre-filled data. Set to `true` for dynamic mode to call a live service.
-| `api.api_base` | (Required for dynamic mode only) Provide the URL of your {ls-short} service.
+| `api.api_base` | (Required for dynamic mode only) Provide the URL of your {ia-short} service.
 | `api.endpoint_type` | Specify the service configuration type: `streaming` or `query`.
 |===
 

--- a/modules/shared/ref-best-results-for-assistant-queries.adoc
+++ b/modules/shared/ref-best-results-for-assistant-queries.adoc
@@ -4,7 +4,7 @@
 = Best results for assistant queries
 
 [role="_abstract"]
-To resolve technical blockers and accelerate development tasks, you must structure your queries to give specific context to the AI assistant. Using precise prompts makes sure that {ls-short} generates relevant code snippets, architectural advice, or platform-specific instructions.
+To resolve technical blockers and accelerate development tasks, you must structure your queries to give specific context to the AI assistant. Using precise prompts makes sure that {ia-short} generates relevant code snippets, architectural advice, or platform-specific instructions.
 
 Use the following strategies to improve the accuracy of the assistant's output during your development workflow:
 

--- a/modules/shared/ref-evaluation-metrics-and-historical-data-reference.adoc
+++ b/modules/shared/ref-evaluation-metrics-and-historical-data-reference.adoc
@@ -4,7 +4,7 @@
 = Evaluation metrics and historical data reference
 
 [role="_abstract"]
-Use the link:https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/[available metrics] to evaluate the performance of {ls-short} at the conversation turn level. 
+Use the link:https://docs.ragas.io/en/stable/concepts/metrics/available_metrics/[available metrics] to evaluate the performance of {ia-short} at the conversation turn level. 
 
 These metrics provide a standardized way to measure the accuracy and reliability of the generated responses and the retrieved content.
 

--- a/modules/shared/ref-release-report-and-historical-data.adoc
+++ b/modules/shared/ref-release-report-and-historical-data.adoc
@@ -4,7 +4,7 @@
 = Release report and historical data
 
 [role="_abstract"]
-Use the link:https://github.com/redhat-ai-dev/developer-lightspeed-evaluation[latest Q&A data set and evaluation results] to monitor the current performance of {ls-short}. 
+Use the link:https://github.com/redhat-ai-dev/developer-lightspeed-evaluation[latest Q&A data set and evaluation results] to monitor the current performance of {ia-short}. 
 
 Access version-specific branches that contain the data sets and evaluation results required to track improvements or regressions across product releases.
 

--- a/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
+++ b/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
@@ -5,8 +5,8 @@ include::artifacts/attributes.adoc[]
 
 :context: interacting-with-the-intelligent-assistant-for-rhdh
 :title: {developer-lightspeed-book-title}
-:subtitle: Leverage Artificial Intelligence (AI)-driven expertise of the {ls-brand-name} to help you use {product} ({product-very-short})
-:abstract: The {ls-brand-name} is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with the {ls-short} to explore {product-very-short} capabilities in detail.
+:subtitle: Leverage Artificial Intelligence (AI)-driven expertise of the {ia-brand-name} to help you use {product} ({product-very-short})
+:abstract: The {ia-brand-name} is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with the {ia-short} to explore {product-very-short} capabilities in detail.
 
 [id="{context}"]
 = {title}

--- a/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
+++ b/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
@@ -3,10 +3,10 @@
 
 include::artifacts/attributes.adoc[]
 
-:context: interacting-with-developer-lightspeed-for-rhdh
+:context: interacting-with-the-intelligent-assistant-for-rhdh
 :title: {developer-lightspeed-book-title}
-:subtitle: Leverage Artificial Intelligence (AI)-driven expertise of the {ls-brand-name} ({ls-short}) virtual assistant to help you use {product} ({product-very-short})
-:abstract: {ls-brand-name} ({ls-short}) is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with {ls-short} to explore {product-very-short} capabilities in detail.
+:subtitle: Leverage Artificial Intelligence (AI)-driven expertise of the {ls-brand-name} to help you use {product} ({product-very-short})
+:abstract: The {ls-brand-name} is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with the {ls-short} to explore {product-very-short} capabilities in detail.
 
 [id="{context}"]
 = {title}

--- a/titles/product_product/category-maps/discover/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: CONCEPT
 
-= Build a private knowledge base with {ls-short} Notebooks
+= Build a private knowledge base with {ia-short} Notebooks
 
 [role="_abstract"]
-Use {ls-short} notebooks to create isolated research environments. These workspaces allow you to analyze project data securely by using a large language model (LLM) grounded in your specific documentation.
+Use {ia-short} notebooks to create isolated research environments. These workspaces allow you to analyze project data securely by using a large language model (LLM) grounded in your specific documentation.
 
 include::../../artifacts/snip-developer-preview.adoc[]

--- a/titles/product_product/category-maps/discover/con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Developer Lightspeed AI virtual assistant capabilities
+= AI virtual assistant capabilities
 
 [role="_abstract"]
 Understand the {ls-brand-name} AI assistant architecture and system design to plan backend deployment and integration with {product}.

--- a/titles/product_product/category-maps/discover/con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
@@ -3,4 +3,4 @@
 = AI virtual assistant capabilities
 
 [role="_abstract"]
-Understand the {ls-brand-name} AI assistant architecture and system design to plan backend deployment and integration with {product}.
+Understand the {ia-brand-name} AI assistant architecture and system design to plan backend deployment and integration with {product}.

--- a/titles/product_product/category-maps/discover/con-evaluate-ai-model-accuracy-and-response-quality.adoc
+++ b/titles/product_product/category-maps/discover/con-evaluate-ai-model-accuracy-and-response-quality.adoc
@@ -3,7 +3,7 @@
 = AI model evaluation data to select the right AI model
 
 [role="_abstract"]
-Use the {ls-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ls-short}.
+Use the {ia-brand-name} evaluation framework to validate the performance, accuracy, and reliability of {ia-short}.
 
 With this automated toolset, you can measure how effectively various large language models (LLMs) answer questions based on {product} documentation.
 
@@ -13,5 +13,5 @@ With this automated toolset, you can measure how effectively various large langu
 | Component | Description
 | Evaluation framework | Contains the core logic and scripts used to run evaluations.
 | Datasets | Includes the input files used to test the model.
-| Evaluation metrics integration | Provides scoring through various metrics, including Ragas, DeepEval, and custom metrics. Ragas is the primary metric used to validate {ls-short} performance.
+| Evaluation metrics integration | Provides scoring through various metrics, including Ragas, DeepEval, and custom metrics. Ragas is the primary metric used to validate {ia-short} performance.
 |===

--- a/titles/product_product/category-maps/discover/con-why-internal-developer-platforms.adoc
+++ b/titles/product_product/category-maps/discover/con-why-internal-developer-platforms.adoc
@@ -64,5 +64,5 @@ Support growing teams and applications while maintaining access to the same tool
 * {techdocs-book-link}[{techdocs-book-title}]
 * {customizing-book-link}#proc-customize-rhdh-learning-paths_configuring-templates[Customizing the Learning Paths in {product}]
 * {installing-and-viewing-plugins-book-link}[{installing-and-viewing-plugins-book-title}]
-* xref:platform-integrations-for-toolchain-connectivity_developer-lightspeed-ai-virtual-assistant-capabilities[Integrations in {product}]
+* xref:platform-integrations-for-toolchain-connectivity_intelligent-assistant-capabilities[Integrations in {product}]
 * {authentication-book-link}[{authentication-book-title}]

--- a/titles/product_product/category-maps/discover/con-why-internal-developer-platforms.adoc
+++ b/titles/product_product/category-maps/discover/con-why-internal-developer-platforms.adoc
@@ -64,5 +64,5 @@ Support growing teams and applications while maintaining access to the same tool
 * {techdocs-book-link}[{techdocs-book-title}]
 * {customizing-book-link}#proc-customize-rhdh-learning-paths_configuring-templates[Customizing the Learning Paths in {product}]
 * {installing-and-viewing-plugins-book-link}[{installing-and-viewing-plugins-book-title}]
-* xref:platform-integrations-for-toolchain-connectivity_intelligent-assistant-capabilities[Integrations in {product}]
+* xref:platform-integrations-for-toolchain-connectivity_developer-lightspeed-ai-virtual-assistant-capabilities[Integrations in {product}]
 * {authentication-book-link}[{authentication-book-title}]

--- a/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
-= Build a private knowledge base with {ls-short} notebooks
+= Build a private knowledge base with {ia-short} notebooks
 :context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
+[id="build-a-private-knowledge-base-with-lightspeed-notebooks_{context}"]
 = Build a private knowledge base with {ia-short} notebooks
-:context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
+:context: build-a-private-knowledge-base-with-lightspeed-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/discover/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="build-a-private-knowledge-base-with-lightspeed-notebooks_{context}"]
-= Build a private knowledge base with {ls-short} Notebooks
-:context: build-a-private-knowledge-base-with-lightspeed-notebooks
+[id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
+= Build a private knowledge base with {ls-short} notebooks
+:context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="developer-lightspeed-ai-virtual-assistant-capabilities_{context}"]
-= Developer Lightspeed AI virtual assistant capabilities
-:context: developer-lightspeed-ai-virtual-assistant-capabilities
+[id="intelligent-assistant-capabilities_{context}"]
+= AI virtual assistant capabilities
+:context: intelligent-assistant-capabilities
 
 include::con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
+++ b/titles/product_product/category-maps/discover/nav-developer-lightspeed-ai-virtual-assistant-capabilities.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="intelligent-assistant-capabilities_{context}"]
+[id="developer-lightspeed-ai-virtual-assistant-capabilities_{context}"]
 = AI virtual assistant capabilities
-:context: intelligent-assistant-capabilities
+:context: developer-lightspeed-ai-virtual-assistant-capabilities
 
 include::con-developer-lightspeed-ai-virtual-assistant-capabilities.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
+++ b/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="platform-integrations-for-toolchain-connectivity_{context}"]
-[id="platform-integrations-for-toolchain-connectivity_intelligent-assistant-capabilities"]
+[id="platform-integrations-for-toolchain-connectivity_developer-lightspeed-ai-virtual-assistant-capabilities"]
 = Platform integrations for toolchain connectivity
 :context: platform-integrations-for-toolchain-connectivity
 

--- a/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
+++ b/titles/product_product/category-maps/discover/nav-platform-integrations-for-toolchain-connectivity.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="platform-integrations-for-toolchain-connectivity_{context}"]
-[id="platform-integrations-for-toolchain-connectivity_developer-lightspeed-ai-virtual-assistant-capabilities"]
+[id="platform-integrations-for-toolchain-connectivity_intelligent-assistant-capabilities"]
 = Platform integrations for toolchain connectivity
 :context: platform-integrations-for-toolchain-connectivity
 

--- a/titles/product_product/category-maps/get-started/con-get-ai-assisted-help-for-your-development-tasks.adoc
+++ b/titles/product_product/category-maps/get-started/con-get-ai-assisted-help-for-your-development-tasks.adoc
@@ -3,8 +3,8 @@
 = Get AI-assisted help for your development tasks
 
 [role="_abstract"]
-Use {ls-brand-name}, a generative AI assistant in {product} ({product-very-short}), to ask platform questions, analyze logs, generate code, and create test plans from a chat interface.
+Use {ia-brand-name}, a generative AI assistant in {product} ({product-very-short}), to ask platform questions, analyze logs, generate code, and create test plans from a chat interface.
 
 == Prerequisites
 
-* Your platform engineer has configured the {ls-short} service in your {product-very-short} instance.
+* Your platform engineer has configured the {ia-short} service in your {product-very-short} instance.

--- a/titles/product_product/category-maps/integrate/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/integrate/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Build a private knowledge base with {ls-short} notebooks
+= Build a private knowledge base with {ia-short} notebooks
 
 [role="_abstract"]
-Use {ls-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.
+Use {ia-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.

--- a/titles/product_product/category-maps/integrate/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/integrate/con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Build a private knowledge base with Lightspeed Notebooks
+= Build a private knowledge base with {ls-short} notebooks
 
 [role="_abstract"]
 Use {ls-short} Notebooks to research, troubleshoot, and analyze projects by using a large language model (LLM) grounded in your own documentation. Notebooks use Retrieval-Augmented Generation (RAG) to ensure that responses are based strictly on the files you upload.

--- a/titles/product_product/category-maps/integrate/con-configure-mcp-tokens-and-endpoints.adoc
+++ b/titles/product_product/category-maps/integrate/con-configure-mcp-tokens-and-endpoints.adoc
@@ -3,4 +3,4 @@
 = Configure MCP tokens and endpoints
 
 [role="_abstract"]
-When using third-party MCP integrations, you can store your personal access tokens securely and manage credentials in {ls-brand-name} so that the AI acts on your behalf.
+When using third-party MCP integrations, you can store your personal access tokens securely and manage credentials in {ia-brand-name} so that the AI acts on your behalf.

--- a/titles/product_product/category-maps/integrate/con-customize-the-system-prompt-and-ui-options.adoc
+++ b/titles/product_product/category-maps/integrate/con-customize-the-system-prompt-and-ui-options.adoc
@@ -3,4 +3,4 @@
 = Customize the system prompt and UI options
 
 [role="_abstract"]
-You can customize {ls-short} to align model behavior with your operational goals, enhance developer productivity, and ensure secure data retention.
+You can customize {ia-short} to align model behavior with your operational goals, enhance developer productivity, and ensure secure data retention.

--- a/titles/product_product/category-maps/integrate/con-developer-lightspeed-for-rhdh-architecture.adoc
+++ b/titles/product_product/category-maps/integrate/con-developer-lightspeed-for-rhdh-architecture.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= Developer Lightspeed for RHDH architecture
+= {ls-short} architecture
 
 [role="_abstract"]
 {ls-brand-name} is enabled by default on {product} ({product-very-short}) instances. To provide developers with chat assistance, configure your deployment settings by using either the Operator or the Helm chart.

--- a/titles/product_product/category-maps/integrate/con-developer-lightspeed-for-rhdh-architecture.adoc
+++ b/titles/product_product/category-maps/integrate/con-developer-lightspeed-for-rhdh-architecture.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-= {ls-short} architecture
+= {ia-short} architecture
 
 [role="_abstract"]
-{ls-brand-name} is enabled by default on {product} ({product-very-short}) instances. To provide developers with chat assistance, configure your deployment settings by using either the Operator or the Helm chart.
+{ia-brand-name} is enabled by default on {product} ({product-very-short}) instances. To provide developers with chat assistance, configure your deployment settings by using either the Operator or the Helm chart.

--- a/titles/product_product/category-maps/integrate/con-enable-ai-assistance-for-developers.adoc
+++ b/titles/product_product/category-maps/integrate/con-enable-ai-assistance-for-developers.adoc
@@ -3,4 +3,4 @@
 = Enable AI assistance for developers
 
 [role="_abstract"]
-{ls-brand-name} ({ls-short}) is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with {ls-short} to explore {product-very-short} capabilities in detail.
+{ia-brand-name} ({ia-short}) is an AI-powered virtual assistant for {product} ({product-very-short}). You can interact with {ia-short} to explore {product-very-short} capabilities in detail.

--- a/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
-= Build a private knowledge base with {ls-short} notebooks
+= Build a private knowledge base with {ia-short} notebooks
 :context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
+[id="build-a-private-knowledge-base-with-lightspeed-notebooks_{context}"]
 = Build a private knowledge base with {ia-short} notebooks
-:context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
+:context: build-a-private-knowledge-base-with-lightspeed-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
+++ b/titles/product_product/category-maps/integrate/nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="build-a-private-knowledge-base-with-lightspeed-notebooks_{context}"]
-= Build a private knowledge base with Lightspeed Notebooks
-:context: build-a-private-knowledge-base-with-lightspeed-notebooks
+[id="build-a-private-knowledge-base-with-intelligent-assistant-notebooks_{context}"]
+= Build a private knowledge base with {ls-short} notebooks
+:context: build-a-private-knowledge-base-with-intelligent-assistant-notebooks
 
 include::con-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
+++ b/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: MAP
 
 [id="intelligent-assistant-architecture_{context}"]
-= {ls-short} architecture
+= {ia-short} architecture
 :context: intelligent-assistant-architecture
 
 include::con-developer-lightspeed-for-rhdh-architecture.adoc[leveloffset=+1]

--- a/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
+++ b/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="intelligent-assistant-architecture_{context}"]
+[id="developer-lightspeed-for-rhdh-architecture_{context}"]
 = {ia-short} architecture
-:context: intelligent-assistant-architecture
+:context: developer-lightspeed-for-rhdh-architecture
 
 include::con-developer-lightspeed-for-rhdh-architecture.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
+++ b/titles/product_product/category-maps/integrate/nav-developer-lightspeed-for-rhdh-architecture.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: MAP
 
-[id="developer-lightspeed-for-rhdh-architecture_{context}"]
-= Developer Lightspeed for RHDH architecture
-:context: developer-lightspeed-for-rhdh-architecture
+[id="intelligent-assistant-architecture_{context}"]
+= {ls-short} architecture
+:context: intelligent-assistant-architecture
 
 include::con-developer-lightspeed-for-rhdh-architecture.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1
**Issue:** https://redhat.atlassian.net/browse/RHIDP-15826
**Preview:** N/A

## Summary

- Rename `{ls-brand-name}` and `{ls-short}` attributes to `{ia-brand-name}` and `{ia-short}` in `artifacts/attributes.adoc` and update all references across doc source files
- Update user-visible text across files: titles, headings, UI labels, and image alt text to use "intelligent assistant" branding
- Config keys (`lightspeed:`), RBAC permissions (`lightspeed.chat.read`), container names (`lightspeed-core`), upstream component names (Lightspeed Core Service), and file paths are deliberately unchanged pending upstream rebranding

## Known CQA-00b failure (intentional) (@pabel-rh and @jmagak please note this known faliure)

CQA-00b flags that `titles/integrate_interacting-with-developer-lightspeed-for-rhdh/` and its image directory should be renamed to match the new "intelligent-assistant" branding. We are intentionally leaving these directories unchanged to preserve inbound URLs. Renaming them would break published links, which is the same class of issue that CQA-14b guards against for IDs.

## Not included (@pabel-rh and @jmagak please note what's not included)

- Generated plugin table labels in `ref-ga-plugins.adoc` — managed by `rhdh-supported-plugins.sh`, will update when upstream plugin metadata changes
- Config YAML keys, Kubernetes resource names, OCI package paths, RBAC permission strings — these are actual technical identifiers that must match the running software

## Test plan

- [ ] Verify attribute substitution renders correctly in HTML preview
- [ ] Confirm no broken cross-references from context ID changes
- [ ] Verify CQA passes (CQA-00b excluded as noted above)