### PR TITLE
[RHIDP-15239]: Replace Llama Stack references with LCORE naming and add AI migration docs

### DIFF
--- a/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
+++ b/modules/integrate_interacting-with-model-context-protocol-tools-for-rhdh/proc-configure-mcp-clients-to-access-the-rhdh-server.adoc
@@ -38,9 +38,9 @@ mcp_servers:
 ----
 +
 
-`model-context-protocol`:: Enter the tool runtime provider defined in the llama-stack `run.yaml` configuration for {lcs-short}.
+`model-context-protocol`:: Enter the tool runtime provider defined in the {lcs-short} `run.yaml` configuration.
 
-.. Optional: To use a custom Llama Stack configuration, add the following code to the `run.yaml` Llama Stack configuration file.
+.. Optional: To use a custom {lcs-short} configuration, add the following code to the `run.yaml` {lcs-short} configuration file.
 +
 [source,yaml]
 ----

--- a/modules/shared/con-ai-feature-changes-in-rhdh-2-1.adoc
+++ b/modules/shared/con-ai-feature-changes-in-rhdh-2-1.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="ai-feature-changes-in-rhdh-2-1_{context}"]
+= AI feature changes in {product-very-short} 2.1
+
+[role="_abstract"]
+{product} ({product-very-short}) 2.1 introduces changes to the AI backend infrastructure and permission model that affect your configuration.
+
+Infrastructure naming changes::
+
+{product-very-short} 2.1 replaces all Llama Stack references with {lcs-name} ({lcs-short}) naming. If your deployment uses custom configuration files or Kubernetes resources with Llama Stack names, you must update them. For example:
+
+* Config map names: `llama-stack-config` is now `lightspeed-core-config`.
+* Container names: `llama-stack` is now `lightspeed-core`.
+* Configuration file references: `llama-stack-configs/config.yaml` is now part of the {lcs-short} configuration.
+
+Permission model changes::
+
+{product-very-short} 2.1 replaces the `lightspeed.*` permission identifiers with behavior-linked names that use the `intelligent-assistant.*` and `mcp.*` namespaces. This is a breaking change. For the full list of new permissions and a migration table from previous names, see link:{developer-lightspeed-book-link}#ai-feature-permissions_interacting-with-developer-lightspeed-for-rhdh[AI feature permissions] in the _{developer-lightspeed-book-title}_ guide.
+
+Safety guard configuration::
+
+The default safety shield configuration remains available. The `run.yaml` configuration file structure is unchanged, but resource names in your Kubernetes manifests must reflect the {lcs-short} naming convention.
+
+.Additional resources
+* link:{developer-lightspeed-book-link}#migrate-ai-configuration-from-rhdh-1-10-to-2-1_interacting-with-developer-lightspeed-for-rhdh[Migrate AI configuration from {product-very-short} 1.10 to 2.1]
+* link:{developer-lightspeed-book-link}#ai-feature-permissions_interacting-with-developer-lightspeed-for-rhdh[AI feature permissions]

--- a/modules/shared/proc-configure-safety-guards-in-rhdh.adoc
+++ b/modules/shared/proc-configure-safety-guards-in-rhdh.adoc
@@ -4,11 +4,11 @@
 = Configure safety guards in {product}
 
 [role="_abstract"]
-To protect users from insecure or harmful AI model outputs, {product} ({product-very-short}) uses Llama Guard as a default safety shield. You must configure these guards to align with your organization's security policies.
+To protect users from insecure or harmful AI model outputs, {product} ({product-very-short}) includes a default safety shield. You must configure these guards to align with your organization's security policies.
 
 `Default safety guard configuration`::
 
-The system uses Llama Guard as the default safety shield. Override these settings in the `run.yaml` file.
+The system includes a default safety shield. Override these settings in the `run.yaml` file.
 
 [NOTE] 
 ====
@@ -38,7 +38,7 @@ To run the system without a safety guard, perform these steps:
 [source,yaml]
 ----
 version: 2
-image_name: redhat-ai-dev-llama-stack-no-guard
+image_name: lightspeed-core-no-guard
 apis:
   - agents
   - inference
@@ -102,7 +102,7 @@ providers:
     - provider_id: localfs
       provider_type: inline::localfs
       config:
-        storage_dir: /tmp/llama-stack-files
+        storage_dir: /tmp/lightspeed-core-files
         metadata_store:
           table_name: files_metadata
           backend: sql_files
@@ -158,15 +158,15 @@ server:
   tls_keyfile:
 ----
 
-. Mount the config map to your Llama Stack container at `/app-root/run.yaml` to make sure it overrides the default image file:
+. Mount the config map to your {lcs-short} container at `/app-root/run.yaml` to make sure it overrides the default image file:
 +
 [source,yaml]
 ----
-name: llama-stack
+name: lightspeed-core
 volumeMounts:
 - mountPath: /app-root/run.yaml
   subPath: run.yaml
