### PR TITLE
[RHIDP-15133]: Document rate limiting configuration for the intelligent assistant

### DIFF
--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -62,7 +62,7 @@
 :logging-short: OpenShift Logging
 :ls-brand-name: Red Hat Developer Lightspeed for {product}
 :ls-short: Developer Lightspeed for {product-very-short}
-:ia-short: intelligent assistant
+:ia-brand: Red Hat Developer Hub intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -62,7 +62,7 @@
 :logging-short: OpenShift Logging
 :ls-brand-name: Red Hat Developer Lightspeed for {product}
 :ls-short: Developer Lightspeed for {product-very-short}
-:ia-short: intelligent assistant
+:ia-short: {product-short} intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -62,6 +62,7 @@
 :logging-short: OpenShift Logging
 :ls-brand-name: Red Hat Developer Lightspeed for {product}
 :ls-short: Developer Lightspeed for {product-very-short}
+:ia-short: intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP

--- a/artifacts/attributes.adoc
+++ b/artifacts/attributes.adoc
@@ -62,7 +62,7 @@
 :logging-short: OpenShift Logging
 :ls-brand-name: Red Hat Developer Lightspeed for {product}
 :ls-short: Developer Lightspeed for {product-very-short}
-:ia-brand: Red Hat Developer Hub intelligent assistant
+:ia-short: intelligent assistant
 :ocp-brand-name: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
 :ocp-very-short: RHOCP

--- a/assemblies/shared/assembly-customize-ai-responses.adoc
+++ b/assemblies/shared/assembly-customize-ai-responses.adoc
@@ -17,6 +17,8 @@ include::../modules/shared/proc-customize-ai-responses-by-using-system-prompts.a
 
 include::../modules/shared/proc-customize-chat-history-storage.adoc[leveloffset=+1]
 
+include::../modules/shared/proc-configure-rate-limits-for-lightspeed.adoc[leveloffset=+1]
+
 // include::../modules/shared/proc-changing-your-llm-provider.adoc[leveloffset=+1]
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -1,22 +1,22 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rate-limits-for-the-intelligent-assistant_{context}"]
-= Configure rate limits for {ls-short}
+= Configure rate limits for the {ia-short}
 
 [role="_abstract"]
-Configure per-user rate limits for {ls-short} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
+Configure per-user rate limits for the {ia-short} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
 
 Rate limiting is active by default. Requests are tracked per authenticated user entity reference within a fixed 1-minute window. When a user exceeds the configured limit, the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header and a JSON error body containing a `RateLimitExceeded` error type.
 
-{ls-short} applies rate limits by tier:
+The {ia-short} applies rate limits by tier:
 
