### PR TITLE
RHIDP-15905: Document HTTP/2 enablement options for RHDH installations

### DIFF
--- a/assemblies/configure_configuring-rhdh/assembly-enable-http2-to-reduce-page-load-times.adoc
+++ b/assemblies/configure_configuring-rhdh/assembly-enable-http2-to-reduce-page-load-times.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+ifdef::context[:parent-context: {context}]
+
+[id="enable-http2-to-reduce-page-load-times_{context}"]
+= Enable HTTP/2 to reduce page load times
+
+:previouscontext: {context}
+:context: enable-http2-to-reduce-page-load-times
+
+[role="_abstract"]
+You can enable HTTP/2 for {product} to reduce frontend load times when your environment supports TLS certificates that browsers trust.
+
+include::../modules/configure_configuring-rhdh/con-http2-and-the-frontend-connection-bottleneck.adoc[leveloffset=+1]
+
+include::../modules/configure_configuring-rhdh/ref-http2-tls-requirements-and-connection-coalescing-caveats.adoc[leveloffset=+1]
+
+include::../modules/configure_configuring-rhdh/proc-enable-http2-by-using-a-reverse-proxy.adoc[leveloffset=+1]
+
+include::../modules/configure_configuring-rhdh/proc-request-cluster-wide-http2-on-openshift.adoc[leveloffset=+1]
+
+:context: {previouscontext}
+:!previouscontext:
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/modules/configure_configuring-rhdh/con-http2-and-the-frontend-connection-bottleneck.adoc
+++ b/modules/configure_configuring-rhdh/con-http2-and-the-frontend-connection-bottleneck.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="http2-and-the-frontend-connection-bottleneck_{context}"]
+= HTTP/2 and the frontend connection bottleneck
+
+[role="_abstract"]
+You can use HTTP/2 to eliminate the six-connection bottleneck that slows page loads in plugin-heavy {product-very-short} deployments by multiplexing browser requests over a single connection.
+
+{product-very-short} does not enable HTTP/2 by default because it requires valid TLS certificates that browsers trust.
+
+Browsers limit HTTP/1.1 to six concurrent connections per origin.
+In plugin-heavy {product-very-short} deployments, the browser must download many JavaScript assets before the page becomes interactive.
+With HTTP/1.1, these downloads queue across the six-connection limit, which can result in page load times of 20 to 30 seconds.
+
+The benefit is greatest during the initial page load, when the browser fetches all plugin assets at once.

--- a/modules/configure_configuring-rhdh/proc-enable-http2-by-using-a-reverse-proxy.adoc
+++ b/modules/configure_configuring-rhdh/proc-enable-http2-by-using-a-reverse-proxy.adoc
@@ -1,0 +1,51 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="enable-http2-by-using-a-reverse-proxy_{context}"]
+= Enable HTTP/2 by using a reverse proxy
+
+[role="_abstract"]
+You can deploy a reverse proxy in front of {product-very-short} to enable HTTP/2 without requiring cluster-wide configuration changes.
+
+// TODO: RHIDP-15712 — Replace this stub with tested procedure after engineering delivers the officially supported reverse proxy setup.
+// Pending details:
+// - Officially supported reverse proxy image (Caddy UBI rebuild or alternative)
+// - Kubernetes manifests (Deployment, Service, ConfigMap for proxy config)
+// - OCP passthrough Route configuration
+// - Vanilla Kubernetes Ingress configuration with TLS passthrough
+// - app-config.yaml base URL updates (app.baseUrl, backend.baseUrl, backend.cors.origin)
+// - HTTP/1.1 fallback verification steps
+
+.Prerequisites
+
+* You have a valid TLS certificate and key for the {product-very-short} route hostname.
+* You have an existing {product-very-short} deployment.
+
+.Procedure
+
+// This procedure is pending the completion of engineering validation (RHIDP-15712).
+
+. Deploy a reverse proxy as a separate Deployment in the same namespace as {product-very-short}.
+. Configure TLS termination on the reverse proxy with your certificate.
+. Create a passthrough Route (on {ocp-short}) or an Ingress with TLS passthrough (on Kubernetes) that points to the reverse proxy Service.
+. Update the `{my-app-config-file}` to set `app.baseUrl`, `backend.baseUrl`, and `backend.cors.origin` to the new reverse proxy URL.
+
+.Verification
+
+. Verify that the {product-very-short} UI loads through the reverse proxy URL.
+. Verify HTTP/2 negotiation by running:
++
+[source,terminal]
+----
+$ curl -vso /dev/null --http2 https://<reverse_proxy_route_url> 2>&1 | grep ALPN
+----
++
+If HTTP/2 is active, the output includes:
++
+[source,terminal]
+----
+* ALPN: server accepted h2
+----
+
+.Additional resources
+
+* xref:http2-tls-requirements-and-connection-coalescing-caveats_{context}[HTTP/2 TLS requirements and connection coalescing caveats]