-  name: llama-stack-config
+  name: lightspeed-core-config
 ----
 
 . Configure the required volume:
@@ -174,13 +174,13 @@ volumeMounts:
 [source,yaml]
 ----
 volumes:
-- name: llama-stack-config
+- name: lightspeed-core-config
   configMap:
-    name: llama-stack-config
+    name: lightspeed-core-config
 ----
 +
 where:
 
-`llama-stack-config`:: The config map where you added the new no-guard configuration file.
+`lightspeed-core-config`:: The config map where you added the new no-guard configuration file.
 
 . Restart the deployment if it does not trigger an automatic rollout.

--- a/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
+++ b/modules/shared/proc-enable-data-persistence-for-developer-lightspeed-notebooks.adoc
@@ -16,7 +16,7 @@ By default, the service uses ephemeral storage in the `/tmp` directory, which th
 
 .Procedure
 
-. Update your custom config map `llama-stack-configs/config.yaml` file to point the `kv_notebooks` storage backend to your persistent mount point:
+. Update your custom config map `config.yaml` file to point the `kv_notebooks` storage backend to your persistent mount point:
 +
 [source,yaml]
 ----
@@ -55,7 +55,7 @@ spec:
         claimName: lightspeed-notebooks-pvc
     - name: config
       configMap:
-        name: llama-stack-config
+        name: lightspeed-core-config
     - name: lightspeed-config
       configMap:
         name: lightspeed-core-config
@@ -78,7 +78,7 @@ spec:
             - name: lightspeed-notebooks
               mountPath: /var/lib/lightspeed-data
       containers:
-        - name: lightspeed-stack
+        - name: lightspeed-core
           image: quay.io/lightspeed-core/lightspeed-stack:0.5.1
           ports:
             - containerPort: 8080
@@ -102,7 +102,7 @@ spec:
             claimName: lightspeed-notebooks-pvc
         - name: config
           configMap:
-            name: llama-stack-config
+            name: lightspeed-core-config
 ----
 . Apply the updated configuration and restart the service.
 

--- a/modules/shared/proc-migrate-ai-configuration-from-rhdh-1-10-to-2-1.adoc
+++ b/modules/shared/proc-migrate-ai-configuration-from-rhdh-1-10-to-2-1.adoc
@@ -1,0 +1,76 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="migrate-ai-configuration-from-rhdh-1-10-to-2-1_{context}"]
+= Migrate AI configuration from {product-very-short} 1.10 to 2.1
+
+[role="_abstract"]
+Update your AI backend configuration to align with the {lcs-name} ({lcs-short}) naming conventions introduced in {product} ({product-very-short}) 2.1.
+
+.Prerequisites
+
+* You have a running {product-very-short} 1.10 instance with AI features enabled.
+* You have access to your deployment manifests and RBAC policy files.
+
+.Procedure
+
+. Update config map names in your deployment manifests by replacing `llama-stack-config` with `lightspeed-core-config`:
++
+[cols="1,1",options="header"]
+|===
+| Old name (1.10) | New name (2.1)
+
+| `llama-stack-config`
+| `lightspeed-core-config`
+|===
+
+. Update container names in your deployment manifests by replacing `llama-stack` with `lightspeed-core`:
++
+[source,yaml]
+----
+containers:
+  - name: lightspeed-core
+----
+
+. If you use custom `run.yaml` configuration files that reference Llama Stack paths, update them:
++
+[cols="1,1",options="header"]
+|===
+| Old value (1.10) | New value (2.1)
+
+| `llama-stack-configs/config.yaml`
+| `config.yaml`
+
+| `/tmp/llama-stack-files`
+| `/tmp/lightspeed-core-files`
+|===
+
+. Update your RBAC policies to use the new permission identifiers. {product-very-short} 2.1 replaces the `lightspeed.*` permission namespace with `intelligent-assistant.*` and `mcp.*`. For the full mapping of old to new permission names, see link:{developer-lightspeed-book-link}#ai-feature-permissions_interacting-with-developer-lightspeed-for-rhdh[AI feature permissions] in the _{developer-lightspeed-book-title}_ guide.
++
+For example, replace:
++
+[source,text]
+----
+p, role:default/<team>, lightspeed.chat.read, read, allow
+p, role:default/<team>, lightspeed.chat.create, create, allow
+----
++
+with:
++
+[source,text,subs="+quotes"]
+----
+p, role:default/_<team>_, intelligent-assistant.chat.access, use, allow
+p, role:default/_<team>_, intelligent-assistant.chat.use, use, allow
+----
+
+. Apply the updated configuration and restart your {product-very-short} deployment.
+
+.Verification
+
+. Verify that the {lcs-short} container starts without errors:
++
+[source,terminal]
+----
+$ oc logs deployment/<deployment_name> -c lightspeed-core
+----
+. Open the {ls-short} chat interface and verify that the AI assistant responds.
+. If you use Notebooks, verify that existing Notebooks are accessible from the *My Notebooks* dashboard.

