### PR TITLE
RHDHBUGS-3666: Wrong rendering of "+" in Conditional policy with criteria section

### DIFF
--- a/modules/shared/ref-conditional-policy-with-criteria.adoc
+++ b/modules/shared/ref-conditional-policy-with-criteria.adoc
@@ -37,9 +37,9 @@ To add the criteria, you can add another rule as `IS_ENTITY_KIND` in the conditi
 Running conditions in parallel during creation is not supported.
 Therefore, consider defining nested conditional policies based on the available criteria.
 ====
-+
+
 Example of nested conditions:
-+
+
 [source,json]
 ----
 {


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][RHIDP#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest released and/or in-development version of RHDH, open your PR against the `main` branch and cherrypick your PR to any released branches that you want to apply your changes to. --->

<!--- Add the relevant labels to the Pull Request. Update the labels, as needed, to reflect the current status of the PR. --->


**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1, 1.10
<!--- Specify the version(s) of RHDH that your PR applies to. -->
**Issue:** [RHDHBUGS-3666](https://redhat.atlassian.net/browse/RHDHBUGS-3666)
<!--- Add a link to the Jira issue. --->
**Preview:**
<!--- Add a link to the preview of the changed file(s). --->
[11.2.3. Conditional policy with criteria](https://redhat-developer.github.io/red-hat-developers-documentation-rhdh/pr-2557/control-access_authorization-in-rhdh/#conditional-policy-with-criteria_conditional-policies-reference)