--- a/modules/configure_configuring-rhdh/proc-request-cluster-wide-http2-on-openshift.adoc
+++ b/modules/configure_configuring-rhdh/proc-request-cluster-wide-http2-on-openshift.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="request-cluster-wide-http2-on-openshift_{context}"]
+= Request cluster-wide HTTP/2 on {ocp-short}
+
+[role="_abstract"]
+On {ocp-brand-name}, you can request that a cluster administrator enable HTTP/2 for all routes by annotating the Ingress Controller instead of deploying a separate reverse proxy.
+
+This approach applies to the entire cluster and affects all routes, not only {product-very-short}.
+
+.Prerequisites
+
+* You have access to a cluster administrator who can modify the Ingress Controller configuration.
+* The cluster uses valid TLS certificates that browsers trust.
+
+.Procedure
+
+. Ask your cluster administrator to enable HTTP/2 on the Ingress Controller by running:
++
+[source,terminal]
+----
+$ oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true
+----
+
+. Verify that the {product-very-short} route serves HTTP/2. In a terminal, run:
++
+[source,terminal]
+----
+$ curl -vso /dev/null --http2 https://<my_developer_hub_url> 2>&1 | grep ALPN
+----
++
+If HTTP/2 is active, the output includes:
++
+[source,terminal]
+----
+* ALPN: server accepted h2
+----
+
+.Additional resources
+
+* xref:http2-tls-requirements-and-connection-coalescing-caveats_{context}[HTTP/2 TLS requirements and connection coalescing caveats]
+* link:https://access.redhat.com/solutions/2274201[Is it possible to enable HTTP/2 on OpenShift?]
+* link:https://access.redhat.com/solutions/7018818[Impact of enabling HTTP/2 Ingress connectivity in OpenShift 4]

--- a/modules/configure_configuring-rhdh/ref-http2-tls-requirements-and-connection-coalescing-caveats.adoc
+++ b/modules/configure_configuring-rhdh/ref-http2-tls-requirements-and-connection-coalescing-caveats.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="http2-tls-requirements-and-connection-coalescing-caveats_{context}"]
+= HTTP/2 TLS requirements and connection coalescing caveats
+
+[role="_abstract"]
+Verify that your environment meets the TLS requirements and review the connection coalescing caveats before you enable HTTP/2 for {product-very-short}.
+
+Your environment must meet the following requirements to enable HTTP/2:
+
+Valid TLS certificate:: You must obtain the TLS certificate from a certificate authority (CA) that the browser trusts. Self-signed certificates do not enable HTTP/2 negotiation in most browsers.
+
+ALPN support:: The TLS termination point must support Application-Layer Protocol Negotiation (ALPN) so that the browser and server can agree on HTTP/2 during the TLS handshake.
+
+HTTP/1.1 fallback:: Environments behind corporate proxies or in restricted networks might not support HTTP/2. The solution must degrade gracefully to HTTP/1.1 without manual intervention.
+
+Be aware of the following caveats:
+
+Connection coalescing::
+Browsers can reuse a single HTTP/2 connection for multiple hostnames if those hostnames resolve to the same IP address and share a TLS certificate.
+If the proxy that terminates TLS does not serve all of those hostnames, the proxy can misroute requests intended for other services.
++
+To avoid connection coalescing issues:
++
+* Use a TLS certificate that covers only the {product-very-short} route hostname.
+* Do not use a wildcard certificate that also covers other services on the same IP address, unless the same proxy serves those services.
+
+.Additional resources
+
+* link:https://access.redhat.com/solutions/2274201[Is it possible to enable HTTP/2 on OpenShift?]
+* link:https://access.redhat.com/solutions/7018818[Impact of enabling HTTP/2 Ingress connectivity in OpenShift 4]

--- a/titles/configure_configuring-rhdh/master.adoc
+++ b/titles/configure_configuring-rhdh/master.adoc
@@ -49,6 +49,8 @@ include::assemblies/configure_configuring-rhdh/assembly-use-the-dynamic-plugins-
 
 include::modules/configure_configuring-rhdh/proc-enable-the-rhdh-plugin-assets-cache.adoc[leveloffset=+1]
 
+include::assemblies/configure_configuring-rhdh/assembly-enable-http2-to-reduce-page-load-times.adoc[leveloffset=+1]
+
 include::modules/configure_configuring-rhdh/proc-inject-extra-files-and-environment-variables-into-containers.adoc[leveloffset=+1]
 
 include::modules/configure_configuring-rhdh/proc-configure-mount-paths-for-default-secrets-and-persistent-volume-claims-pvcs.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):**
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHIDP-15905](https://redhat.atlassian.net/browse/RHIDP-15905)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[13. Enable HTTP/2 to reduce page load times](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2548/configure_configuring-rhdh/#enable-http2-to-reduce-page-load-times_configuring-rhdh)
[13.1. HTTP/2 and the frontend connection bottleneck](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2548/configure_configuring-rhdh/#http2-and-the-frontend-connection-bottleneck_enable-http2-to-reduce-page-load-times)
[13.2. HTTP/2 TLS requirements and connection coalescing caveats](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2548/configure_configuring-rhdh/#http2-tls-requirements-and-connection-coalescing-caveats_enable-http2-to-reduce-page-load-times)
[13.3. Enable HTTP/2 by using a reverse proxy](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2548/configure_configuring-rhdh/#enable-http2-by-using-a-reverse-proxy_enable-http2-to-reduce-page-load-times)
[13.4. Request cluster-wide HTTP/2 on OpenShift Container Platform](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2548/configure_configuring-rhdh/#request-cluster-wide-http2-on-openshift_enable-http2-to-reduce-page-load-times)