--- a/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
+++ b/titles/integrate_interacting-with-developer-lightspeed-for-rhdh/master.adoc
@@ -22,9 +22,13 @@ include::modules/shared/con-ai-reference-and-tool-calling-capabilities-through.a
 
 include::modules/shared/con-retrieval-augmented-generation-rag-embeddings-for-grounded-ai-responses.adoc[leveloffset=+1]
 
-include::assemblies/shared/assembly-configure-to-initialize-the-ai-assistant.adoc[leveloffset=+1]
+include::modules/shared/con-ai-feature-changes-in-rhdh-2-1.adoc[leveloffset=+1]
+
+include::modules/shared/proc-migrate-ai-configuration-from-rhdh-1-10-to-2-1.adoc[leveloffset=+1]
 
 include::modules/shared/ref-ai-feature-permissions.adoc[leveloffset=+1]
+
+include::assemblies/shared/assembly-configure-to-initialize-the-ai-assistant.adoc[leveloffset=+1]
 
 include::assemblies/shared/assembly-customize-ai-responses.adoc[leveloffset=+1]
 

--- a/titles/product_product/category-maps/integrate/nav-enable-ai-assistance-for-developers.adoc
+++ b/titles/product_product/category-maps/integrate/nav-enable-ai-assistance-for-developers.adoc
@@ -6,6 +6,8 @@
 
 include::con-enable-ai-assistance-for-developers.adoc[leveloffset=+1]
 
+include::modules/shared/con-ai-feature-changes-in-rhdh-2-1.adoc[leveloffset=+1]
+
 include::nav-developer-lightspeed-for-rhdh-architecture.adoc[leveloffset=+1]
 
 include::nav-build-a-private-knowledge-base-with-lightspeed-notebooks.adoc[leveloffset=+1]

--- a/titles/upgrade_upgrade-rhdh/master.adoc
+++ b/titles/upgrade_upgrade-rhdh/master.adoc
@@ -20,6 +20,8 @@ include::modules/upgrade_upgrade-rhdh/proc-upgrade-the-rhdh-helm-chart.adoc[leve
 
 include::modules/upgrade_upgrade-rhdh/proc-upgrade-rhdh-from-1-8-to-using-the-helm-chart.adoc[leveloffset=+1]
 
+include::modules/shared/proc-migrate-ai-configuration-from-rhdh-1-10-to-2-1.adoc[leveloffset=+1]
+
 include::modules/shared/proc-rollback-a-plugin-to-a-previous-version.adoc[leveloffset=+1]
 
 include::modules/upgrade_upgrade-rhdh/con-rhdh-upgrade-helper-skill.adoc[leveloffset=+1]


### PR DESCRIPTION
**IMPORTANT: Do Not Merge - To be merged by Docs Team Only**

**Version(s):** 2.1
**Issue:** https://redhat.atlassian.net/browse/RHIDP-15239
**Preview:** N/A (draft)

## Summary

- Remove all Llama Stack references from 3 modules: safety guards, notebook persistence, and MCP client configuration
- Replace with {lcs-short} (LCORE) naming: container names (`lightspeed-core`), config map names (`lightspeed-core-config`), and generic "default safety shield" prose
- Create `con-ai-feature-changes-in-rhdh-2-1.adoc` — concept module summarizing infrastructure, permission, and naming changes in RHDH 2.1
- Create `proc-migrate-ai-configuration-from-rhdh-1-10-to-2-1.adoc` — step-by-step migration procedure (config maps, containers, RBAC policies)
- Include new modules in Lightspeed title, upgrade title, and JTBD nav
- Reorder `ref-ai-feature-permissions.adoc` include in Lightspeed title master.adoc to fix xref context collision with nested assemblies (the `configure-to-initialize` assembly was overwriting `parent-context`)

## Scope note

The Jira ticket listed 5 files to update, but 3 were already clean (no Llama Stack refs). Instead, 3 unlisted files had the actual references. This PR updates the files with actual refs and flags this discrepancy.

The `rhdh-local/developer-lightspeed/README.md` file referenced in the ticket does not exist in this repository.

## SME verification needed

The following LCORE-internal config values need SME verification (upstream repo is private):

- `image_name: lightspeed-core-no-guard` (was `redhat-ai-dev-llama-stack-no-guard`)
- `storage_dir: /tmp/lightspeed-core-files` (was `/tmp/llama-stack-files`)

## Test plan

- [ ] Verify `image_name` and `storage_dir` values with LCORE engineering
- [ ] Build all titles — check Lightspeed, upgrade, and product titles render correctly
- [ ] Grep for remaining `llama-stack` / `Llama Stack` references (only migration docs should have them)
- [ ] Verify xrefs to `ref-ai-feature-permissions.adoc` resolve in both Lightspeed and upgrade titles
- [ ] Run CQA checks on Lightspeed title


Generated with [Claude Code](https://claude.com/claude-code)