### PR TITLE
RHIDP-14342: Admin guide documents catalog entity picker usage for Orchestrator workflows

### DIFF
--- a/assemblies/extend_orchestrator-in-rhdh/assembly-enable-orchestrator-plugins-components.adoc
+++ b/assemblies/extend_orchestrator-in-rhdh/assembly-enable-orchestrator-plugins-components.adoc
@@ -7,8 +7,12 @@ ifdef::context[:parent-context: {context}]
 :context: enable-orchestrator-plugins-components
 
 [role="_abstract"]
-Enable and configure the Orchestrator plugin components in your {product-short} instance.
+To run serverless workflows in {product-short}, enable the Orchestrator plugin components and configure scaffolder templates with entity pickers and output links.
 
 include::../modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc[leveloffset=+1]
+
+include::../modules/extend_orchestrator-in-rhdh/proc-configure-catalog-entity-picker-for-orchestrator-workflows.adoc[leveloffset=+1]
+
+include::../modules/extend_orchestrator-in-rhdh/ref-orchestrator-workflow-run-action-outputs.adoc[leveloffset=+1]
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/modules/extend_orchestrator-in-rhdh/proc-configure-catalog-entity-picker-for-orchestrator-workflows.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-catalog-entity-picker-for-orchestrator-workflows.adoc
@@ -1,0 +1,96 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configure-catalog-entity-picker-for-orchestrator-workflows_{context}"]
+= Configure a catalog entity picker for Orchestrator workflows
+
+[role="_abstract"]
+To allow users to select a target entity and receive navigation links on the template completion page after running a workflow, configure a scaffolder template with a catalog entity picker and output links for the `orchestrator:workflow:run` action.
+
+.Prerequisites
+
+* You have enabled the `scaffolder-backend-module-orchestrator` plugin. For more information, see xref:configure-orchestrator-plugins_{context}[].
+* You have deployed a serverless workflow and it is available in the Orchestrator.
+* The target catalog entities exist in the {product-short} catalog.
+
+.Procedure
+
+. In your scaffolder template, add an `EntityPicker` parameter field to the `parameters` section:
++
+[source,yaml]
+----
+spec:
+  parameters:
+    - title: Select target entity
+      properties:
+        targetEntity:
+          title: Target Entity
+          type: string
+          description: Select the catalog entity to associate with this workflow run.
+          ui:field: EntityPicker
+----
++
+The `EntityPicker` field renders a searchable dropdown that lists available catalog entities.
++
+The selected value is returned as a catalog entity reference string (for example, `component:default/my-service`), which you can pass directly to the `target_entity` input (for example, `${{ parameters.targetEntity }}` or `${{ parameters.target_entity }}`).
++
+Optionally, use `ui:options.catalogFilter` to limit which catalog entities users can select:
++
+[source,yaml]
+----
+targetEntity:
+  title: Target Entity
+  type: string
+  description: Select the catalog entity to associate with this workflow run.
+  ui:field: EntityPicker
+  ui:options:
+    catalogFilter:
+      kind: Component
+----
+
+. In the `steps` section, pass the selected entity to the `target_entity` input of the `orchestrator:workflow:run` action:
++
+[source,yaml]
+----
+  steps:
+    - id: runWorkflow
+      name: Run the workflow
+      action: orchestrator:workflow:run
+      input:
+        workflow_id: <your_workflow_id>
+        target_entity: ${{ parameters.targetEntity }}
+        parameters:
+          name: ${{ parameters.name }}
+----
++
+where:
++
+`workflow_id`::: Replace `<your_workflow_id>` with the ID of the serverless workflow to run.
+`target_entity`::: The action resolves this value from the entity picker selection. Use a catalog entity reference in `kind:namespace/name` format (for example, `component:default/my-service`). Other formats can produce incorrect output URLs.
++
+[NOTE]
+====
+If you do not provide the `target_entity` input, the output links default to using the template's own entity reference.
+====
+
+. In the `output` section, add links that reference the action's output variables:
++
+[source,yaml]
+----
+  output:
+    links:
+      - title: Open workflow run
+        url: ${{ steps.runWorkflow.output.instanceUrl }}
+      - title: Open Workflows tab
+        url: ${{ steps.runWorkflow.output.catalogEntityUrl }}
+      - title: View all workflows
+        url: ${{ steps.runWorkflow.output.orchestratorWorkflowsUrl }}
+----
++
+These links appear on the template completion page after the workflow finishes. For more information about the available output variables, see xref:orchestrator-workflow-run-action-outputs_{context}[].
+
+.Verification
+
+. In {product-short}, navigate to *Create* and select your scaffolder template.
+. Use the entity picker to select a target entity and complete the template form.
+. On the completion page, verify that the output links are displayed and navigate to the correct pages.
+

--- a/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
+++ b/modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc
@@ -24,7 +24,7 @@ Provides custom widgets for the workflow execution form, allowing you to customi
 Orchestrator-scaffolder-backend-module::
 
 `scaffolder-backend-module-orchestrator`:::