-Expensive (default: 25 requests/min/user):: Applies to `POST /v1/query` (LLM inference), notebook document uploads, and RAG queries.
-General (default: 200 requests/min/user):: Applies to all other authenticated endpoints, including conversation listing, MCP server management, feedback, and notebook session CRUD.
+Expensive (default: 25 requests/min/user):: Applies to `POST /v1/query` (LLM inference), notebook document uploads, and Retrieval Augmented Generation (RAG) queries.
+General (default: 200 requests/min/user):: Applies to all other authenticated endpoints, including conversation listing, Model Context Protocol (MCP) server management, feedback, and notebook session create, read, update, and delete operations.
 Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/health`).
 
 .Prerequisites
 
-* You have a deployed and configured {ls-short} instance.
+* You have a deployed and configured {ia-short} instance.
 * You have administrative access to the {product-very-short} host platform filesystem.
 
 .Procedure
@@ -48,9 +48,11 @@ lightspeed:
       max: 50
 ----
 
+. Save the file.
+
 . Restart the {product-very-short} service to apply the updated configuration.
 
 .Verification
 
-. Log in to {product-very-short} and submit requests to the {ls-short} chat interface that exceed the configured `expensive` limit.
+. Log in to {product-very-short} and submit requests to the {ia-short} chat interface that exceed the configured `expensive` limit.
 . Confirm that the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header indicating when to retry.

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -16,7 +16,7 @@ Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/
 
 .Prerequisites
 
-* You have a deployed and configured {ia-short} instance.
+* You have deployed and configured the {ia-short} instance.
 * You have administrative access to the {product-very-short} host platform filesystem.
 
 .Procedure

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rate-limits-for-the-intelligent-assistant_{context}"]
-= Configure rate limits for the {ia-short}
+= Configure rate limits for the {ia-brand}
 
 [role="_abstract"]
-Configure per-user rate limits for the {ia-short} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
+Configure per-user rate limits for the {ia-brand} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
 
 Rate limiting is active by default. Requests are tracked per authenticated user entity reference within a fixed 1-minute window. When a user exceeds the configured limit, the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header and a JSON error body containing a `RateLimitExceeded` error type.
 
-The {ia-short} applies rate limits by tier:
+The {ia-brand} applies rate limits by tier:
 
 Expensive (default: 25 requests/min/user):: Applies to `POST /v1/query` (LLM inference), notebook document uploads, and Retrieval Augmented Generation (RAG) queries.
 General (default: 200 requests/min/user):: Applies to all other authenticated endpoints, including conversation listing, Model Context Protocol (MCP) server management, feedback, and notebook session create, read, update, and delete operations.
@@ -16,7 +16,7 @@ Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/
 
 .Prerequisites
 
-* You have a deployed and configured {ia-short} instance.
+* You have a deployed and configured {ia-brand} instance.
 * You have administrative access to the {product-very-short} host platform filesystem.
 
 .Procedure
@@ -54,5 +54,5 @@ lightspeed:
 
 .Verification
 
-. Log in to {product-very-short} and submit requests to the {ia-short} chat interface that exceed the configured `expensive` limit.
+. Log in to {product-very-short} and submit requests to the {ia-brand} chat interface that exceed the configured `expensive` limit.
 . Confirm that the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header indicating when to retry.

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configure-rate-limits-for-the-intelligent-assistant_{context}"]
-= Configure rate limits for the {ia-brand}
+= Configure rate limits for the {ia-short}
 
 [role="_abstract"]
-Configure per-user rate limits for the {ia-brand} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
+Configure per-user rate limits for the {ia-short} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
 
 Rate limiting is active by default. Requests are tracked per authenticated user entity reference within a fixed 1-minute window. When a user exceeds the configured limit, the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header and a JSON error body containing a `RateLimitExceeded` error type.
 
-The {ia-brand} applies rate limits by tier:
+The {ia-short} applies rate limits by tier:
 
 Expensive (default: 25 requests/min/user):: Applies to `POST /v1/query` (LLM inference), notebook document uploads, and Retrieval Augmented Generation (RAG) queries.
 General (default: 200 requests/min/user):: Applies to all other authenticated endpoints, including conversation listing, Model Context Protocol (MCP) server management, feedback, and notebook session create, read, update, and delete operations.
@@ -16,7 +16,7 @@ Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/
 
 .Prerequisites
 
-* You have deployed and configured the {ia-brand} instance.
+* You have a deployed and configured {ia-short} instance.
 * You have administrative access to the {product-very-short} host platform filesystem.
 
 .Procedure
@@ -54,5 +54,5 @@ lightspeed:
 
 .Verification
 
-. Log in to {product-very-short} and submit requests to the {ia-brand} chat interface that exceed the configured `expensive` limit.
+. Log in to {product-very-short} and submit requests to the {ia-short} chat interface that exceed the configured `expensive` limit.
 . Confirm that the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header indicating when to retry.

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-rate-limits-for-the-intelligent-assistant_{context}"]
+= Configure rate limits for {ls-short}
+
+[role="_abstract"]
+Configure per-user rate limits for {ls-short} to prevent abuse, control large language model (LLM) inference costs, and protect backend resources.
+
+Rate limiting is active by default. Requests are tracked per authenticated user entity reference within a fixed 1-minute window. When a user exceeds the configured limit, the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header and a JSON error body containing a `RateLimitExceeded` error type.
+
+{ls-short} applies rate limits by tier:
+
+Expensive (default: 25 requests/min/user):: Applies to `POST /v1/query` (LLM inference), notebook document uploads, and RAG queries.
+General (default: 200 requests/min/user):: Applies to all other authenticated endpoints, including conversation listing, MCP server management, feedback, and notebook session CRUD.
+Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/health`).
+
+.Prerequisites
+
+* You have a deployed and configured {ls-short} instance.
+* You have administrative access to the {product-very-short} host platform filesystem.
+
+.Procedure
+
+. In your `{my-app-config-file}` file, add or modify the `rateLimit` block under the `lightspeed` section:
++
+[source,yaml]
+----
+lightspeed:
+  rateLimit:
+    expensive:
+      max: 25
+    general:
+      max: 200
+----
++
+`expensive.max`:: Maximum requests per minute per user for expensive endpoints such as LLM inference. Set to `0` to disable rate limiting for this tier.
+`general.max`:: Maximum requests per minute per user for general endpoints. Set to `0` to disable rate limiting for this tier.
++
+The following example shows a tightened configuration for a small deployment with limited LLM resources:
++
+[source,yaml]
+----
+lightspeed:
+  rateLimit:
+    expensive:
+      max: 10
+    general:
+      max: 50
+----
+
+. Restart the {product-very-short} service to apply the updated configuration.
+
+.Verification
+
+. Log in to {product-very-short} and submit requests to the {ls-short} chat interface that exceed the configured `expensive` limit.
+. Confirm that the server returns an HTTP `429 Too Many Requests` response with a `Retry-After` header indicating when to retry.

--- a/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
+++ b/modules/shared/proc-configure-rate-limits-for-lightspeed.adoc
@@ -16,7 +16,7 @@ Excluded (no limit):: Applies to health check endpoints (`/health`, `/notebooks/
 
 .Prerequisites
 
-* You have a deployed and configured {ia-brand} instance.
+* You have deployed and configured the {ia-brand} instance.
 * You have administrative access to the {product-very-short} host platform filesystem.
 
 .Procedure


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1
**Issue:** https://redhat.atlassian.net/browse/RHIDP-15133
**Preview:** N/A

## Summary

- New procedure module: `proc-configure-rate-limits-for-lightspeed.adoc` — documents per-user rate limiting on backend endpoints
- Covers the two configurable tiers (expensive: 25 req/min, general: 200 req/min), defaults, how to tighten or disable limits, and 429 response behavior
- Included in the `assembly-customize-ai-responses.adoc` assembly

## Open questions

- **Helm/Operator exposure:** Is `rateLimit` configurable only via `app-config.yaml`, or is it also exposed as a Helm chart value or Operator CR field? If so, the Helm and Operator config procedures need updates (plan item D3).
- **Config key namespace:** Engineering PR rhdh-plugins#3531 may use `intelligent-assistant:` instead of `lightspeed:` as the YAML config key. This PR uses `lightspeed:` for consistency with existing docs. Verify against the merged PR.

## Test plan

- [ ] Verify the new module renders correctly in the HTML preview
- [ ] Confirm CQA checks pass for the guide
- [ ] Validate the YAML config shape against the merged engineering PR rhdh-plugins#3531

🤖 Generated with [Claude Code](https://claude.com/claude-code)