-Provides callable actions from Scaffolder templates, such as `orchestrator:workflow:run` or `orchestrator:workflow:get_params`.
+Provides callable actions from Scaffolder templates, such as `orchestrator:workflow:run` or `orchestrator:workflow:get_params`. For more information about action outputs, see xref:orchestrator-workflow-run-action-outputs_{context}[].
 
 .Prerequisites
 

--- a/modules/extend_orchestrator-in-rhdh/ref-orchestrator-workflow-run-action-outputs.adoc
+++ b/modules/extend_orchestrator-in-rhdh/ref-orchestrator-workflow-run-action-outputs.adoc
@@ -1,0 +1,65 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="orchestrator-workflow-run-action-outputs_{context}"]
+= Orchestrator scaffolder action outputs
+
+[role="_abstract"]
+The `orchestrator:workflow:run` scaffolder action provides three output variables that you can reference in template output links. After a workflow runs, the template completion page displays links to the workflow run, the catalog entity page, and the Orchestrator workflows list.
+
+The following table describes the output variables:
+
+[cols="1,1,2", options="header"]
+|===
+| Output variable
+| URL pattern
+| Description
+
+| `orchestratorWorkflowsUrl`
+| `/orchestrator/workflows`
+| A static link to the Orchestrator workflows list page. This URL remains the same regardless of which entity or workflow you run.
+
+| `catalogEntityUrl`
+| `/catalog/_<namespace>_/_<kind>_/_<name>_/workflows`
+| A dynamic link to the *Workflows* tab on the catalog entity page for the target entity. The action resolves the URL segments from the target entity reference.
+
+| `instanceUrl`
+| `/orchestrator/entity/_<namespace>_/_<kind>_/_<name>_/_<workflow_id>_/_<instance_id>_`
+| A dynamic link to the specific workflow run instance page. The action resolves the URL segments from the target entity reference, workflow ID, and run instance ID.
+|===
+
+The `catalogEntityUrl` and `instanceUrl` outputs construct their URLs from a target entity reference. The action resolves the target entity as follows:
+
+. If the template step specifies the `target_entity` input parameter, the action uses that entity reference.
+. If the step does not provide `target_entity`, the action falls back to the template's own entity reference.
+
+The action parses the entity reference string, for example `component:default/my-service`, to extract the kind, namespace, and name segments for the URL.
+
+The following scaffolder template excerpt shows how to reference all three output variables as links on the template completion page:
+
+[source,yaml]
+----
+spec:
+  steps:
+    - id: runWorkflow
+      name: Run the workflow
+      action: orchestrator:workflow:run
+      input:
+        workflow_id: my-workflow
+        target_entity: ${{ parameters.targetEntity }}
+        parameters:
+          name: ${{ parameters.name }}
+  output:
+    links:
+      - title: Open workflow run
+        url: ${{ steps.runWorkflow.output.instanceUrl }}
+      - title: Open Workflows tab
+        url: ${{ steps.runWorkflow.output.catalogEntityUrl }}
+      - title: View all workflows
+        url: ${{ steps.runWorkflow.output.orchestratorWorkflowsUrl }}
+----
+
+For example, if the target entity is `component:default/my-service`, the workflow ID is `greeting`, and the instance ID is `instance-123`, the resolved URLs are:
+
+* `orchestratorWorkflowsUrl`: `/orchestrator/workflows`
+* `catalogEntityUrl`: `/catalog/default/component/my-service/workflows`
+* `instanceUrl`: `/orchestrator/entity/default/component/my-service/greeting/instance-123`

--- a/titles/product_product/category-maps/extend/nav-enable-and-configure-the-orchestrator-extension.adoc
+++ b/titles/product_product/category-maps/extend/nav-enable-and-configure-the-orchestrator-extension.adoc
@@ -14,6 +14,10 @@ include::modules/extend_orchestrator-in-rhdh/con-orchestrator-plugin-dependencie
 
 include::modules/extend_orchestrator-in-rhdh/proc-configure-orchestrator-plugins.adoc[leveloffset=+1]
 
+include::modules/extend_orchestrator-in-rhdh/proc-configure-catalog-entity-picker-for-orchestrator-workflows.adoc[leveloffset=+1]
+
+include::modules/extend_orchestrator-in-rhdh/ref-orchestrator-workflow-run-action-outputs.adoc[leveloffset=+1]
+
 include::modules/extend_orchestrator-in-rhdh/proc-enable-the-orchestrator-plugins-using-the-operator.adoc[leveloffset=+1]
 
 include::modules/extend_orchestrator-in-rhdh/proc-install-components-using-the-rhdh-helper-script.adoc[leveloffset=+1]


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHIDP-14342](https://redhat.atlassian.net/browse/RHIDP-14342)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[2. Enable Orchestrator plugins components](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2547/extend_orchestrator-in-rhdh/#enable-orchestrator-plugins-components_orchestrator-in-rhdh)
[2.2. Configure a catalog entity picker for Orchestrator workflows](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2547/extend_orchestrator-in-rhdh/#configure-catalog-entity-picker-for-orchestrator-workflows_enable-orchestrator-plugins-components)
[2.3. Orchestrator scaffolder action outputs](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2547/extend_orchestrator-in-rhdh/#orchestrator-workflow-run-action-outputs_enable-orchestrator-plugins-components)
